### PR TITLE
fix: add label to ImageWrapperComponent

### DIFF
--- a/src/components/puck/Image.tsx
+++ b/src/components/puck/Image.tsx
@@ -116,6 +116,7 @@ const ImageWrapper: React.FC<ImageWrapperProps> = ({
 };
 
 export const ImageWrapperComponent: ComponentConfig<ImageWrapperProps> = {
+  label: "Image",
   fields: imageWrapperFields,
   defaultProps: {
     image: {


### PR DESCRIPTION
Verified that the label appears correctly and the component name shows up as "Image" instead of "ImageWrapperComponent"