### PR TITLE
fix: make quick find keyboard shortcut work

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -8759,7 +8759,7 @@ SOFTWARE.
 
 The following npm package may be included in this product:
 
- - json5@2.2.3
+ - json5@1.0.2
 
 This package contains the following license and notice below:
 

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -8759,7 +8759,7 @@ SOFTWARE.
 
 The following npm package may be included in this product:
 
- - json5@1.0.2
+ - json5@2.2.3
 
 This package contains the following license and notice below:
 

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -355,6 +355,31 @@ export const Editor = ({ document, puckConfigs }: EditorProps) => {
     TARGET_ORIGINS
   );
 
+  const { sendToParent: openQuickFind } = useSendMessageToParent(
+    "openQuickFind",
+    TARGET_ORIGINS
+  );
+
+  const keyboardHandler = (event: KeyboardEvent) => {
+    if ((event.ctrlKey || event.metaKey) && event.key === "k") {
+      openQuickFind({
+        payload: {
+          ctrlKey: event.ctrlKey,
+          metaKey: event.metaKey,
+          key: event.key,
+          code: event.code,
+        },
+      });
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener("keydown", keyboardHandler);
+    return () => {
+      window.removeEventListener("keydown", keyboardHandler);
+    };
+  }, []);
+
   const isLoading =
     !puckConfig ||
     !templateMetadata ||

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -362,14 +362,7 @@ export const Editor = ({ document, puckConfigs }: EditorProps) => {
 
   const keyboardHandler = (event: KeyboardEvent) => {
     if ((event.ctrlKey || event.metaKey) && event.key === "k") {
-      openQuickFind({
-        payload: {
-          ctrlKey: event.ctrlKey,
-          metaKey: event.metaKey,
-          key: event.key,
-          code: event.code,
-        },
-      });
+      openQuickFind();
     }
   };
 


### PR DESCRIPTION
Adds event listeners for cmd+k and ctrl+k. When triggered, sends a message to the parent (storm).

Adds support for the shortcut when the header or sidebars are selected. Still does not work on the puck preview iframe because we cannot add a listener to that iframe from outside the puck package.