### PR TITLE
fix: entity field tooltips mess up css layout

### DIFF
--- a/src/components/editor/EntityField.tsx
+++ b/src/components/editor/EntityField.tsx
@@ -30,18 +30,16 @@ export const EntityField = ({
     tooltipContent = `${displayName}`;
   }
 
+  if (!tooltipsVisible) {
+    return children;
+  }
+
   return (
     <div>
       <TooltipProvider>
-        <Tooltip open={tooltipsVisible && !!tooltipContent}>
+        <Tooltip open={!!tooltipContent}>
           <TooltipTrigger asChild>
-            <div
-              className={
-                tooltipsVisible
-                  ? "ve-outline-2 ve-outline-dotted" + " ve-outline-[#5A58F2]"
-                  : ""
-              }
-            >
+            <div className="ve-outline-2 ve-outline-dotted ve-outline-[#5A58F2]">
               {children}
             </div>
           </TooltipTrigger>


### PR DESCRIPTION
Even when the Entity Field tooltips were closed, they were adding extra divs to the page. These could get in the way of styling, such as this set of buttons that were supposed to be `width: 100%, flexWrap: "wrap"`

Before:
![Screenshot 2024-10-28 at 4 44 59 PM](https://github.com/user-attachments/assets/027a19b2-217b-4527-834d-980cdba04fa8)
After:
![Screenshot 2024-10-28 at 4 46 25 PM](https://github.com/user-attachments/assets/36f1ccbf-62ad-46ea-8acb-25544fb9901a)
