### PR TITLE
fix: remove tooltip warning 

### DIFF
--- a/src/components/EntityField.tsx
+++ b/src/components/EntityField.tsx
@@ -33,7 +33,7 @@ export const EntityField = ({
   return (
     <TooltipProvider>
       <Tooltip open={tooltipsVisible && !!tooltipContent}>
-        <TooltipTrigger asChild>
+        <TooltipTrigger>
           <div
             className={
               tooltipsVisible


### PR DESCRIPTION
```react-dom@18.2.0.development.js:73 Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()? Check the render method of `Tooltip`. at DevLivePreviewGenerator```