### PR TITLE
fix:  update Puck after clearing local changes and fix undo state

### DIFF
--- a/src/internal/puck/components/Header.tsx
+++ b/src/internal/puck/components/Header.tsx
@@ -33,22 +33,15 @@ const handleClick = (slug: string) => {
 export const customHeader = (
   handleClearLocalChanges: () => void,
   handleHistoryChange: (histories: History[], index: number) => void,
-  data: Data,
+  currentPuckData: Data, // the current state of Puck data
+  initialPuckData: Data, // the initial state of Puck data before any local changes
   handleSaveData: (data: Data) => Promise<void>,
   isDevMode: boolean
 ) => {
   const entityDocument = useDocument<any>();
   const {
-    history: {
-      back,
-      forward,
-      histories,
-      index,
-      hasFuture,
-      hasPast,
-      setHistories,
-      setHistoryIndex,
-    },
+    dispatch: puckDispatch,
+    history: { back, forward, histories, index, hasFuture, setHistories },
   } = usePuck();
 
   useEffect(() => {
@@ -63,7 +56,12 @@ export const customHeader = (
       </div>
       <div className="header-center"></div>
       <div className="actions">
-        <Button variant="ghost" size="icon" disabled={!hasPast} onClick={back}>
+        <Button
+          variant="ghost"
+          size="icon"
+          disabled={index === 0} // prevent going to -1 because it would loop data back to the saveState
+          onClick={back}
+        >
           <RotateCcw className="sm-icon" />
         </Button>
         <Button
@@ -79,7 +77,10 @@ export const customHeader = (
           onClearLocalChanges={() => {
             handleClearLocalChanges();
             setHistories([]);
-            setHistoryIndex(-1);
+            puckDispatch({
+              type: "setData",
+              data: initialPuckData,
+            });
           }}
         />
         <Button
@@ -93,7 +94,7 @@ export const customHeader = (
             variant="secondary"
             disabled={histories.length === 0}
             onClick={async () => {
-              await handleSaveData(data);
+              await handleSaveData(currentPuckData);
               handleClearLocalChanges();
             }}
           >
@@ -135,7 +136,7 @@ const ClearLocalChangesButton = ({
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <Button onClick={() => handleClearLocalChanges()}>Confirm</Button>
+          <Button onClick={handleClearLocalChanges}>Confirm</Button>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/src/internal/puck/components/Header.tsx
+++ b/src/internal/puck/components/Header.tsx
@@ -119,8 +119,15 @@ const ClearLocalChangesButton = ({
   disabled,
   onClearLocalChanges,
 }: ClearLocalChangesButtonProps) => {
+  const [dialogOpen, setDialogOpen] = React.useState<boolean>(false);
+
+  const handleClearLocalChanges = () => {
+    onClearLocalChanges();
+    setDialogOpen(false);
+  };
+
   return (
-    <AlertDialog>
+    <AlertDialog open={dialogOpen} onOpenChange={setDialogOpen}>
       <AlertDialogTrigger disabled={disabled} asChild>
         <Button variant="outline">Clear Local Changes</Button>
       </AlertDialogTrigger>
@@ -133,7 +140,7 @@ const ClearLocalChangesButton = ({
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <Button onClick={onClearLocalChanges}>Confirm</Button>
+          <Button onClick={() => handleClearLocalChanges()}>Confirm</Button>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>


### PR DESCRIPTION
[SUMO-6143](https://yexttest.atlassian.net/browse/SUMO-6143?atlOrigin=eyJpIjoiZGI5NTk1ZmUzOTE2NGZlNGEzYTdmN2UwZjc2N2EzYzEiLCJwIjoiaiJ9)

This fixes the Clear Local Changes button to:
1. Close the modal on confirmation
2. Reset the Puck data state without a page refresh

Additionally, this fixes the undo button to properly undo to the original state before there were any changes instead of getting stuck at the first change.