### PR TITLE
fix: hide sidebar titles in theme mode via DOM

### DIFF
--- a/src/internal/components/InternalEditor.tsx
+++ b/src/internal/components/InternalEditor.tsx
@@ -147,6 +147,20 @@ export const InternalEditor = ({
                   };
                 };
               });
+
+              const componentList = document.querySelector<HTMLElement>(
+                "[class*='PuckLayout-leftSideBar'] > div[class*='SidebarSection--noBorderTop']"
+              );
+              if (componentList) {
+                componentList.style.display = themeModeActive ? "none" : "";
+              }
+              const fieldListTitle = document.querySelector<HTMLElement>(
+                "[class*='PuckLayout-rightSideBar'] > div[class*='SidebarSection--noBorderTop'] > div[class*='SidebarSection-title']"
+              );
+              if (fieldListTitle) {
+                fieldListTitle.style.display = themeModeActive ? "none" : "";
+              }
+
               refreshPermissions();
             }, [themeModeActive]);
 


### PR DESCRIPTION
There's no way to get rid of the sidebar section titles via individual component puck overrides.

We could override the entire Puck component, but most of the default Puck components are not exported so we'd have to fork a number of files from Puck into our package and maintain them in parallel.

This solution grabs entire ComponentList from the left side bar and the title from the right side bar and hides them via the DOM. 

