### PR TITLE
refactor: separate message receivers

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -8811,7 +8811,7 @@ SOFTWARE.
 
 The following npm package may be included in this product:
 
- - json5@2.2.3
+ - json5@1.0.2
 
 This package contains the following license and notice below:
 

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -8811,7 +8811,7 @@ SOFTWARE.
 
 The following npm package may be included in this product:
 
- - json5@1.0.2
+ - json5@2.2.3
 
 This package contains the following license and notice below:
 

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -7,7 +7,7 @@ import "@measured/puck/puck.css";
 import { DevLogger } from "../utils/devLogger.ts";
 import { ThemeConfig } from "../utils/themeResolver.ts";
 import { useQuickFindShortcut } from "../internal/hooks/useQuickFindShortcut.ts";
-import { useMessageReceivers } from "../internal/hooks/useMessageReceivers.ts";
+import { useCommonMessageReceivers } from "../internal/hooks/useMessageReceivers.ts";
 import { LayoutEditor } from "../internal/components/LayoutEditor.tsx";
 import { ThemeEditor } from "../internal/components/ThemeEditor.tsx";
 import { useCommonMessageSenders } from "../internal/hooks/useMessageSenders.ts";
@@ -38,13 +38,7 @@ export const Editor = ({
     puckConfig,
     visualConfigurationData,
     visualConfigurationDataFetched,
-    layoutSaveState,
-    layoutSaveStateFetched,
-    themeData,
-    themeDataFetched,
-    themeSaveState,
-    themeSaveStateFetched,
-  } = useMessageReceivers(componentRegistry);
+  } = useCommonMessageReceivers(componentRegistry);
 
   const { pushPageSets } = useCommonMessageSenders();
 
