### PR TITLE
wip: fix: published pages use the wrong layout

### DIFF
--- a/src/utils/resolveVisualEditorData.test.ts
+++ b/src/utils/resolveVisualEditorData.test.ts
@@ -32,10 +32,19 @@ test("resolveVisualEditorData returns value from entity visual configuration", a
           document: {
             visualConfigurations: [
               {
+                visualConfiguration: {
+                  pageSet: "location",
+                  data: {},
+                  siteId: "789",
+                },
+              },
+              {
                 pageSet: "location",
                 data: puckData,
+                siteId: "123456",
               },
             ],
+            siteId: 123456,
           },
         },
         "location"
@@ -51,11 +60,20 @@ test("resolveVisualEditorData returns value from pagesLayouts", async () => {
       resolveVisualEditorData(
         {
           document: {
+            siteId: 123456,
             pageLayouts: [
               {
                 visualConfiguration: {
                   pageSet: "location",
+                  data: {},
+                  siteId: "789",
+                },
+              },
+              {
+                visualConfiguration: {
+                  pageSet: "location",
                   data: puckData,
+                  siteId: "123456",
                 },
               },
             ],
@@ -74,12 +92,21 @@ test("resolveVisualEditorData returns value from _site defaultLayouts", async ()
       resolveVisualEditorData(
         {
           document: {
+            siteId: 123456,
             _site: {
               defaultLayouts: [
                 {
                   visualConfiguration: {
                     pageSet: "location",
+                    data: {},
+                    siteId: "789",
+                  },
+                },
+                {
+                  visualConfiguration: {
+                    pageSet: "location",
                     data: puckData,
+                    siteId: "123456",
                   },
                 },
               ],

--- a/src/utils/resolveVisualEditorData.ts
+++ b/src/utils/resolveVisualEditorData.ts
@@ -1,7 +1,7 @@
 type VisualConfiguration = {
   pageSet: string;
   data: string;
-  siteId: number;
+  siteId: string;
 };
 
 type PagesLayout = {
@@ -40,7 +40,10 @@ export function resolveVisualEditorData(
 
   // check base entity
   for (const entityConfiguration of entityConfigurations) {
-    if (entityConfiguration.pageSet === pageSet) {
+    if (
+      entityConfiguration.pageSet === pageSet &&
+      entityConfiguration.siteId === String(document.siteId)
+    ) {
       visualTemplate = JSON.parse(
         validateOrDefault(entityConfiguration.data, pageSet)
       );
@@ -51,7 +54,10 @@ export function resolveVisualEditorData(
   // check layouts referenced by the base entity
   if (!visualTemplate) {
     for (const entityLayout of entityLayoutConfigurations) {
-      if (entityLayout.visualConfiguration?.pageSet === pageSet) {
+      if (
+        entityLayout.visualConfiguration?.pageSet === pageSet &&
+        entityLayout.visualConfiguration?.siteId === String(document.siteId)
+      ) {
         visualTemplate = JSON.parse(
           validateOrDefault(entityLayout.visualConfiguration.data, pageSet)
         );
@@ -63,7 +69,10 @@ export function resolveVisualEditorData(
   // check layouts referenced by the site entity
   if (!visualTemplate && siteLayoutConfigurations) {
     for (const siteLayout of siteLayoutConfigurations) {
-      if (siteLayout.visualConfiguration?.pageSet === pageSet) {
+      if (
+        siteLayout.visualConfiguration?.pageSet === pageSet &&
+        siteLayout.visualConfiguration?.siteId === String(document.siteId)
+      ) {
         visualTemplate = JSON.parse(
           validateOrDefault(siteLayout.visualConfiguration.data, pageSet)
         );


### PR DESCRIPTION
We weren't checking the site id on the layout so it would pick the first one regardless of site id.

This fixes production sites. However, it breaks dev mode because the dev mode document has siteId: 0. Not really sure how to handle this case because defaulting to the first layout doesn't really make sense.