### PR TITLE
fix: sidebar loses focus after user input

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -8811,7 +8811,7 @@ SOFTWARE.
 
 The following npm package may be included in this product:
 
- - json5@2.2.3
+ - json5@1.0.2
 
 This package contains the following license and notice below:
 

--- a/src/internal/components/ThemeEditor.tsx
+++ b/src/internal/components/ThemeEditor.tsx
@@ -147,13 +147,7 @@ export const ThemeEditor = (props: ThemeEditorProps) => {
       return;
     }
 
-    devLogger.log(
-      "No loadThemeInitialHistory case matched, setting to empty theme."
-    );
-    setThemeInitialHistory({
-      history: [{}],
-      index: 0,
-    });
+    devLogger.log("No loadThemeInitialHistory case matched.");
     setThemeInitialHistoryFetched(true);
   }, [
     setThemeInitialHistory,
@@ -235,8 +229,8 @@ export const ThemeEditor = (props: ThemeEditorProps) => {
       publishThemeConfiguration={publishThemeConfiguration}
       themeConfig={themeConfig}
       saveThemeSaveState={saveThemeSaveState}
-      themeHistory={themeInitialHistory}
-      setThemeHistory={setThemeInitialHistory}
+      themeInitialHistory={themeInitialHistory}
+      setThemeInitialHistory={setThemeInitialHistory}
       clearThemeHistory={clearHistory}
       sendDevThemeSaveStateData={sendDevThemeSaveStateData}
       buildThemeLocalStorageKey={buildThemeLocalStorageKey}

--- a/src/internal/puck/components/ColorSelector.tsx
+++ b/src/internal/puck/components/ColorSelector.tsx
@@ -1,57 +1,39 @@
-import React, { useState, useCallback } from "react";
-import { Field, FieldLabel } from "@measured/puck";
+import React, { useState } from "react";
+import { FieldLabel } from "@measured/puck";
 import { RenderProps } from "../../utils/renderEntityFields.ts";
 import { Color, ColorResult, SketchPicker } from "react-color";
 
-export type ColorSelectorProps = {
-  label: string;
-};
+export const ColorSelector = ({ field, value, onChange }: RenderProps) => {
+  const [isOpen, setIsOpen] = useState(false);
 
-export const ColorSelector = (props: ColorSelectorProps): Field => {
-  const colorSelectorRenderer = useCallback(
-    ({ field, value, onChange }: RenderProps) => {
-      const [isOpen, setIsOpen] = useState(false);
-
-      const fieldStyles = colorPickerStyles(value);
-      return (
-        <>
-          <FieldLabel
-            label={field.label || "Label is undefined"}
-            className="ve-mt-2.5"
-          >
-            <div
-              style={fieldStyles.swatch}
-              onClick={() => setIsOpen((current) => !current)}
-            >
-              <div style={fieldStyles.color} />
-            </div>
-            {isOpen && (
-              <div style={fieldStyles.popover}>
-                <div
-                  style={fieldStyles.cover}
-                  onClick={() => setIsOpen(false)}
-                />
-                <SketchPicker
-                  disableAlpha={true}
-                  color={value}
-                  onChange={(colorResult: ColorResult) => {
-                    onChange(colorResult.hex);
-                  }}
-                />
-              </div>
-            )}
-          </FieldLabel>
-        </>
-      );
-    },
-    []
+  const fieldStyles = colorPickerStyles(value);
+  return (
+    <>
+      <FieldLabel
+        label={field.label || "Label is undefined"}
+        className="ve-mt-2.5"
+      >
+        <div
+          style={fieldStyles.swatch}
+          onClick={() => setIsOpen((current) => !current)}
+        >
+          <div style={fieldStyles.color} />
+        </div>
+        {isOpen && (
+          <div style={fieldStyles.popover}>
+            <div style={fieldStyles.cover} onClick={() => setIsOpen(false)} />
+            <SketchPicker
+              disableAlpha={true}
+              color={value}
+              onChange={(colorResult: ColorResult) => {
+                onChange(colorResult.hex);
+              }}
+            />
+          </div>
+        )}
+      </FieldLabel>
+    </>
   );
-
-  return {
-    type: "custom",
-    label: props.label,
-    render: colorSelectorRenderer,
-  };
 };
 
 const colorPickerStyles = (color: Color) => {

--- a/src/internal/puck/components/ColorSelector.tsx
+++ b/src/internal/puck/components/ColorSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useCallback } from "react";
 import { Field, FieldLabel } from "@measured/puck";
 import { RenderProps } from "../../utils/renderEntityFields.ts";
 import { Color, ColorResult, SketchPicker } from "react-color";
@@ -8,10 +8,8 @@ export type ColorSelectorProps = {
 };
 
 export const ColorSelector = (props: ColorSelectorProps): Field => {
-  return {
-    type: "custom",
-    label: props.label,
-    render: ({ field, value, onChange }: RenderProps) => {
+  const colorSelectorRenderer = useCallback(
+    ({ field, value, onChange }: RenderProps) => {
       const [isOpen, setIsOpen] = useState(false);
 
       const fieldStyles = colorPickerStyles(value);
@@ -46,6 +44,13 @@ export const ColorSelector = (props: ColorSelectorProps): Field => {
         </>
       );
     },
+    []
+  );
+
+  return {
+    type: "custom",
+    label: props.label,
+    render: colorSelectorRenderer,
   };
 };
 

--- a/src/internal/puck/components/ThemeHeader.tsx
+++ b/src/internal/puck/components/ThemeHeader.tsx
@@ -12,7 +12,7 @@ import { ClearLocalChangesButton } from "../ui/ClearLocalChangesButton.tsx";
 type ThemeHeaderProps = {
   onPublishTheme: () => Promise<void>;
   isDevMode: boolean;
-  setThemeHistory: (themeHistory: ThemeSaveState) => void;
+  setThemeInitialHistory: (themeHistory: ThemeSaveState) => void;
   themeConfig?: ThemeConfig;
   themeHistory?: ThemeSaveState;
   clearThemeHistory: () => void;
@@ -21,7 +21,7 @@ type ThemeHeaderProps = {
 export const ThemeHeader = (props: ThemeHeaderProps) => {
   const {
     isDevMode,
-    setThemeHistory,
+    setThemeInitialHistory,
     onPublishTheme,
     themeConfig,
     themeHistory,
@@ -59,7 +59,7 @@ export const ThemeHeader = (props: ThemeHeaderProps) => {
             if (themeConfig) {
               updateThemeInEditor(themeHistory?.history[0], themeConfig);
             }
-            setThemeHistory({
+            setThemeInitialHistory({
               history: [themeHistory?.history[0]],
               index: 0,
             });
@@ -71,7 +71,7 @@ export const ThemeHeader = (props: ThemeHeaderProps) => {
             disabled={themeHistory?.history.length === 1}
             onClick={async () => {
               await onPublishTheme();
-              setThemeHistory({
+              setThemeInitialHistory({
                 history: [
                   themeHistory?.history[themeHistory?.history.length - 1],
                 ],

--- a/src/internal/puck/components/ThemeSidebar.tsx
+++ b/src/internal/puck/components/ThemeSidebar.tsx
@@ -6,16 +6,15 @@ import {
   constructThemePuckFields,
   constructThemePuckValues,
 } from "../../utils/constructThemePuckFields.ts";
-import { ThemeSaveState } from "../../types/themeSaveState.ts";
 
 type ThemeSidebarProps = {
   themeConfig?: ThemeConfig;
-  themeHistory: ThemeSaveState;
+  themeValues: Record<string, any>;
   onThemeChange: (parentStyleKey: string, value: Record<string, any>) => void;
 };
 
 const ThemeSidebar = (props: ThemeSidebarProps) => {
-  const { themeConfig, themeHistory, onThemeChange } = props;
+  const { themeConfig, themeValues, onThemeChange } = props;
   if (!themeConfig) {
     return (
       <div>
@@ -39,7 +38,7 @@ const ThemeSidebar = (props: ThemeSidebarProps) => {
       {Object.entries(themeConfig).map(([parentStyleKey, parentStyle]) => {
         const field = constructThemePuckFields(parentStyle);
         const values = constructThemePuckValues(
-          themeHistory.history[themeHistory.index],
+          themeValues,
           parentStyle,
           parentStyleKey
         );

--- a/src/internal/utils/constructThemePuckFields.ts
+++ b/src/internal/utils/constructThemePuckFields.ts
@@ -1,4 +1,9 @@
-import { ObjectField, SelectField, NumberField } from "@measured/puck";
+import {
+  ObjectField,
+  SelectField,
+  NumberField,
+  CustomField,
+} from "@measured/puck";
 import { ParentStyle, SavedTheme, Style } from "../../utils/themeResolver.ts";
 import { ColorSelector } from "../puck/components/ColorSelector.tsx";
 
@@ -36,7 +41,11 @@ export const convertStyleToPuckField = (style: Style) => {
         options: style.options,
       } as SelectField;
     case "color":
-      return ColorSelector({ label: style.label });
+      return {
+        label: style.label,
+        type: "custom",
+        render: ColorSelector,
+      } as CustomField;
   }
 };
 


### PR DESCRIPTION
The sidebar Puck override was re-mounting on every state change, effectively creating new fields each time and losing user state. This moves the themeHistory state lower in the hierarchy and maintains it separately from themeInitialHistory.

- number inputs now stay focused
- color inputs now stay open until you click outside them