### PR TITLE
refactor: switch <AutoFieldPrivate> to <AutoField> 

### DIFF
--- a/src/internal/puck/components/ThemeSidebar.tsx
+++ b/src/internal/puck/components/ThemeSidebar.tsx
@@ -1,4 +1,4 @@
-import { AutoFieldPrivate } from "@measured/puck";
+import { AutoField, FieldLabel } from "@measured/puck";
 import React from "react";
 import { Alert, AlertDescription } from "../../components/atoms/Alert.tsx";
 import { ThemeConfig } from "../../../utils/themeResolver.ts";
@@ -45,12 +45,17 @@ const ThemeSidebar = (props: ThemeSidebarProps) => {
         );
 
         return (
-          <AutoFieldPrivate
+          <FieldLabel
+            label={field.label ?? ""}
+            className="theme-field"
             key={parentStyleKey}
-            field={field}
-            onChange={(value) => onThemeChange(parentStyleKey, value)}
-            value={values}
-          />
+          >
+            <AutoField
+              field={field}
+              onChange={(value) => onThemeChange(parentStyleKey, value)}
+              value={values}
+            />
+          </FieldLabel>
         );
       })}
     </div>

--- a/src/internal/puck/ui/puck.css
+++ b/src/internal/puck/ui/puck.css
@@ -42,3 +42,17 @@
   height: 1rem;
   width: 1rem;
 }
+
+.theme-field {
+  padding: 16px 16px 0 16px;
+}
+
+.theme-field > fieldset {
+  padding: 16px 15px;
+}
+
+.theme-field fieldset > div,
+.theme-field fieldset > label {
+  padding: 0;
+  border: none !important;
+}


### PR DESCRIPTION
AutoFieldPrivate will be removed in a future version of Puck as it was never supposed to be exported.

![Screenshot 2024-10-21 at 5 30 34 PM](https://github.com/user-attachments/assets/3d6a3051-a420-4cf3-adf9-156cb51f5e72)
