### PR TITLE
feat: redirect to 404.html if origin is not in storm

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -55,6 +55,20 @@ export const Editor = ({ document, puckConfigs }: EditorProps) => {
   const [devPageSets, setDevPageSets] = useState<any>(undefined);
   const [templateMetadata, setTemplateMetadata] = useState<TemplateMetadata>();
   const [puckConfig, setPuckConfig] = useState<Config>();
+  const [parentLoaded, setParentLoaded] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const ancestors = window.location.ancestorOrigins;
+      if (ancestors.length === 0) {
+        window.location.assign("/404.html");
+      } else if (!ancestors[0].includes ("pagescdn") && !ancestors[0].includes("yext.com")) {
+          window.location.assign("/404.html");
+      } else {
+          setParentLoaded("true");
+      }
+    }
+  }, []);
 
   useReceiveMessage("getTemplateMetadata", TARGET_ORIGINS, (send, payload) => {
     const puckConfig = puckConfigs.get(payload.templateId);
@@ -349,7 +363,7 @@ export const Editor = ({ document, puckConfigs }: EditorProps) => {
           />
         </DocumentProvider>
       ) : (
-        <LoadingScreen progress={progress} />
+        parentLoaded && <LoadingScreen progress={progress} />
       )}
       <Toaster closeButton richColors />
     </>

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -68,7 +68,7 @@ export const Editor = ({ document, puckConfigs }: EditorProps) => {
       ) {
         window.location.assign("/404.html");
       } else {
-          setParentLoaded(true);
+        setParentLoaded(true);
       }
     }
   }, []);

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -65,7 +65,7 @@ export const Editor = ({ document, puckConfigs }: EditorProps) => {
       } else if (!ancestors[0].includes ("pagescdn") && !ancestors[0].includes("yext.com")) {
           window.location.assign("/404.html");
       } else {
-          setParentLoaded("true");
+          setParentLoaded(true);
       }
     }
   }, []);


### PR DESCRIPTION
Verified that VE works in storm in multiple envs (where ancestor origin contains pagescdn or yext.com), verified that running VE on localhost redirects to 404 and that no content loads prior to the redirect.