### PR TITLE
fix: make _site object available on documents in dev mode

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -53,6 +53,7 @@ export const Editor = ({ document, componentRegistry }: EditorProps) => {
   const [saveState, setSaveState] = useState<SaveState>();
   const [saveStateFetched, setSaveStateFetched] = useState<boolean>(false); // needed because saveState can be empty
   const [devPageSets, setDevPageSets] = useState<any>(undefined);
+  const [devSiteStream, setDevSiteStream] = useState<any>(undefined);
   const [templateMetadata, setTemplateMetadata] = useState<TemplateMetadata>();
   const [puckConfig, setPuckConfig] = useState<Config>();
   const [parentLoaded, setParentLoaded] = useState<boolean>(false);
@@ -108,6 +109,8 @@ export const Editor = ({ document, componentRegistry }: EditorProps) => {
       try {
         // @ts-expect-error pageSets is a global variable set by pagesJS
         setDevPageSets(pageSets);
+        // @ts-expect-error siteStream is a global variable set by pagesJS
+        setDevSiteStream(siteStream);
         // eslint-disable-next-line
       } catch (ignored) {
         console.warn("pageSets are not defined");
@@ -321,7 +324,7 @@ export const Editor = ({ document, componentRegistry }: EditorProps) => {
       devPageSets
     ) {
       pushPageSets({
-        payload: devPageSets,
+        payload: { ...devPageSets, siteStream: devSiteStream },
       });
     }
   }, [templateMetadata?.isDevMode, devPageSets]);


### PR DESCRIPTION
- reads siteStream global variable from pages.js
- passes siteStream to Storm
- upcoming update to storm will use this to return `_site` in dev mode
- together with [https://github.com/yext/pages/pull/542](https://github.com/yext/pages/pull/542) 