### PR TITLE
fix: entity fields toggle incorrectly switching off

### DIFF
--- a/src/internal/puck/components/Header.tsx
+++ b/src/internal/puck/components/Header.tsx
@@ -189,7 +189,10 @@ const ToggleEntityFields = () => {
       <Tooltip>
         <TooltipTrigger asChild>
           <div className="ve-flex ve-flex-row ve-self-center ve-gap-3 ve-pl-2">
-            <Switch onCheckedChange={toggleTooltips} />
+            <Switch
+              onCheckedChange={toggleTooltips}
+              checked={tooltipsVisible}
+            />
             <p className="ve-self-center ve-text-sm">Entity Fields</p>
           </div>
         </TooltipTrigger>


### PR DESCRIPTION
The entity fields toggle was switching off when the page saved because it was not passing the toggle state to the component.