### PR TITLE
feat: add dev mode theme preview

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -477,17 +477,17 @@ export const Editor = ({
   // Handles sending the sendDevThemeSaveStateData on initial load so that nothing isn't rendered for preview.
   // Subsequent changes are sent via handleChange in ThemeSidebar.tsx.
   useEffect(() => {
-    if (!themeSaveStateFetched || !templateMetadata?.isThemeMode) {
+    if (!themeInitialHistoryFetched || !templateMetadata?.isThemeMode) {
       return;
     }
 
-    const themeToSend = themeSaveState?.history[themeSaveState.index];
+    const themeToSend = themeInitialHistory?.history[themeInitialHistory.index];
 
     devLogger.logFunc("sendDevThemeSaveStateData useEffect");
     sendDevThemeSaveStateData({
       payload: { devThemeSaveStateData: JSON.stringify(themeToSend) },
     });
-  }, [themeSaveStateFetched, themeSaveState, templateMetadata]);
+  }, [themeInitialHistoryFetched, themeInitialHistory, templateMetadata]);
 
   const { sendToParent: iFrameLoaded } = useSendMessageToParent(
     "iFrameLoaded",

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -344,7 +344,7 @@ export const Editor = ({
   // Handles sending the devSaveStateData on initial load so that nothing isn't rendered for preview.
   // Subsequent changes are sent via handleHistoryChange in InternalEditor.tsx.
   useEffect(() => {
-    if (!puckInitialHistoryFetched) {
+    if (!puckInitialHistoryFetched || templateMetadata?.isThemeMode) {
       return;
     }
 
@@ -356,7 +356,7 @@ export const Editor = ({
     sendDevSaveStateData({
       payload: { devSaveStateData: JSON.stringify(historyToSend) },
     });
-  }, [puckInitialHistoryFetched, puckInitialHistory]);
+  }, [puckInitialHistoryFetched, puckInitialHistory, templateMetadata]);
 
   useEffect(() => {
     if (puckInitialHistory) {
@@ -477,7 +477,7 @@ export const Editor = ({
   // Handles sending the sendDevThemeSaveStateData on initial load so that nothing isn't rendered for preview.
   // Subsequent changes are sent via handleChange in ThemeSidebar.tsx.
   useEffect(() => {
-    if (!themeSaveStateFetched) {
+    if (!themeSaveStateFetched || !templateMetadata?.isThemeMode) {
       return;
     }
 
@@ -487,7 +487,7 @@ export const Editor = ({
     sendDevThemeSaveStateData({
       payload: { devThemeSaveStateData: JSON.stringify(themeToSend) },
     });
-  }, [themeSaveStateFetched, themeSaveState]);
+  }, [themeSaveStateFetched, themeSaveState, templateMetadata]);
 
   const { sendToParent: iFrameLoaded } = useSendMessageToParent(
     "iFrameLoaded",

--- a/src/internal/components/InternalEditor.tsx
+++ b/src/internal/components/InternalEditor.tsx
@@ -29,6 +29,7 @@ interface InternalEditorProps {
   saveVisualConfigData: (data: any) => void;
   sendDevSaveStateData: (data: any) => void;
   saveThemeData: (data: any) => void;
+  sendDevThemeSaveStateData: (data: any) => void;
   buildVisualConfigLocalStorageKey: () => string;
   devLogger: DevLogger;
   themeConfig?: ThemeConfig;
@@ -54,6 +55,7 @@ export const InternalEditor = ({
   devLogger,
   themeConfig,
   saveThemeSaveState,
+  sendDevThemeSaveStateData,
   themeHistory,
   setThemeHistory,
 }: InternalEditorProps) => {
@@ -198,8 +200,11 @@ export const InternalEditor = ({
                 <ThemeSidebar
                   themeConfig={themeConfig}
                   saveTheme={saveThemeSaveState}
+                  sendDevThemeSaveStateData={sendDevThemeSaveStateData}
                   themeHistory={themeHistory!}
                   setThemeHistory={setThemeHistory}
+                  templateMetadata={templateMetadata}
+                  devLogger={devLogger}
                 />
               )
             : undefined,

--- a/src/internal/puck/components/ThemeSidebar.tsx
+++ b/src/internal/puck/components/ThemeSidebar.tsx
@@ -10,16 +10,29 @@ import { updateThemeInEditor } from "../../../utils/applyTheme.ts";
 import { generateCssVariablesFromPuckFields } from "../../utils/internalThemeResolver.ts";
 import { ThemeSaveState } from "../../types/themeSaveState.ts";
 import { Payload } from "../../hooks/useMessage.ts";
+import { TemplateMetadata } from "../../types/templateMetadata.ts";
+import { DevLogger } from "../../../utils/devLogger.ts";
 
 type ThemeSidebarProps = {
   themeConfig?: ThemeConfig;
   saveTheme: (themeSaveState: Payload) => void;
+  sendDevThemeSaveStateData: (data: any) => void;
   themeHistory: ThemeSaveState;
   setThemeHistory: (themeHistory: ThemeSaveState) => void;
+  templateMetadata: TemplateMetadata;
+  devLogger: DevLogger;
 };
 
 const ThemeSidebar = (props: ThemeSidebarProps) => {
-  const { saveTheme, themeConfig, themeHistory, setThemeHistory } = props;
+  const {
+    saveTheme,
+    sendDevThemeSaveStateData,
+    themeConfig,
+    themeHistory,
+    setThemeHistory,
+    templateMetadata,
+    devLogger,
+  } = props;
   if (!themeConfig) {
     return (
       <div>
@@ -42,12 +55,25 @@ const ThemeSidebar = (props: ThemeSidebarProps) => {
       history: [...themeHistory.history, newThemeValues],
       index: themeHistory.index + 1,
     };
-    saveTheme({
-      payload: {
-        history: JSON.stringify(newHistory.history),
-        index: newHistory.index,
-      },
-    });
+
+    if (templateMetadata.isDevMode && !templateMetadata.devOverride) {
+      devLogger.logFunc("sendDevThemeSaveStateData");
+      sendDevThemeSaveStateData({
+        payload: {
+          devThemeSaveStateData: JSON.stringify(
+            newHistory.history[newHistory.index]
+          ),
+        },
+      });
+    } else {
+      devLogger.logFunc("saveTheme");
+      saveTheme({
+        payload: {
+          history: JSON.stringify(newHistory.history),
+          index: newHistory.index,
+        },
+      });
+    }
     setThemeHistory(newHistory);
   };
 


### PR DESCRIPTION
Adds theme preview for dev mode.

- Also fixes preview for VE in dev mode for the initial load. It was only working after a change was made.
- Now only pulls the published VE data for theme mode
- Properly clears history between theme and VE