### PR TITLE
feat: hide static value field for complex entity types

### DIFF
--- a/src/components/YextEntityFieldSelector.tsx
+++ b/src/components/YextEntityFieldSelector.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { AutoField, FieldLabel, Field } from "@measured/puck";
 import { RenderProps } from "../utils/renderEntityFields.tsx";
 import {
+  EntityFieldTypes,
   getFilteredEntityFields,
   RenderEntityFieldFilter,
 } from "../utils/getFilteredEntityFields.ts";
@@ -16,6 +17,15 @@ export type RenderYextEntityFieldSelectorProps<T extends Record<string, any>> =
     label: string;
     filter: RenderEntityFieldFilter<T>;
   };
+
+const STATIC_VALUE_TYPES: EntityFieldTypes[] = ["type.string", "type.phone"];
+const shouldDisplayStaticValueField = (typeFilter: EntityFieldTypes[]) => {
+  for (const staticValueType of STATIC_VALUE_TYPES) {
+    if (typeFilter.includes(staticValueType)) {
+      return true;
+    }
+  }
+};
 
 /**
  * Allows the user to select an entity field from the document and set a static value.
@@ -54,23 +64,25 @@ export const YextEntityFieldSelector = <T extends Record<string, any>>(
               value={value?.fieldName}
             />
           </FieldLabel>
-          <FieldLabel
-            label={"Static Value"}
-            className="entityField-staticValue"
-          >
-            <AutoField
-              onChange={(newStaticValue) =>
-                onChange({
-                  fieldName: value?.fieldName ?? "",
-                  staticValue: newStaticValue,
-                })
-              }
-              value={value?.staticValue}
-              field={{
-                type: "text",
-              }}
-            />
-          </FieldLabel>
+          {shouldDisplayStaticValueField(props.filter.types) && (
+            <FieldLabel
+              label={"Static Value"}
+              className="entityField-staticValue"
+            >
+              <AutoField
+                onChange={(newStaticValue) =>
+                  onChange({
+                    fieldName: value?.fieldName ?? "",
+                    staticValue: newStaticValue,
+                  })
+                }
+                value={value?.staticValue}
+                field={{
+                  type: "text",
+                }}
+              />
+            </FieldLabel>
+          )}
         </>
       );
     },

--- a/src/utils/getFilteredEntityFields.ts
+++ b/src/utils/getFilteredEntityFields.ts
@@ -33,11 +33,12 @@ type EntityFieldTypesFilter = {
 export type RenderEntityFieldFilter<T extends Record<string, any>> =
   EntityFieldTypesFilter & EitherOrNeither<AllowList<T>, DisallowList<T>>;
 
-type EntityFieldTypes =
+export type EntityFieldTypes =
   | "type.string"
   | "type.image"
   | "type.hours"
   | "type.address"
+  | "type.phone"
   | `c_${string}`;
 
 const DEFAULT_DISALLOWED_ENTITY_FIELDS = [


### PR DESCRIPTION
Only display the Static Value field if it's type.string or type.phone. Probably more basic types to do this for in the future.