### PR TITLE
chore: clean up theme manager

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -478,7 +478,6 @@ export const Editor = ({
   });
 
   useReceiveMessage("getThemeSaveState", TARGET_ORIGINS, (send, payload) => {
-    devLogger.log("getThemeSaveState PAYLOAD" + JSON.stringify(payload));
     const themeSaveState = {
       history: payload?.history
         ? jsonFromEscapedJsonString(payload?.history)
@@ -510,8 +509,7 @@ export const Editor = ({
   );
 
   useReceiveMessage("getThemeData", TARGET_ORIGINS, (send, payload) => {
-    devLogger.log("getThemeData PAYLOAD: " + JSON.stringify(payload));
-    const themeData = jsonFromEscapedJsonString(payload as any);
+    const themeData = jsonFromEscapedJsonString(payload as unknown as string);
     devLogger.logData("THEME_DATA", themeData);
     setThemeData(themeData);
     setThemeDataFetched(true);

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -63,7 +63,6 @@ export const Editor = ({
   const [templateMetadata, setTemplateMetadata] = useState<TemplateMetadata>();
   const [puckConfig, setPuckConfig] = useState<Config>();
   const [parentLoaded, setParentLoaded] = useState<boolean>(false);
-  const [puckRendered, setPuckRendered] = useState(false);
 
   // theming
   const [themeInitialHistory, setThemeInitialHistory] =
@@ -333,9 +332,6 @@ export const Editor = ({
   }, [puckInitialHistory]);
 
   const loadThemeInitialHistory = useCallback(() => {
-    console.log(
-      `themeData is ${JSON.stringify(themeData)}, themeSaveState is ${JSON.stringify(themeSaveState)}`
-    );
     if (
       !themeSaveStateFetched ||
       !templateMetadata ||
@@ -343,8 +339,9 @@ export const Editor = ({
     ) {
       return;
     }
-
     devLogger.logFunc("loadThemeHistory");
+    devLogger.logData("THEME_DATA", JSON.stringify(themeData));
+    devLogger.logData("THEME_SAVE_STATE", JSON.stringify(themeSaveState));
 
     if (templateMetadata.isDevMode && !templateMetadata.devOverride) {
       // Check localStorage for existing theme history
@@ -361,6 +358,7 @@ export const Editor = ({
           history: localHistories,
           index: localHistoryIndex,
         });
+        devLogger.logData("THEME_INITIAL_HISTORY", themeInitialHistory);
         setThemeInitialHistoryFetched(true);
         return;
       }
@@ -370,12 +368,12 @@ export const Editor = ({
         "Dev Mode - No localStorage. Using theme data from Content"
       );
       if (themeData) {
-        console.log(`starting fresh from content: ${themeData}`);
         setThemeInitialHistory({
           history: [themeData],
           index: 0,
         });
       }
+      devLogger.logData("THEME_INITIAL_HISTORY", themeInitialHistory);
       setThemeInitialHistoryFetched(true);
       return;
     }
@@ -391,6 +389,7 @@ export const Editor = ({
           index: 0,
         });
       }
+      devLogger.logData("THEME_INITIAL_HISTORY", themeInitialHistory);
       setThemeInitialHistoryFetched(true);
 
       return;
@@ -404,7 +403,9 @@ export const Editor = ({
     // No localStorage for themes, start from themeSaveState
     //if (!localHistoryArray) {
     if (themeData) {
-      devLogger.log("Prod Mode - No themeLocalStorage. Using themeSaveState");
+      devLogger.log(
+        "Prod Mode - No themeLocalStorage. Using themeSaveState and themeData"
+      );
       const history = themeData
         ? [themeData, ...themeSaveState.history]
         : [...themeSaveState.history];
@@ -414,17 +415,16 @@ export const Editor = ({
       };
       setThemeInitialHistory(themeInitialHistory);
       setThemeInitialHistoryFetched(true);
-      console.log(
-        `themeInitialHistory is ${JSON.stringify(themeInitialHistory)}`
-      );
+      devLogger.logData("THEME_INITIAL_HISTORY", themeInitialHistory);
       return;
     }
 
-    console.log("Setting blank now");
+    devLogger.log("No loadThemeInitialHistory case matched, setting to blank.");
     setThemeInitialHistory({
       history: [{}],
       index: 0,
     });
+    devLogger.logData("THEME_INITIAL_HISTORY", themeInitialHistory);
     setThemeInitialHistoryFetched(true);
     // If local storage reset theme history to it
     // devLogger.log("Prod Mode - Using themeLocalStorage");
@@ -478,14 +478,14 @@ export const Editor = ({
   });
 
   useReceiveMessage("getThemeSaveState", TARGET_ORIGINS, (send, payload) => {
-    devLogger.logData("THEME_SAVE_STATE", payload);
-    console.log("themeSaveState", JSON.stringify(payload));
+    devLogger.log("getThemeSaveState PAYLOAD" + JSON.stringify(payload));
     const themeSaveState = {
       history: payload?.history
         ? jsonFromEscapedJsonString(payload?.history)
         : [],
       index: payload?.index ?? 0,
     };
+    devLogger.logData("THEME_SAVE_STATE", payload);
     setThemeSaveState(themeSaveState);
     setThemeSaveStateFetched(true);
     send({
@@ -510,7 +510,7 @@ export const Editor = ({
   );
 
   useReceiveMessage("getThemeData", TARGET_ORIGINS, (send, payload) => {
-    console.log(`payload in getThemeData is ${JSON.stringify(payload)}`);
+    devLogger.log("getThemeData PAYLOAD: " + JSON.stringify(payload));
     const themeData = jsonFromEscapedJsonString(payload as any);
     devLogger.logData("THEME_DATA", themeData);
     setThemeData(themeData);
@@ -599,25 +599,15 @@ export const Editor = ({
         !themeInitialHistoryFetched));
 
   useEffect(() => {
-    console.log("theme useEffect");
-    if (
-      puckRendered &&
-      themeInitialHistory &&
-      themeConfig &&
-      templateMetadata?.isThemeMode
-    ) {
+    devLogger.logFunc("themeInitialHistory useEffect");
+    if (themeInitialHistory && themeConfig && templateMetadata?.isThemeMode) {
       devLogger.logData("THEME_INITIAL_HISTORY", themeInitialHistory);
       updateThemeInEditor(
         themeInitialHistory.history[themeInitialHistory.index],
         themeConfig
       );
     }
-  }, [
-    themeInitialHistory,
-    themeConfig,
-    puckRendered,
-    templateMetadata?.isThemeMode,
-  ]);
+  }, [themeInitialHistory, themeConfig, templateMetadata?.isThemeMode]);
 
   const progress: number =
     (100 * // @ts-expect-error adding bools is fine
@@ -659,7 +649,6 @@ export const Editor = ({
           saveThemeSaveState={saveThemeSaveState}
           themeHistory={themeInitialHistory}
           setThemeHistory={setThemeInitialHistory}
-          setPuckRendered={setPuckRendered}
         />
       ) : (
         parentLoaded && <LoadingScreen progress={progress} />

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -340,8 +340,8 @@ export const Editor = ({
       return;
     }
     devLogger.logFunc("loadThemeHistory");
-    devLogger.logData("THEME_DATA", JSON.stringify(themeData));
-    devLogger.logData("THEME_SAVE_STATE", JSON.stringify(themeSaveState));
+    devLogger.logData("THEME_DATA", themeData);
+    devLogger.logData("THEME_SAVE_STATE", themeSaveState);
 
     if (templateMetadata.isDevMode && !templateMetadata.devOverride) {
       // Check localStorage for existing theme history

--- a/src/internal/components/InternalEditor.tsx
+++ b/src/internal/components/InternalEditor.tsx
@@ -36,7 +36,6 @@ interface InternalEditorProps {
   saveThemeSaveState: (data: any) => void;
   themeHistory?: ThemeSaveState;
   setThemeHistory: (themeHistory: ThemeSaveState) => void;
-  setPuckRendered: (isRendered: boolean) => void;
 }
 
 // Render Puck editor
@@ -57,7 +56,6 @@ export const InternalEditor = ({
   saveThemeSaveState,
   themeHistory,
   setThemeHistory,
-  setPuckRendered,
 }: InternalEditorProps) => {
   const [canEdit, setCanEdit] = useState<boolean>(false);
   const historyIndex = useRef<number>(0);
@@ -151,7 +149,6 @@ export const InternalEditor = ({
         overrides={{
           header: () => {
             const { refreshPermissions, config } = usePuck();
-            setPuckRendered(true);
 
             useEffect(() => {
               // set permissions on the component level to allow for dynamic updating

--- a/src/internal/puck/components/ThemeSidebar.tsx
+++ b/src/internal/puck/components/ThemeSidebar.tsx
@@ -12,7 +12,6 @@ import { ThemeSaveState } from "../../types/themeSaveState.ts";
 import { Payload } from "../../hooks/useMessage.ts";
 
 type ThemeSidebarProps = {
-  //savedThemeValues: SavedTheme | undefined;
   themeConfig?: ThemeConfig;
   saveTheme: (themeSaveState: Payload) => void;
   themeHistory: ThemeSaveState;
@@ -43,7 +42,6 @@ const ThemeSidebar = (props: ThemeSidebarProps) => {
       history: [...themeHistory.history, newThemeValues],
       index: themeHistory.index + 1,
     };
-    console.log(`handleThemeChange newHistory ${JSON.stringify(newHistory)}`);
     saveTheme({
       payload: {
         history: JSON.stringify(newHistory.history),

--- a/src/utils/devLogger.ts
+++ b/src/utils/devLogger.ts
@@ -9,7 +9,8 @@ export type DevLoggerPrefix =
   | "DOCUMENT"
   | "PUCK_INDEX"
   | "PUCK_HISTORY"
-  | "PUCK_INITIAL_HISTORY";
+  | "PUCK_INITIAL_HISTORY"
+  | "THEME_VALUES_TO_APPLY";
 
 export class DevLogger {
   constructor(private enabled: boolean = false) {


### PR DESCRIPTION
- uses MutationObserver api to update styles
- moves all console logs to devLogger (should work with Brian's query params changes)
- removes puckRendered since we did not end up using it