### PR TITLE
fix: preview doesn't update on layout switch

### DIFF
--- a/src/internal/components/ThemeEditor.tsx
+++ b/src/internal/components/ThemeEditor.tsx
@@ -194,12 +194,18 @@ export const ThemeEditor = (props: ThemeEditorProps) => {
   }, [themeHistories, themeConfig]);
 
   useEffect(() => {
+    console.log("This useEffect", themeSaveStateFetched, themeDataFetched);
     if (!themeSaveStateFetched || !themeDataFetched) {
       return;
     }
     loadPuckInitialHistory();
     loadThemeHistory();
-  }, [templateMetadata, themeSaveStateFetched, themeDataFetched]);
+  }, [
+    templateMetadata,
+    themeSaveStateFetched,
+    themeDataFetched,
+    visualConfigurationData,
+  ]);
 
   // Log PUCK_INITIAL_HISTORY (layout) on load
   useEffect(() => {

--- a/src/internal/components/ThemeEditor.tsx
+++ b/src/internal/components/ThemeEditor.tsx
@@ -194,7 +194,6 @@ export const ThemeEditor = (props: ThemeEditorProps) => {
   }, [themeHistories, themeConfig]);
 
   useEffect(() => {
-    console.log("This useEffect", themeSaveStateFetched, themeDataFetched);
     if (!themeSaveStateFetched || !themeDataFetched) {
       return;
     }


### PR DESCRIPTION
On layout switch, I think there was a race condition that if templateMetadata was sent faster than themeData, then loadPuckInitialHistory would run but still have the old data and so it wouldn't update the preview