### PR TITLE
fix: accordions inside EntityField tooltip

### DIFF
--- a/src/components/EntityField.tsx
+++ b/src/components/EntityField.tsx
@@ -33,7 +33,7 @@ export const EntityField = ({
   return (
     <TooltipProvider>
       <Tooltip open={tooltipsVisible && !!tooltipContent}>
-        <TooltipTrigger>
+        <TooltipTrigger asChild>
           <div
             className={
               tooltipsVisible


### PR DESCRIPTION
When EntityField (which uses Tooltip under the hood) wraps an Accordion, it results in all content that occurs afterward to be duplicated in the DOM. Setting `asChild` to the TooltipTrigger fixes it.

https://github.com/radix-ui/primitives/discussions/560#discussioncomment-5325935