### PR TITLE
fix: redirecting on localhost

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -75,7 +75,8 @@ export const Editor = ({ document, componentRegistry }: EditorProps) => {
         window.location.assign("/404.html");
       } else if (
         !ancestors[0].includes("pagescdn") &&
-        !ancestors[0].includes("yext.com")
+        !ancestors[0].includes("yext.com") &&
+        !ancestors[0].includes("localhost")
       ) {
         window.location.assign("/404.html");
       } else {


### PR DESCRIPTION
We were auto redirecting to 404 on localhost which made local development not work in Yext dev.