### PR TITLE
fix(components): fixed history desync after publish

### DIFF
--- a/src/internal/components/InternalEditor.tsx
+++ b/src/internal/components/InternalEditor.tsx
@@ -172,11 +172,13 @@ export const InternalEditor = ({
               refreshPermissions();
             }, [themeModeActive]);
 
+            const { history } = usePuck();
+
             return customHeader(
               handleClearLocalChanges,
               handleHistoryChange,
               appState.data,
-              puckInitialHistory?.histories[0].state.data, // used for clearing local changes - reset to first puck history
+              history?.histories[0].state.data, // used for clearing local changes - reset to first puck history
               handleSave,
               templateMetadata.isDevMode && !templateMetadata.devOverride,
               themeModeActive,

--- a/src/internal/components/InternalEditor.tsx
+++ b/src/internal/components/InternalEditor.tsx
@@ -172,8 +172,6 @@ export const InternalEditor = ({
               refreshPermissions();
             }, [themeModeActive]);
 
-            const { history } = usePuck();
-
             return customHeader(
               handleClearLocalChanges,
               handleHistoryChange,

--- a/src/internal/components/InternalEditor.tsx
+++ b/src/internal/components/InternalEditor.tsx
@@ -140,7 +140,7 @@ export const InternalEditor = ({
         onChange={change}
         overrides={{
           header: () => {
-            const { appState, refreshPermissions, config } = usePuck();
+            const { appState, refreshPermissions, config, history } = usePuck();
 
             useEffect(() => {
               // set permissions on the component level to allow for dynamic updating

--- a/src/internal/components/InternalEditor.tsx
+++ b/src/internal/components/InternalEditor.tsx
@@ -140,7 +140,7 @@ export const InternalEditor = ({
         onChange={change}
         overrides={{
           header: () => {
-            const { appState, refreshPermissions, config, history } = usePuck();
+            const { refreshPermissions, config } = usePuck();
 
             useEffect(() => {
               // set permissions on the component level to allow for dynamic updating
@@ -175,8 +175,6 @@ export const InternalEditor = ({
             return customHeader(
               handleClearLocalChanges,
               handleHistoryChange,
-              appState.data,
-              history?.histories[0].state.data, // used for clearing local changes - reset to first puck history
               handleSave,
               templateMetadata.isDevMode && !templateMetadata.devOverride,
               themeModeActive,

--- a/src/internal/puck/components/Header.tsx
+++ b/src/internal/puck/components/Header.tsx
@@ -97,6 +97,7 @@ export const customHeader = (
             onClick={async () => {
               await handleSaveData(currentPuckData);
               handleClearLocalChanges();
+              setHistories([{ id: "root", state: { data: currentPuckData } }]);
             }}
           >
             Publish

--- a/src/internal/puck/components/Header.tsx
+++ b/src/internal/puck/components/Header.tsx
@@ -28,14 +28,13 @@ import "../../../components/index.css";
 export const customHeader = (
   handleClearLocalChanges: () => void,
   handleHistoryChange: (histories: History[], index: number) => void,
-  currentPuckData: Data, // the current state of Puck data
-  initialPuckData: Data | undefined, // the initial state of Puck data before any local changes
   handleSaveData: (data: Data) => Promise<void>,
   isDevMode: boolean,
   themeModeActive: boolean,
   setThemeModeActive: () => void
 ) => {
   const {
+    appState,
     history: {
       back,
       forward,
@@ -87,7 +86,9 @@ export const customHeader = (
           disabled={histories.length === 1}
           onClearLocalChanges={() => {
             handleClearLocalChanges();
-            setHistories([{ id: "root", state: { data: initialPuckData } }]);
+            setHistories([
+              { id: "root", state: { data: histories[0].state.data } },
+            ]);
           }}
         />
         {!isDevMode && (
@@ -95,9 +96,9 @@ export const customHeader = (
             variant="secondary"
             disabled={histories.length === 1}
             onClick={async () => {
-              await handleSaveData(currentPuckData);
+              await handleSaveData(appState.data);
               handleClearLocalChanges();
-              setHistories([{ id: "root", state: { data: currentPuckData } }]);
+              setHistories([{ id: "root", state: { data: appState.data } }]);
             }}
           >
             Publish


### PR DESCRIPTION
We were using InitialPuckHistory which does not update to reset the local changes.

We also were not updating the history after clearing local changes.

After these changes, history is updated and clear local changes is disabled after publish.

After publish, user can add and clear local changes as expected.