### PR TITLE
feat: add hooks/provider for entityFields

### DIFF
--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -10,12 +10,58 @@ Meant to be used in conjunction with the [DocumentProvider](https://github.com/y
 
 ```tsx
 import { Editor, usePlatformBridgeDocument } from "@yext/visual-editor";
+import { DocumentProvider } from "@yext/pages/util";
 
-const entityDocument = usePlatformBridgeDocument();
+const Edit: () => JSX.Element = () => {
+  const entityDocument = usePlatformBridgeDocument();
 
-return (
-  <DocumentProvider value={entityDocument}>
-    <Editor document={entityDocument} componentRegistry={componentRegistry} />
-  </DocumentProvider>
-);
+  return (
+    <DocumentProvider value={entityDocument}>
+      <Editor document={entityDocument} componentRegistry={componentRegistry} />
+    </DocumentProvider>
+  );
+};
 ```
+
+## usePlatformBridgeEntityFields
+
+Use this hook to capture the entityFields from the Yext platform in your `edit.tsx` file.
+This is a requirement to use mappable entity fields in your component props.
+Meant to be used in conjunction with the [EntityFieldsProvider](#entityfieldsprovider).
+
+### Usage
+
+```tsx
+import {
+  Editor,
+  usePlatformBridgeDocument,
+  usePlatformBridgeEntityFields,
+  EntityFieldsProvider,
+} from "@yext/visual-editor";
+import { DocumentProvider } from "@yext/pages/util";
+
+// Render the editor
+const Edit: () => JSX.Element = () => {
+  const entityDocument = usePlatformBridgeDocument();
+  const entityFields = usePlatformBridgeEntityFields();
+
+  return (
+    <DocumentProvider value={entityDocument}>
+      <EntityFieldsProvider entityFields={entityFields}>
+        <Editor
+          document={entityDocument}
+          componentRegistry={componentRegistry}
+        />
+      </EntityFieldsProvider>
+    </DocumentProvider>
+  );
+};
+```
+
+## useEntityFields
+
+A React hook that returns entityFields available to your TemplateConfig's Stream. This is necessary to use mappable entity fields in your component props. Must be used within an[EntityFieldsProvider](#entityfieldsprovider).
+
+## EntityFieldsProvider
+
+A React component that wraps any components using the above [useEntityFields](#useentityfields) hook.

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,6 @@
 export { usePlatformBridgeDocument } from "./usePlatformBridgeDocument.ts";
+export {
+  useEntityFields,
+  EntityFieldsProvider,
+  usePlatformBridgeEntityFields,
+} from "./useEntityFields.tsx";

--- a/src/hooks/useEntityFields.tsx
+++ b/src/hooks/useEntityFields.tsx
@@ -1,0 +1,68 @@
+import * as React from "react";
+import { useReceiveMessage } from "../internal/hooks/useMessage.ts";
+import { useState } from "react";
+import { TARGET_ORIGINS } from "../components/Editor.tsx";
+
+/**
+ * Under the hood we receive a Stream for a template, but we expose
+ * hooks with a more user-friendly name.
+ */
+export const usePlatformBridgeEntityFields = () => {
+  const [templateStream, setTemplateStream] = useState<any>(undefined);
+
+  useReceiveMessage("getTemplateStream", TARGET_ORIGINS, (send, payload) => {
+    setTemplateStream(payload);
+    send({
+      status: "success",
+      payload: { message: "templateStream received" },
+    });
+  });
+
+  return templateStream as EntityFields;
+};
+
+const EntityFieldsContext = React.createContext<EntityFields | undefined>(
+  undefined
+);
+
+type EntityFieldsProviderProps = {
+  entityFields: EntityFields;
+  children: React.ReactNode;
+};
+
+export const EntityFieldsProvider = ({
+  entityFields,
+  children,
+}: EntityFieldsProviderProps) => {
+  return (
+    <EntityFieldsContext.Provider value={entityFields}>
+      {children}
+    </EntityFieldsContext.Provider>
+  );
+};
+
+export const useEntityFields = () => {
+  const context = React.useContext(EntityFieldsContext);
+  if (!context) {
+    throw new Error("useEntityFields must be used within a DocumentProvider");
+  }
+
+  return context;
+};
+
+export type EntityFields = {
+  stream: Stream;
+};
+
+export type Stream = {
+  expression: {
+    fields: Field[];
+  };
+};
+
+export type Field = {
+  name: string;
+  children: {
+    fields: Field[];
+  };
+};


### PR DESCRIPTION
Adds `usePlatformBridgeEntityFields`, `EntityFieldsProvider`, and `useEntityFields`. These are used to support mappable entity fields in the Puck props.