### PR TITLE
fix(components): add nullchecks for history

### DIFF
--- a/src/internal/components/InternalEditor.tsx
+++ b/src/internal/components/InternalEditor.tsx
@@ -127,7 +127,7 @@ export const InternalEditor = ({
               handleClearLocalChanges,
               handleHistoryChange,
               appState.data,
-              puckInitialHistory?.histories[0].state.data, // used for clearing local changes - reset to first puck history
+              puckInitialHistory?.histories[0]?.state?.data, // used for clearing local changes - reset to first puck history
               handleSave,
               templateMetadata.isDevMode && !templateMetadata.devOverride
             );


### PR DESCRIPTION
When using the mappable-fields PR, I was getting errors from this line stating "cannot access 'data' of undefined", implying that 'state' was null.

This change adds null-checks to the whole string to fix this issue.