### PR TITLE
fix: loadPuckInitialHistory is never called

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -142,7 +142,7 @@ export const Editor = ({ document, componentRegistry }: EditorProps) => {
       return;
     }
     loadPuckInitialHistory(); // do something after state has updated
-  }, [templateMetadata, saveState, visualConfigurationData]);
+  }, [templateMetadata, saveStateFetched, visualConfigurationDataFetched]);
 
   /**
    * Determines the initialHistory to send to Puck. It is based on a combination
@@ -376,7 +376,7 @@ export const Editor = ({ document, componentRegistry }: EditorProps) => {
         !!document +
         saveStateFetched +
         visualConfigurationDataFetched)) /
-    6;
+    5;
 
   return (
     <>


### PR DESCRIPTION
`loadPuckInitialHistory()` was called when `visualConfigurationData` updated, but sometimes it would immediate return because `visualConfigurationDataFetched` was false, causing the puck history to never load.

Since `setVisualConfigurationData()` & `setVisualConfigurationDataFetched()` are called in the same function, this case would sometimes happen.

Switched the `useEffect` for  `loadPuckInitialHistory()` to watch for `saveStateFetched` and `visualConfigurationDataFetched` to avoid this condition.