### PR TITLE
refactor: type layout data

### DIFF
--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -109,14 +109,14 @@ export const Editor = ({
           <ThemeEditor
             puckConfig={puckConfig}
             templateMetadata={templateMetadata}
-            visualConfigurationData={visualConfigurationData}
+            visualConfigurationData={visualConfigurationData!}
             themeConfig={themeConfig}
           />
         ) : (
           <LayoutEditor
             puckConfig={puckConfig}
             templateMetadata={templateMetadata}
-            visualConfigurationData={visualConfigurationData}
+            visualConfigurationData={visualConfigurationData!}
           />
         )
       ) : (

--- a/src/internal/components/InternalLayoutEditor.tsx
+++ b/src/internal/components/InternalLayoutEditor.tsx
@@ -4,6 +4,7 @@ import {
   Config,
   type History,
   InitialHistory,
+  AppState,
 } from "@measured/puck";
 import React from "react";
 import { useState, useRef, useCallback } from "react";
@@ -49,7 +50,7 @@ export const InternalLayoutEditor = ({
    * to the parent which saves the state to the VES database.
    */
   const handleHistoryChange = useCallback(
-    (histories: History[], index: number) => {
+    (histories: History<Partial<AppState>>[], index: number) => {
       if (
         index !== 0 &&
         historyIndex.current !== index &&

--- a/src/internal/components/LayoutEditor.tsx
+++ b/src/internal/components/LayoutEditor.tsx
@@ -1,10 +1,9 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { InternalLayoutEditor } from "./InternalLayoutEditor.tsx";
-import { InitialHistory, Config } from "@measured/puck";
+import { InitialHistory, Config, Data } from "@measured/puck";
 import { TemplateMetadata } from "../types/templateMetadata.ts";
 import { useLayoutLocalStorage } from "../hooks/layout/useLocalStorage.ts";
 import { DevLogger } from "../../utils/devLogger.ts";
-import { jsonFromEscapedJsonString } from "../utils/jsonFromEscapedJsonString.ts";
 import { useLayoutMessageSenders } from "../hooks/layout/useMessageSenders.ts";
 import { useLayoutMessageReceivers } from "../hooks/layout/useMessageReceivers.ts";
 import { LoadingScreen } from "../puck/components/LoadingScreen.tsx";
@@ -14,7 +13,7 @@ const devLogger = new DevLogger();
 type LayoutEditorProps = {
   puckConfig: Config;
   templateMetadata: TemplateMetadata;
-  visualConfigurationData: any;
+  visualConfigurationData: Data;
 };
 
 export const LayoutEditor = (props: LayoutEditorProps) => {
@@ -75,9 +74,10 @@ export const LayoutEditor = (props: LayoutEditorProps) => {
       // Use localStorage directly if it exists
       if (localHistoryArray) {
         devLogger.log("Layout Dev Mode - Using layout data from localStorage");
-        const localHistories = JSON.parse(localHistoryArray);
+        const localHistories = JSON.parse(localHistoryArray) as History[];
         const localHistoryIndex = localHistories.length - 1;
         setPuckInitialHistory({
+          // @ts-expect-error https://github.com/measuredco/puck/issues/673
           histories: localHistories,
           index: localHistoryIndex,
           appendData: false,
@@ -135,13 +135,13 @@ export const LayoutEditor = (props: LayoutEditorProps) => {
               { id: "root", state: { data: visualConfigurationData } },
               {
                 id: layoutSaveState.hash,
-                state: jsonFromEscapedJsonString(layoutSaveState.history),
+                state: { data: layoutSaveState.history.data },
               },
             ]
           : [
               {
                 id: layoutSaveState.hash,
-                state: jsonFromEscapedJsonString(layoutSaveState.history),
+                state: { data: layoutSaveState.history.data },
               },
             ],
         index: visualConfigurationData ? 1 : 0,

--- a/src/internal/components/ThemeEditor.tsx
+++ b/src/internal/components/ThemeEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { InitialHistory, Config } from "@measured/puck";
+import { InitialHistory, Config, Data } from "@measured/puck";
 import { TemplateMetadata } from "../types/templateMetadata.ts";
 import { useThemeLocalStorage } from "../hooks/theme/useLocalStorage.ts";
 import { DevLogger } from "../../utils/devLogger.ts";
@@ -9,14 +9,14 @@ import { InternalThemeEditor } from "./InternalThemeEditor.tsx";
 import { useThemeMessageSenders } from "../hooks/theme/useMessageSenders.ts";
 import { useThemeMessageReceivers } from "../hooks/theme/useMessageReceivers.ts";
 import { LoadingScreen } from "../puck/components/LoadingScreen.tsx";
-import { ThemeHistories } from "../types/themeData.ts";
+import { ThemeHistories, ThemeHistory } from "../types/themeData.ts";
 
 const devLogger = new DevLogger();
 
 type ThemeEditorProps = {
   puckConfig: Config;
   templateMetadata: TemplateMetadata;
-  visualConfigurationData: any;
+  visualConfigurationData: Data;
   themeConfig: ThemeConfig | undefined;
 };
 
@@ -95,7 +95,7 @@ export const ThemeEditor = (props: ThemeEditorProps) => {
       // Use localStorage directly if it exists
       if (localHistoryArray) {
         devLogger.log("Theme Dev Mode - Using theme localStorage");
-        const localHistories = JSON.parse(localHistoryArray);
+        const localHistories = JSON.parse(localHistoryArray) as ThemeHistory[];
         const localHistoryIndex = localHistories.length - 1;
         setThemeHistories({
           histories: localHistories,

--- a/src/internal/hooks/layout/useMessageReceivers.ts
+++ b/src/internal/hooks/layout/useMessageReceivers.ts
@@ -3,6 +3,7 @@ import { DevLogger } from "../../../utils/devLogger.ts";
 import { LayoutSaveState } from "../../types/saveState.ts";
 import { useReceiveMessage, TARGET_ORIGINS } from "../useMessage.ts";
 import { useCommonMessageSenders } from "../useMessageSenders.ts";
+import { jsonFromEscapedJsonString } from "../../utils/jsonFromEscapedJsonString.ts";
 
 const devLogger = new DevLogger();
 
@@ -20,8 +21,15 @@ export const useLayoutMessageReceivers = () => {
     useState<boolean>(false); // needed because saveState can be empty
 
   useReceiveMessage("getSaveState", TARGET_ORIGINS, (send, payload) => {
-    devLogger.logData("SAVE_STATE", payload);
-    setLayoutSaveState(payload as LayoutSaveState);
+    let layoutSaveState;
+    if (payload) {
+      layoutSaveState = {
+        ...payload,
+        history: jsonFromEscapedJsonString(payload.history),
+      } as LayoutSaveState;
+    }
+    devLogger.logData("SAVE_STATE", layoutSaveState);
+    setLayoutSaveState(layoutSaveState);
     setLayoutSaveStateFetched(true);
     send({ status: "success", payload: { message: "saveState received" } });
   });

--- a/src/internal/hooks/theme/useMessageReceivers.ts
+++ b/src/internal/hooks/theme/useMessageReceivers.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { DevLogger } from "../../../utils/devLogger.ts";
-import { ThemeSaveState } from "../../types/themeData.ts";
+import { ThemeData, ThemeSaveState } from "../../types/themeData.ts";
 import { jsonFromEscapedJsonString } from "../../utils/jsonFromEscapedJsonString.ts";
 import { useReceiveMessage, TARGET_ORIGINS } from "../useMessage.ts";
 import { useCommonMessageSenders } from "../useMessageSenders.ts";
@@ -16,7 +16,7 @@ export const useThemeMessageReceivers = () => {
   }, []);
 
   // Theme from Content
-  const [themeData, setThemeData] = useState<any>(); // json data
+  const [themeData, setThemeData] = useState<ThemeData>();
   const [themeDataFetched, setThemeDataFetched] = useState<boolean>(false); // needed because themeData can be empty
 
   // Theme from DB
@@ -39,7 +39,7 @@ export const useThemeMessageReceivers = () => {
   useReceiveMessage("getThemeData", TARGET_ORIGINS, (send, payload) => {
     const themeData = jsonFromEscapedJsonString(payload as unknown as string);
     devLogger.logData("THEME_DATA", themeData);
-    setThemeData(themeData);
+    setThemeData(themeData as ThemeData);
     setThemeDataFetched(true);
     send({
       status: "success",

--- a/src/internal/hooks/useMessageReceivers.ts
+++ b/src/internal/hooks/useMessageReceivers.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { TARGET_ORIGINS, useReceiveMessage } from "./useMessage.ts";
 import { TemplateMetadata } from "../types/templateMetadata.ts";
 import { DevLogger } from "../../utils/devLogger.ts";
-import { Config } from "@measured/puck";
+import { Config, Data } from "@measured/puck";
 import { jsonFromEscapedJsonString } from "../utils/jsonFromEscapedJsonString.ts";
 import { useCommonMessageSenders } from "./useMessageSenders.ts";
 
@@ -23,7 +23,8 @@ export const useCommonMessageReceivers = (
   const [puckConfig, setPuckConfig] = useState<Config>();
 
   // Layout from Content
-  const [visualConfigurationData, setVisualConfigurationData] = useState<any>(); // json data
+  const [visualConfigurationData, setVisualConfigurationData] =
+    useState<Data>(); // json data
   const [visualConfigurationDataFetched, setVisualConfigurationDataFetched] =
     useState<boolean>(false); // needed because visualConfigurationData can be empty
 
@@ -42,7 +43,9 @@ export const useCommonMessageReceivers = (
     "getVisualConfigurationData",
     TARGET_ORIGINS,
     (send, payload) => {
-      const vcd = jsonFromEscapedJsonString(payload.visualConfigurationData);
+      const vcd = jsonFromEscapedJsonString(
+        payload.visualConfigurationData
+      ) as Data;
       devLogger.logData("VISUAL_CONFIGURATION_DATA", vcd);
       setVisualConfigurationData(vcd);
       setVisualConfigurationDataFetched(true);

--- a/src/internal/hooks/useMessageReceivers.ts
+++ b/src/internal/hooks/useMessageReceivers.ts
@@ -24,7 +24,7 @@ export const useCommonMessageReceivers = (
 
   // Layout from Content
   const [visualConfigurationData, setVisualConfigurationData] =
-    useState<Data>(); // json data
+    useState<Data>();
   const [visualConfigurationDataFetched, setVisualConfigurationDataFetched] =
     useState<boolean>(false); // needed because visualConfigurationData can be empty
 

--- a/src/internal/puck/components/LayoutHeader.tsx
+++ b/src/internal/puck/components/LayoutHeader.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Data, usePuck, type History } from "@measured/puck";
+import { AppState, Data, usePuck, type History } from "@measured/puck";
 import { RotateCcw, RotateCw } from "lucide-react";
 import { useEffect } from "react";
 import { Button } from "../ui/button.tsx";
@@ -31,7 +31,12 @@ export const LayoutHeader = (props: LayoutHeaderProps) => {
       hasFuture,
       setHistories,
     },
-  } = usePuck();
+  } = usePuck() as {
+    appState: ReturnType<typeof usePuck>["appState"];
+    history: Omit<ReturnType<typeof usePuck>["history"], "histories"> & {
+      histories: History<Partial<AppState>>[];
+    };
+  };
 
   useEffect(() => {
     onHistoryChange(histories, index);

--- a/src/internal/types/saveState.ts
+++ b/src/internal/types/saveState.ts
@@ -1,4 +1,6 @@
+import { AppState } from "@measured/puck";
+
 export type LayoutSaveState = {
-  history: any; // json object
+  history: AppState;
   hash: string;
 };


### PR DESCRIPTION
This adds types to the layout data so it's much easier to work with. Additionally, convert the types as soon as they are received in the messageReceivers instead of doing it in multiple places downstream.