### PR TITLE
feat: update getFilteredEntityFields to return lists

### DIFF
--- a/src/internal/utils/getFilteredEntityFields.ts
+++ b/src/internal/utils/getFilteredEntityFields.ts
@@ -29,6 +29,7 @@ type DisallowList<T extends Record<string, any>> = {
 
 type EntityFieldTypesFilter = {
   types: EntityFieldTypes[];
+  includeListsOnly?: boolean;
 };
 export type RenderEntityFieldFilter<T extends Record<string, any>> =
   EntityFieldTypesFilter & EitherOrNeither<AllowList<T>, DisallowList<T>>;
@@ -84,7 +85,7 @@ const walkSubfields = (
   }
 
   if (schemaField.definition.isList) {
-    return []; // skip all children of list types
+    return [{ name: fieldNameInternal, schemaField: schemaField }]; // skip all children of list types
   }
 
   const fieldNames: EntityFieldNameAndSchema[] = [
@@ -195,6 +196,10 @@ export const getFilteredEntityFields = <T extends Record<string, any>>(
     });
     filteredEntitySubFields = updatedFilteredEntitySubFields;
   }
+
+  filteredEntitySubFields = filteredEntitySubFields.filter(
+    (field) => !!field.definition.isList === !!filter?.includeListsOnly
+  );
 
   return filteredEntitySubFields;
 };


### PR DESCRIPTION
This updates `getFilteredEntityFields` to accept a new `includeListsOnly` field in the filter. When this field is not provided or set to `false`, the behavior is the same as before, and list fields are filtered out. If it is set to `true`, then list fields are returned and non-list fields are filtered out.