### PR TITLE
fix: add null check to message.data

### DIFF
--- a/src/internal/hooks/useMessage.ts
+++ b/src/internal/hooks/useMessage.ts
@@ -176,7 +176,7 @@ const useListenAndRespondMessage = (
   const onWatchEventHandler = useCallback(
     ({ origin, source, data }: MessageEvent) => {
       // Ignore React Dev Tools messages
-      if (data.source?.startsWith("react-devtools")) {
+      if (data?.source?.startsWith("react-devtools")) {
         return;
       }
       if (!targetOrigins.includes(origin)) {


### PR DESCRIPTION
There is a case where I see a `MessageEvent` with an origin, source, and null data. In this case the origin is not a target origin, but the code errors out on the null data first before it can throw a "Unrecognized origin" error. 