@@ -98,21 +92,15 @@ export const Editor = ({
     !puckConfig ||
     !templateMetadata ||
     !document ||
-    !(layoutSaveStateFetched || templateMetadata?.isThemeMode) ||
-    !visualConfigurationDataFetched ||
-    !(themeDataFetched || !templateMetadata?.isThemeMode) ||
-    !(themeSaveStateFetched || !templateMetadata?.isThemeMode);
+    !visualConfigurationDataFetched;
 
   const progress: number =
-    100 * // @ts-expect-error adding bools is fine
+    60 * // @ts-expect-error adding bools is fine
     ((!!puckConfig +
       !!templateMetadata +
       !!document +
-      ((layoutSaveStateFetched || templateMetadata?.isThemeMode) ?? 0) +
-      visualConfigurationDataFetched +
-      ((themeDataFetched || !templateMetadata?.isThemeMode) ?? 0) +
-      ((themeSaveStateFetched || !templateMetadata?.isThemeMode) ?? 0)) /
-      7);
+      visualConfigurationDataFetched) /
+      4);
 
   return (
     <>
@@ -121,8 +109,6 @@ export const Editor = ({
           <ThemeEditor
             puckConfig={puckConfig}
             templateMetadata={templateMetadata}
-            themeSaveState={themeSaveState}
-            themeData={themeData}
             visualConfigurationData={visualConfigurationData}
             themeConfig={themeConfig}
           />
@@ -130,7 +116,6 @@ export const Editor = ({
           <LayoutEditor
             puckConfig={puckConfig}
             templateMetadata={templateMetadata}
-            layoutSaveState={layoutSaveState}
             visualConfigurationData={visualConfigurationData}
           />
         )

--- a/src/internal/components/LayoutEditor.tsx
+++ b/src/internal/components/LayoutEditor.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { InternalLayoutEditor } from "./InternalLayoutEditor.tsx";
 import { InitialHistory, Config } from "@measured/puck";
-import {} from "../types/saveState.ts";
 import { TemplateMetadata } from "../types/templateMetadata.ts";
 import { useLayoutLocalStorage } from "../hooks/layout/useLocalStorage.ts";
 import { DevLogger } from "../../utils/devLogger.ts";

--- a/src/internal/components/ThemeEditor.tsx
+++ b/src/internal/components/ThemeEditor.tsx
@@ -8,27 +8,21 @@ import { ThemeConfig } from "../../utils/themeResolver.ts";
 import { updateThemeInEditor } from "../../utils/applyTheme.ts";
 import { InternalThemeEditor } from "./InternalThemeEditor.tsx";
 import { useThemeMessageSenders } from "../hooks/theme/useMessageSenders.ts";
+import { useThemeMessageReceivers } from "../hooks/theme/useMessageReceivers.ts";
+import { LoadingScreen } from "../puck/components/LoadingScreen.tsx";
 
 const devLogger = new DevLogger();
 
 type ThemeEditorProps = {
   puckConfig: Config;
   templateMetadata: TemplateMetadata;
-  themeSaveState: ThemeSaveState | undefined;
-  themeData: any;
   visualConfigurationData: any;
   themeConfig: ThemeConfig | undefined;
 };
 
 export const ThemeEditor = (props: ThemeEditorProps) => {
-  const {
-    puckConfig,
-    templateMetadata,
-    themeSaveState,
-    themeData,
-    visualConfigurationData,
-    themeConfig,
-  } = props;
+  const { puckConfig, templateMetadata, visualConfigurationData, themeConfig } =
+    props;
 
   const {
     sendDevThemeSaveStateData,
@@ -36,6 +30,9 @@ export const ThemeEditor = (props: ThemeEditorProps) => {
     publishThemeConfiguration,
     deleteThemeSaveState,
   } = useThemeMessageSenders();
+
+  const { themeData, themeDataFetched, themeSaveState, themeSaveStateFetched } =
+    useThemeMessageReceivers();
 
   const { buildThemeLocalStorageKey, clearThemeLocalStorage } =
     useThemeLocalStorage(templateMetadata);
@@ -177,9 +174,12 @@ export const ThemeEditor = (props: ThemeEditorProps) => {
   }, [themeInitialHistory, themeConfig]);
 
   useEffect(() => {
+    if (!themeSaveStateFetched || !themeDataFetched) {
+      return;
+    }
     loadPuckInitialHistory();
     loadThemeInitialHistory();
-  }, [templateMetadata]);
+  }, [templateMetadata, themeSaveStateFetched, themeDataFetched]);
 
   // Log PUCK_INITIAL_HISTORY (layout) on load
   useEffect(() => {
@@ -212,24 +212,36 @@ export const ThemeEditor = (props: ThemeEditorProps) => {
     });
   }, [themeInitialHistoryFetched, themeInitialHistory, templateMetadata]);
 
-  const isLoading = !puckInitialHistoryFetched || !themeInitialHistoryFetched;
+  const isLoading =
+    !puckInitialHistoryFetched ||
+    !themeInitialHistoryFetched ||
+    !themeDataFetched ||
+    !themeSaveStateFetched;
 
-  return (
-    !isLoading && (
-      <InternalThemeEditor
-        puckConfig={puckConfig}
-        puckInitialHistory={puckInitialHistory}
-        isLoading={isLoading}
-        templateMetadata={templateMetadata}
-        publishThemeConfiguration={publishThemeConfiguration}
-        themeConfig={themeConfig}
-        saveThemeSaveState={saveThemeSaveState}
-        themeHistory={themeInitialHistory}
-        setThemeHistory={setThemeInitialHistory}
-        clearThemeHistory={clearHistory}
-        sendDevThemeSaveStateData={sendDevThemeSaveStateData}
-        buildThemeLocalStorageKey={buildThemeLocalStorageKey}
-      />
-    )
+  const progress =
+    60 + // @ts-expect-error adding bools is fine
+    (puckInitialHistoryFetched +
+      themeInitialHistoryFetched +
+      themeDataFetched +
+      themeSaveStateFetched) *
+      10;
+
+  return !isLoading ? (
+    <InternalThemeEditor
+      puckConfig={puckConfig}
+      puckInitialHistory={puckInitialHistory}
+      isLoading={isLoading}
+      templateMetadata={templateMetadata}
+      publishThemeConfiguration={publishThemeConfiguration}
+      themeConfig={themeConfig}
+      saveThemeSaveState={saveThemeSaveState}
+      themeHistory={themeInitialHistory}
+      setThemeHistory={setThemeInitialHistory}
+      clearThemeHistory={clearHistory}
+      sendDevThemeSaveStateData={sendDevThemeSaveStateData}
+      buildThemeLocalStorageKey={buildThemeLocalStorageKey}
+    />
+  ) : (
+    <LoadingScreen progress={progress} />
   );
 };

--- a/src/internal/hooks/layout/useMessageReceivers.ts
+++ b/src/internal/hooks/layout/useMessageReceivers.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+import { DevLogger } from "../../../utils/devLogger.ts";
+import { LayoutSaveState } from "../../types/saveState.ts";
+import { useReceiveMessage, TARGET_ORIGINS } from "../useMessage.ts";
+import { useCommonMessageSenders } from "../useMessageSenders.ts";
+
+const devLogger = new DevLogger();
+
+export const useLayoutMessageReceivers = () => {
+  const { iFrameLoaded } = useCommonMessageSenders();
+
+  // Trigger additional data flow from parent
+  useEffect(() => {
+    iFrameLoaded({ payload: { message: "Layout Editor is loaded" } });
+  }, []);
+
+  // Layout from DB
+  const [layoutSaveState, setLayoutSaveState] = useState<LayoutSaveState>();
+  const [layoutSaveStateFetched, setLayoutSaveStateFetched] =
+    useState<boolean>(false); // needed because saveState can be empty
+
+  useReceiveMessage("getSaveState", TARGET_ORIGINS, (send, payload) => {
+    devLogger.logData("SAVE_STATE", payload);
+    setLayoutSaveState(payload as LayoutSaveState);
+    setLayoutSaveStateFetched(true);
+    send({ status: "success", payload: { message: "saveState received" } });
+  });
+
+  return {
+    layoutSaveState,
+    layoutSaveStateFetched,
+  };
+};

--- a/src/internal/hooks/theme/useMessageReceivers.ts
+++ b/src/internal/hooks/theme/useMessageReceivers.ts
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react";
+import { DevLogger } from "../../../utils/devLogger.ts";
+import { ThemeSaveState } from "../../types/themeSaveState.ts";
+import { jsonFromEscapedJsonString } from "../../utils/jsonFromEscapedJsonString.ts";
+import { useReceiveMessage, TARGET_ORIGINS } from "../useMessage.ts";
+import { useCommonMessageSenders } from "../useMessageSenders.ts";
+
+const devLogger = new DevLogger();
+
+export const useThemeMessageReceivers = () => {
+  const { iFrameLoaded } = useCommonMessageSenders();
+
+  // Trigger additional data flow from parent
+  useEffect(() => {
+    iFrameLoaded({ payload: { message: "Theme Editor is loaded" } });
+  }, []);
+
+  // Theme from Content
+  const [themeData, setThemeData] = useState<any>(); // json data
+  const [themeDataFetched, setThemeDataFetched] = useState<boolean>(false); // needed because themeData can be empty
+
+  // Theme from DB
+  const [themeSaveState, setThemeSaveState] = useState<
+    ThemeSaveState | undefined
+  >(undefined);
+  const [themeSaveStateFetched, setThemeSaveStateFetched] =
+    useState<boolean>(false); // needed because themeSaveState can be empty
+
+  useReceiveMessage("getThemeSaveState", TARGET_ORIGINS, (send, payload) => {
+    const themeSaveState = {
+      history: payload?.history
+        ? jsonFromEscapedJsonString(payload?.history)
+        : [],
+      index: payload?.index ?? 0,
+    };
+    devLogger.logData("THEME_SAVE_STATE", payload);
+    setThemeSaveState(themeSaveState);
+    setThemeSaveStateFetched(true);
+    send({
+      status: "success",
+      payload: { message: "themeSaveState received" },
+    });
+  });
+
+  useReceiveMessage("getThemeData", TARGET_ORIGINS, (send, payload) => {
+    const themeData = jsonFromEscapedJsonString(payload as unknown as string);
+    devLogger.logData("THEME_DATA", themeData);
+    setThemeData(themeData);
+    setThemeDataFetched(true);
+    send({
+      status: "success",
+      payload: { message: "getThemeData received" },
+    });
+  });
+
+  return {
+    themeData,
+    themeDataFetched,
+    themeSaveState,
+    themeSaveStateFetched,
+  };
+};

--- a/src/internal/hooks/useMessageReceivers.ts
+++ b/src/internal/hooks/useMessageReceivers.ts
@@ -2,15 +2,13 @@ import { useEffect, useState } from "react";
 import { TARGET_ORIGINS, useReceiveMessage } from "./useMessage.ts";
 import { TemplateMetadata } from "../types/templateMetadata.ts";
 import { DevLogger } from "../../utils/devLogger.ts";
-import { LayoutSaveState } from "../types/saveState.ts";
 import { Config } from "@measured/puck";
-import { ThemeSaveState } from "../types/themeSaveState.ts";
 import { jsonFromEscapedJsonString } from "../utils/jsonFromEscapedJsonString.ts";
 import { useCommonMessageSenders } from "./useMessageSenders.ts";
 
 const devLogger = new DevLogger();
 
-export const useMessageReceivers = (
+export const useCommonMessageReceivers = (
   componentRegistry: Map<string, Config<any>>
 ) => {
   const { iFrameLoaded } = useCommonMessageSenders();
@@ -28,22 +26,6 @@ export const useMessageReceivers = (
   const [visualConfigurationData, setVisualConfigurationData] = useState<any>(); // json data
   const [visualConfigurationDataFetched, setVisualConfigurationDataFetched] =
     useState<boolean>(false); // needed because visualConfigurationData can be empty
-
-  // Layout from DB
-  const [layoutSaveState, setLayoutSaveState] = useState<LayoutSaveState>();
-  const [layoutSaveStateFetched, setLayoutSaveStateFetched] =
-    useState<boolean>(false); // needed because saveState can be empty
-
-  // Theme from Content
-  const [themeData, setThemeData] = useState<any>(); // json data
-  const [themeDataFetched, setThemeDataFetched] = useState<boolean>(false); // needed because themeData can be empty
-
-  // Theme from DB
-  const [themeSaveState, setThemeSaveState] = useState<
-    ThemeSaveState | undefined
-  >(undefined);
-  const [themeSaveStateFetched, setThemeSaveStateFetched] =
-    useState<boolean>(false); // needed because themeSaveState can be empty
 
   useReceiveMessage("getTemplateMetadata", TARGET_ORIGINS, (send, payload) => {
     const puckConfig = componentRegistry.get(payload.templateId);
@@ -71,50 +53,10 @@ export const useMessageReceivers = (
     }
   );
 
-  useReceiveMessage("getSaveState", TARGET_ORIGINS, (send, payload) => {
-    devLogger.logData("SAVE_STATE", payload);
-    setLayoutSaveState(payload as LayoutSaveState);
-    setLayoutSaveStateFetched(true);
-    send({ status: "success", payload: { message: "saveState received" } });
-  });
-
-  useReceiveMessage("getThemeSaveState", TARGET_ORIGINS, (send, payload) => {
-    const themeSaveState = {
-      history: payload?.history
-        ? jsonFromEscapedJsonString(payload?.history)
-        : [],
-      index: payload?.index ?? 0,
-    };
-    devLogger.logData("THEME_SAVE_STATE", payload);
-    setThemeSaveState(themeSaveState);
-    setThemeSaveStateFetched(true);
-    send({
-      status: "success",
-      payload: { message: "themeSaveState received" },
-    });
-  });
-
-  useReceiveMessage("getThemeData", TARGET_ORIGINS, (send, payload) => {
-    const themeData = jsonFromEscapedJsonString(payload as unknown as string);
-    devLogger.logData("THEME_DATA", themeData);
-    setThemeData(themeData);
-    setThemeDataFetched(true);
-    send({
-      status: "success",
-      payload: { message: "getThemeData received" },
-    });
-  });
-
   return {
     visualConfigurationData,
     visualConfigurationDataFetched,
     templateMetadata,
     puckConfig,
-    themeData,
-    themeDataFetched,
-    layoutSaveState,
-    layoutSaveStateFetched,
-    themeSaveState,
-    themeSaveStateFetched,
   };
 };


### PR DESCRIPTION
- creates useCommonMessageReceivers, useLayoutMessageReceivers, useThemeMessageReceivers
- Editor.tsx now calls iFrameLoaded and receives puckConfig, templateMetadata, document, and visualConfigurationData
- Then, either LayoutEditor or ThemeEditor is loaded, iFrameLoaded is called again, and the subeditors receive layoutSaveState or themeData+themeSaveState 

Together with https://gerrit.yext.com/c/alpha/+/273121