### PR TITLE
fix: formatting of entity fields when used in devMode 

### DIFF
--- a/src/hooks/useEntityFields.tsx
+++ b/src/hooks/useEntityFields.tsx
@@ -44,7 +44,9 @@ const assignDefinitions = (entityFields: any): YextSchemaField[] => {
         typeRegistryId: field.typeRegistryId,
         isList: field.isList,
       },
-      children: field.children ?? [],
+      children: field.children
+        ? { fields: assignDefinitions(field.children) }
+        : {},
     };
   });
 };


### PR DESCRIPTION
Fixes the problem where the schemaFields in devMode were not formatted correctly and thus not always showing up as options in the EntityFieldSelector