### PR TITLE
fix: theme sidebar padding issue

### DIFF
--- a/src/internal/puck/components/ThemeSidebar.tsx
+++ b/src/internal/puck/components/ThemeSidebar.tsx
@@ -57,6 +57,7 @@ const ThemeSidebar = (props: ThemeSidebarProps) => {
             label={field.label ?? ""}
             className="theme-field"
             key={parentStyleKey}
+            el="div"
           >
             <AutoField
               field={field}


### PR DESCRIPTION
padding wasn't being applied because the field label wasn't a div