### PR TITLE
refactor: new theme.config format

### DIFF
--- a/src/internal/components/InternalThemeEditor.tsx
+++ b/src/internal/components/InternalThemeEditor.tsx
@@ -5,7 +5,7 @@ import { TemplateMetadata } from "../types/templateMetadata.ts";
 import { EntityFieldProvider } from "../../components/editor/EntityField.tsx";
 import { DevLogger } from "../../utils/devLogger.ts";
 import ThemeSidebar from "../puck/components/ThemeSidebar.tsx";
-import { ThemeConfig } from "../../utils/themeResolver.ts";
+import { ThemeConfig, ThemeConfigSection } from "../../utils/themeResolver.ts";
 import { ThemeHeader } from "../puck/components/ThemeHeader.tsx";
 import { generateCssVariablesFromPuckFields } from "../utils/internalThemeResolver.ts";
 import { updateThemeInEditor } from "../../utils/applyTheme.ts";
@@ -73,7 +73,11 @@ export const InternalThemeEditor = ({
     });
   };
 
-  const handleThemeChange = (topLevelKey: string, newValue: any) => {
+  const handleThemeChange = (
+    themeSectionKey: string,
+    themeSection: ThemeConfigSection,
+    newValue: Record<string, any>
+  ) => {
     if (!themeHistoriesRef.current || !themeConfig) {
       return;
     }
@@ -81,7 +85,11 @@ export const InternalThemeEditor = ({
     const newThemeValues = {
       ...themeHistoriesRef.current.histories[themeHistoriesRef.current.index]
         ?.data,
-      ...generateCssVariablesFromPuckFields(newValue, topLevelKey),
+      ...generateCssVariablesFromPuckFields(
+        newValue,
+        themeSectionKey,
+        themeSection
+      ),
     };
 
     const newHistory = {

--- a/src/internal/components/ThemeEditor.tsx
+++ b/src/internal/components/ThemeEditor.tsx
@@ -3,13 +3,13 @@ import { InitialHistory, Config, Data } from "@measured/puck";
 import { TemplateMetadata } from "../types/templateMetadata.ts";
 import { useThemeLocalStorage } from "../hooks/theme/useLocalStorage.ts";
 import { DevLogger } from "../../utils/devLogger.ts";
-import { SavedTheme, ThemeConfig } from "../../utils/themeResolver.ts";
+import { ThemeConfig } from "../../utils/themeResolver.ts";
 import { updateThemeInEditor } from "../../utils/applyTheme.ts";
 import { InternalThemeEditor } from "./InternalThemeEditor.tsx";
 import { useThemeMessageSenders } from "../hooks/theme/useMessageSenders.ts";
 import { useThemeMessageReceivers } from "../hooks/theme/useMessageReceivers.ts";
 import { LoadingScreen } from "../puck/components/LoadingScreen.tsx";
-import { ThemeHistories, ThemeHistory } from "../types/themeData.ts";
+import { ThemeHistories, ThemeHistory, ThemeData } from "../types/themeData.ts";
 
 const devLogger = new DevLogger();
 
@@ -187,7 +187,7 @@ export const ThemeEditor = (props: ThemeEditorProps) => {
     devLogger.logData("THEME_HISTORIES", themeHistories);
     if (themeHistories && themeConfig) {
       updateThemeInEditor(
-        themeHistories.histories[themeHistories.index]?.data as SavedTheme,
+        themeHistories.histories[themeHistories.index]?.data as ThemeData,
         themeConfig
       );
     }

--- a/src/internal/puck/components/ThemeHeader.tsx
+++ b/src/internal/puck/components/ThemeHeader.tsx
@@ -2,13 +2,13 @@ import "../ui/puck.css";
 import React, { useEffect } from "react";
 import { Button } from "../ui/button.tsx";
 import "../../../components/editor/index.css";
-import { SavedTheme, ThemeConfig } from "../../../utils/themeResolver.ts";
+import { ThemeConfig } from "../../../utils/themeResolver.ts";
 import { updateThemeInEditor } from "../../../utils/applyTheme.ts";
 import { EntityFieldsToggle } from "../ui/EntityFieldsToggle.tsx";
 import { UIButtonsToggle } from "../ui/UIButtonsToggle.tsx";
 import { ClearLocalChangesButton } from "../ui/ClearLocalChangesButton.tsx";
 import { InitialHistory, usePuck } from "@measured/puck";
-import { ThemeHistories } from "../../types/themeData.ts";
+import { ThemeData, ThemeHistories } from "../../types/themeData.ts";
 
 type ThemeHeaderProps = {
   onPublishTheme: () => Promise<void>;
@@ -69,7 +69,7 @@ export const ThemeHeader = (props: ThemeHeaderProps) => {
             clearThemeHistory();
             if (themeConfig) {
               updateThemeInEditor(
-                themeHistories?.histories?.[0]?.data as SavedTheme,
+                themeHistories?.histories?.[0]?.data as ThemeData,
                 themeConfig
               );
             }

--- a/src/internal/puck/components/ThemeSidebar.tsx
+++ b/src/internal/puck/components/ThemeSidebar.tsx
@@ -1,7 +1,10 @@
 import { AutoField, FieldLabel } from "@measured/puck";
 import React from "react";
 import { Alert, AlertDescription } from "../../components/atoms/Alert.tsx";
-import { ThemeConfig } from "../../../utils/themeResolver.ts";
+import {
+  ThemeConfig,
+  ThemeConfigSection,
+} from "../../../utils/themeResolver.ts";
 import {
   constructThemePuckFields,
   constructThemePuckValues,
@@ -11,7 +14,11 @@ import { ThemeHistories } from "../../types/themeData.ts";
 type ThemeSidebarProps = {
   themeHistoriesRef: React.MutableRefObject<ThemeHistories | undefined>;
   themeConfig?: ThemeConfig;
-  onThemeChange: (parentStyleKey: string, value: Record<string, any>) => void;
+  onThemeChange: (
+    themeSectionKey: string,
+    themeSection: ThemeConfigSection,
+    value: Record<string, any>
+  ) => void;
 };
 
 const ThemeSidebar = (props: ThemeSidebarProps) => {
@@ -44,24 +51,26 @@ const ThemeSidebar = (props: ThemeSidebarProps) => {
           entire site.
         </AlertDescription>
       </Alert>
-      {Object.entries(themeConfig).map(([parentStyleKey, parentStyle]) => {
-        const field = constructThemePuckFields(parentStyle);
+      {Object.entries(themeConfig).map(([themeSectionKey, themeSection]) => {
+        const field = constructThemePuckFields(themeSection);
         const values = constructThemePuckValues(
           themeData,
-          parentStyle,
-          parentStyleKey
+          themeSection,
+          themeSectionKey
         );
 
         return (
           <FieldLabel
             label={field.label ?? ""}
             className="theme-field"
-            key={parentStyleKey}
+            key={themeSectionKey}
             el="div"
           >
             <AutoField
               field={field}
-              onChange={(value) => onThemeChange(parentStyleKey, value)}
+              onChange={(value) =>
+                onThemeChange(themeSectionKey, themeSection, value)
+              }
               value={values}
             />
           </FieldLabel>

--- a/src/internal/utils/constructThemePuckFields.test.ts
+++ b/src/internal/utils/constructThemePuckFields.test.ts
@@ -1,6 +1,7 @@
-import { Style, ThemeConfig } from "../../utils/themeResolver.ts";
+import { CoreStyle, Style, ThemeConfig } from "../../utils/themeResolver.ts";
 import { describe, it, expect } from "vitest";
 import {
+  assignValue,
   constructThemePuckFields,
   constructThemePuckValues,
   convertStyleToPuckField,
@@ -10,82 +11,70 @@ export const exampleThemeConfig: ThemeConfig = {
   text: {
     label: "Text",
     styles: {
-      font: {
-        label: "Font",
-        styles: {
-          size: {
-            label: "Font Size",
-            type: "number",
-            default: 12,
-            plugin: "fontSize",
-          },
-          family: {
-            label: "Font Family",
-            plugin: "fontFamily",
-            default: "helvetica",
-            type: "select",
-            options: [
-              {
-                label: "Helvetica",
-                value: "helvetica",
-              },
-              {
-                label: "Times New Roman",
-                value: "timesNewRoman",
-              },
-              {
-                label: "Arial",
-                value: "arial",
-              },
-            ],
-          },
-        },
+      size: {
+        label: "Size",
+        plugin: "fontSize",
+        type: "number",
+        default: 12,
       },
-      color: {
-        label: "Color",
-        styles: {
-          lightMode: {
-            label: "Light Mode",
-            styles: {
-              mainColor: {
-                label: "Main Color",
-                plugin: "fontColor",
-                type: "color",
-                default: "black",
-              },
-              secondaryColor: {
-                label: "Secondary Color",
-                plugin: "fontColor",
-                type: "color",
-                default: "grey",
-              },
-            },
+      family: {
+        label: "Font Family",
+        plugin: "fontFamily",
+        default: "helvetica",
+        type: "select",
+        options: [
+          {
+            label: "Helvetica",
+            value: "helvetica",
           },
-          darkMode: {
-            label: "Dark Mode",
-            styles: {
-              mainColor: {
-                label: "Main Color",
-                plugin: "fontColor",
-                type: "color",
-                default: "black",
-              },
-              secondaryColor: {
-                label: "Secondary Color",
-                plugin: "fontColor",
-                type: "color",
-                default: "grey",
-              },
-            },
+          {
+            label: "Times New Roman",
+            value: "timesNewRoman",
           },
-        },
+          {
+            label: "Arial",
+            value: "arial",
+          },
+        ],
       },
     },
   },
-  heading: {
-    label: "Headings",
+  color: {
+    label: "Color",
     styles: {
-      color: {
+      lightMode: {
+        label: "Light Mode",
+        plugin: "colors",
+        styles: {
+          mainColor: {
+            label: "Main Color",
+            type: "color",
+            default: "black",
+          },
+          secondaryColor: {
+            label: "Secondary Color",
+            type: "color",
+            default: "grey",
+          },
+        },
+      },
+      darkMode: {
+        label: "Dark Mode",
+        plugin: "colors",
+        styles: {
+          mainColor: {
+            label: "Main Color",
+            type: "color",
+            default: "black",
+          },
+          secondaryColor: {
+            label: "Secondary Color",
+            type: "color",
+            default: "grey",
+          },
+        },
+      },
+      heading: {
         label: "Heading Color",
         type: "color",
         plugin: "colors",
@@ -103,58 +92,13 @@ describe("constructThemePuckFields", () => {
       label: "Text",
       type: "object",
       objectFields: {
-        font: {
-          label: "Font",
-          type: "object",
-          objectFields: {
-            size: {
-              label: "Font Size",
-              type: "number",
-            },
-            family: {
-              label: "Font Family",
-              type: "select",
-              options: [
-                { label: "Helvetica", value: "helvetica" },
-                { label: "Times New Roman", value: "timesNewRoman" },
-                { label: "Arial", value: "arial" },
-              ],
-            },
-          },
+        size: {
+          label: "Size",
+          type: "number",
         },
-        color: {
-          label: "Color",
-          type: "object",
-          objectFields: {
-            lightMode: {
-              label: "Light Mode",
-              type: "object",
-              objectFields: {
-                mainColor: {
-                  label: "Main Color",
-                  type: "custom",
-                },
-                secondaryColor: {
-                  label: "Secondary Color",
-                  type: "custom",
-                },
-              },
-            },
-            darkMode: {
-              label: "Dark Mode",
-              type: "object",
-              objectFields: {
-                mainColor: {
-                  label: "Main Color",
-                  type: "custom",
-                },
-                secondaryColor: {
-                  label: "Secondary Color",
-                  type: "custom",
-                },
-              },
-            },
-          },
+        family: {
+          label: "Font Family",
+          type: "select",
         },
       },
     });
@@ -216,38 +160,97 @@ describe("convertStyleToPuckField", () => {
   });
 });
 
+describe("assignValue", () => {
+  it("returns the default value when there is no stored value", () => {
+    const style: CoreStyle = {
+      label: "Style",
+      type: "number",
+      default: 10,
+    };
+
+    const result = assignValue(style, undefined);
+    expect(result).toEqual(10);
+  });
+
+  it("returns the stored value for color fields", () => {
+    const storedValue = "#FFFFFF";
+    const style: CoreStyle = {
+      label: "Style",
+      type: "color",
+      default: "#000000",
+    };
+
+    const result = assignValue(style, storedValue);
+    expect(result).toEqual("#FFFFFF");
+  });
+
+  it("returns the stored value for select fields", () => {
+    const storedValue = "a";
+    const style: CoreStyle = {
+      label: "Style",
+      type: "select",
+      default: "b",
+      options: [
+        { label: "A", value: "a" },
+        { label: "B", value: "b" },
+      ],
+    };
+
+    const result = assignValue(style, storedValue);
+    expect(result).toEqual("a");
+  });
+
+  it("returns the stored value for number fields", () => {
+    const storedValue = "10px";
+    const style: CoreStyle = {
+      label: "Style",
+      type: "number",
+      default: 0,
+    };
+
+    const result = assignValue(style, storedValue);
+    expect(result).toEqual(10);
+  });
+
+  it("returns the default value for corrupted number fields", () => {
+    const storedValue = "abcdef";
+    const style: CoreStyle = {
+      label: "Style",
+      type: "number",
+      default: 5,
+    };
+
+    const result = assignValue(style, storedValue);
+    expect(result).toEqual(5);
+  });
+});
+
 describe("constructThemePuckValues", () => {
   it("constructs theme puck values using saved theme values", () => {
     const savedThemeValues = {
-      "--text-font-size": "16px",
-      "--text-font-family": "arial",
-      "--text-color-lightMode-mainColor": "blue",
-      "--text-color-lightMode-secondaryColor": "lightgrey",
-      "--text-color-darkMode-mainColor": "black",
-      "--text-color-darkMode-secondaryColor": "grey",
+      "--colors-color-lightMode-mainColor": "green",
+      "--colors-color-lightMode-secondaryColor": "orange",
+      "--colors-color-darkMode-mainColor": "blue",
+      "--colors-color-darkMode-secondaryColor": "purple",
+      "--colors-color-heading": "red",
     };
 
     const result = constructThemePuckValues(
       savedThemeValues,
-      exampleThemeConfig.text,
-      "text"
+      exampleThemeConfig.color,
+      "color"
     );
 
     expect(result).toEqual({
-      font: {
-        size: 16, // from saved values
-        family: "arial", // from saved values
+      lightMode: {
+        mainColor: "green",
+        secondaryColor: "orange",
       },
-      color: {
-        lightMode: {
-          mainColor: "blue", // from saved values
-          secondaryColor: "lightgrey", // from saved values
-        },
-        darkMode: {
-          mainColor: "black", // default value
-          secondaryColor: "grey", // default value
-        },
+      darkMode: {
+        mainColor: "blue",
+        secondaryColor: "purple",
       },
+      heading: "red",
     });
   });
 
@@ -256,55 +259,46 @@ describe("constructThemePuckValues", () => {
 
     const result = constructThemePuckValues(
       savedThemeValues,
-      exampleThemeConfig.text,
-      "text"
+      exampleThemeConfig.color,
+      "color"
     );
 
     expect(result).toEqual({
-      font: {
-        size: 12, // default value
-        family: "helvetica", // default value
+      lightMode: {
+        mainColor: "black",
+        secondaryColor: "grey",
       },
-      color: {
-        lightMode: {
-          mainColor: "black", // default value
-          secondaryColor: "grey", // default value
-        },
-        darkMode: {
-          mainColor: "black", // default value
-          secondaryColor: "grey", // default value
-        },
+      darkMode: {
+        mainColor: "black",
+        secondaryColor: "grey",
       },
+      heading: "#FF0000",
     });
   });
 
   it("handles a mix of saved and default theme values", () => {
     const savedThemeValues = {
-      "--text-font-size": "14px",
-      "--text-color-lightMode-mainColor": "red",
+      "--colors-color-lightMode-mainColor": "green",
+      "--colors-color-lightMode-secondaryColor": "orange",
+      "--colors-color-heading": "red",
     };
 
     const result = constructThemePuckValues(
       savedThemeValues,
-      exampleThemeConfig.text,
-      "text"
+      exampleThemeConfig.color,
+      "color"
     );
 
     expect(result).toEqual({
-      font: {
-        size: 14, // from saved values
-        family: "helvetica", // default value
+      lightMode: {
+        mainColor: "green",
+        secondaryColor: "orange",
       },
-      color: {
-        lightMode: {
-          mainColor: "red", // from saved values
-          secondaryColor: "grey", // default value
-        },
-        darkMode: {
-          mainColor: "black", // default value
-          secondaryColor: "grey", // default value
-        },
+      darkMode: {
+        mainColor: "black",
+        secondaryColor: "grey",
       },
+      heading: "red",
     });
   });
 });

--- a/src/internal/utils/internalThemeResolver.test.ts
+++ b/src/internal/utils/internalThemeResolver.test.ts
@@ -18,7 +18,7 @@ describe("internalThemeResolver", () => {
   });
 });
 
-describe("generateCssVariables", () => {
+describe("generateCssVariablesFromThemeConfig", () => {
   test("generates css variables with default values", () => {
     const result = generateCssVariablesFromThemeConfig(testThemeConfig);
     expect(result).toEqual(defaultThemeValues);
@@ -29,105 +29,150 @@ describe("generateCssVariablesFromPuckFields", () => {
   test("generates css variables from Puck field", () => {
     const result = generateCssVariablesFromPuckFields(
       { primary: "green" },
-      "colors"
+      "palette",
+      {
+        label: "Palette",
+        styles: {
+          primary: {
+            label: "Primary",
+            type: "color",
+            default: "black",
+            plugin: "colors",
+          },
+        },
+      }
     );
-    expect(result).toEqual({ "--colors-primary": "green" });
-  });
-
-  test("merges css variables", () => {
-    const result = generateCssVariablesFromPuckFields(
-      { primary: "green" },
-      "colors",
-      { "--text-font-size": "12px" }
-    );
-    expect(result).toEqual({
-      "--colors-primary": "green",
-      "--text-font-size": "12px",
-    });
+    expect(result).toEqual({ "--colors-palette-primary": "green" });
   });
 
   test("generates css variables from nested Puck fields", () => {
     const result = generateCssVariablesFromPuckFields(
       {
-        primary: "green",
-        secondary: "purple",
-        alternatives: {
-          lighter: {
-            primary: "white",
-            secondary: "yellow",
-          },
-          darker: {
-            primary: "black",
-            secondary: "grey",
-          },
+        primary: {
+          default: "green",
+          foreground: "blue",
         },
       },
-      "colors"
+      "palette",
+      {
+        label: "Palette",
+        styles: {
+          primary: {
+            label: "Primary",
+            plugin: "colors",
+            styles: {
+              default: {
+                label: "Default",
+                type: "color",
+                default: "black",
+              },
+              foreground: {
+                label: "Foreground",
+                type: "color",
+                default: "white",
+              },
+            },
+          },
+        },
+      }
     );
     expect(result).toEqual({
-      "--colors-primary": "green",
-      "--colors-secondary": "purple",
-      "--colors-alternatives-lighter-primary": "white",
-      "--colors-alternatives-lighter-secondary": "yellow",
-      "--colors-alternatives-darker-primary": "black",
-      "--colors-alternatives-darker-secondary": "grey",
+      "--colors-palette-primary-default": "green",
+      "--colors-palette-primary-foreground": "blue",
     });
   });
 });
 
 const defaultThemeValues = {
-  "--colors-text": "black",
-  "--borderRadius-lg": "8px",
-  "--borderRadius-md": "6px",
-  "--borderRadius-sm": "4px",
-  "--colors-accent-DEFAULT": "hsl(166 55% 67%)",
-  "--colors-accent-foreground": "hsl(0 0% 0%)",
-  "--colors-background": "hsl(0 0% 100%)",
-  "--colors-border": "hsl(214 100% 39%)",
-  "--colors-destructive-DEFAULT": "hsl(0 100% 50%)",
-  "--colors-destructive-foreground": "hsl(210 40% 98%)",
-  "--colors-foreground": "hsl(0 2% 11%)",
-  "--colors-input": "hsl(214.3 31.8% 91.4%)",
-  "--colors-muted-DEFAULT": "hsl(210 40% 96.1%)",
-  "--colors-muted-foreground": "hsl(215.4 16.3% 46.9%)",
-  "--colors-popover-DEFAULT": "hsl(225 7% 12%)",
-  "--colors-popover-foreground": "hsl(0 0% 100%)",
-  "--colors-primary-DEFAULT": "hsl(0 68% 51%)",
-  "--colors-primary-foreground": "hsl(0 0% 100%)",
-  "--colors-ring": "hsl(215 20.2% 65.1%)",
-  "--colors-secondary-DEFAULT": "hsl(11 100% 26%)",
-  "--colors-secondary-foreground": "hsl(0 0% 100%)",
+  "--colors-palette-primary": "#D83B18",
+  "--colors-palette-secondary": "#871900",
+  "--colors-palette-accent": "#FFFFFF",
+  "--colors-palette-text": "#000000",
+  "--colors-palette-background-light": "#FFFFFF",
+  "--colors-palette-background-DEFAULT": "#F7F7F7",
+  "--colors-palette-background-dark": "#F0F0F0",
+  "--colors-palette-foreground": "#000000",
+  "--colors-heading1-color": "var(--colors-palette-primary)",
+  "--colors-heading2-color": "var(--colors-palette-primary)",
+  "--colors-heading3-color": "var(--colors-palette-primary)",
+  "--colors-heading4-color": "var(--colors-palette-secondary)",
+  "--colors-heading5-color": "var(--colors-palette-secondary)",
+  "--colors-heading6-color": "var(--colors-palette-secondary)",
+  "--colors-body-color-light": "var(--colors-palette-text)",
+  "--colors-body-color-dark": "var(--colors-palette-text)",
+  "--colors-button-primary": "var(--colors-palette-primary)",
+  "--colors-button-primaryForeground": "var(--colors-palette-foreground)",
+  "--fontSize-heading1-fontSize": "24px",
+  "--fontSize-heading2-fontSize": "24px",
+  "--fontSize-heading3-fontSize": "24px",
+  "--fontSize-heading4-fontSize": "24px",
+  "--fontSize-heading5-fontSize": "24px",
+  "--fontSize-heading6-fontSize": "24px",
+  "--fontSize-body-fontSize": "12px",
+  "--fontSize-button-fontSize": "12px",
+  "--fontWeight-heading1-fontWeight": "700",
+  "--fontWeight-heading2-fontWeight": "700",
+  "--fontWeight-heading3-fontWeight": "700",
+  "--fontWeight-heading4-fontWeight": "700",
+  "--fontWeight-heading5-fontWeight": "700",
+  "--fontWeight-heading6-fontWeight": "700",
+  "--fontWeight-body-fontWeight": "400",
+  "--fontWeight-button-fontWeight": "400",
+  "--gap-grid-verticalSpacing": "8px",
+  "--backgroundColor-grid-backgroundColor": "var(--colors-palette-background)",
+  "--backgroundColor-page-backgroundColor": "var(--colors-palette-background)",
+  "--backgroundColor-page-footer": "#000000",
+  "--maxWidth-grid-maxWidth": "1280px",
+  "--borderRadius-button-borderRadius": "20px",
 };
 
 const savedThemeValues = {
-  "--colors-text": "grey",
-  "--borderRadius-lg": "16px",
-  "--borderRadius-md": "12px",
-  "--borderRadius-sm": "8px",
-  "--colors-secondary-DEFAULT": "#FF0000",
-  "--colors-secondary-foreground": "#0000FF",
+  "--colors-palette-text": "grey",
+  "--colors-palette-background-DEFAULT": "#EEEEEE",
+  "--gap-grid-verticalSpacing": "16px",
+  "--fontWeight-heading1-fontWeight": "900",
+  "--backgroundColor-grid-backgroundColor": "var(--colors-palette-primary)",
 };
 
 const combinedThemeValues = {
-  "--colors-text": "grey",
-  "--borderRadius-lg": "16px",
-  "--borderRadius-md": "12px",
-  "--borderRadius-sm": "8px",
-  "--colors-accent-DEFAULT": "hsl(166 55% 67%)",
-  "--colors-accent-foreground": "hsl(0 0% 0%)",
-  "--colors-background": "hsl(0 0% 100%)",
-  "--colors-border": "hsl(214 100% 39%)",
-  "--colors-destructive-DEFAULT": "hsl(0 100% 50%)",
-  "--colors-destructive-foreground": "hsl(210 40% 98%)",
-  "--colors-foreground": "hsl(0 2% 11%)",
-  "--colors-input": "hsl(214.3 31.8% 91.4%)",
-  "--colors-muted-DEFAULT": "hsl(210 40% 96.1%)",
-  "--colors-muted-foreground": "hsl(215.4 16.3% 46.9%)",
-  "--colors-popover-DEFAULT": "hsl(225 7% 12%)",
-  "--colors-popover-foreground": "hsl(0 0% 100%)",
-  "--colors-primary-DEFAULT": "hsl(0 68% 51%)",
-  "--colors-primary-foreground": "hsl(0 0% 100%)",
-  "--colors-ring": "hsl(215 20.2% 65.1%)",
-  "--colors-secondary-DEFAULT": "#FF0000",
-  "--colors-secondary-foreground": "#0000FF",
+  "--colors-palette-primary": "#D83B18",
+  "--colors-palette-secondary": "#871900",
+  "--colors-palette-accent": "#FFFFFF",
+  "--colors-palette-text": "grey", // from saved theme
+  "--colors-palette-background-light": "#FFFFFF",
+  "--colors-palette-background-DEFAULT": "#EEEEEE", // from saved theme
+  "--colors-palette-background-dark": "#F0F0F0",
+  "--colors-palette-foreground": "#000000",
+  "--colors-heading1-color": "var(--colors-palette-primary)",
+  "--colors-heading2-color": "var(--colors-palette-primary)",
+  "--colors-heading3-color": "var(--colors-palette-primary)",
+  "--colors-heading4-color": "var(--colors-palette-secondary)",
+  "--colors-heading5-color": "var(--colors-palette-secondary)",
+  "--colors-heading6-color": "var(--colors-palette-secondary)",
+  "--colors-body-color-light": "var(--colors-palette-text)",
+  "--colors-body-color-dark": "var(--colors-palette-text)",
+  "--colors-button-primary": "var(--colors-palette-primary)",
+  "--colors-button-primaryForeground": "var(--colors-palette-foreground)",
+  "--fontSize-heading1-fontSize": "24px",
+  "--fontSize-heading2-fontSize": "24px",
+  "--fontSize-heading3-fontSize": "24px",
+  "--fontSize-heading4-fontSize": "24px",
+  "--fontSize-heading5-fontSize": "24px",
+  "--fontSize-heading6-fontSize": "24px",
+  "--fontSize-body-fontSize": "12px",
+  "--fontSize-button-fontSize": "12px",
+  "--fontWeight-heading1-fontWeight": "900", // from saved theme
+  "--fontWeight-heading2-fontWeight": "700",
+  "--fontWeight-heading3-fontWeight": "700",
+  "--fontWeight-heading4-fontWeight": "700",
+  "--fontWeight-heading5-fontWeight": "700",
+  "--fontWeight-heading6-fontWeight": "700",
+  "--fontWeight-body-fontWeight": "400",
+  "--fontWeight-button-fontWeight": "400",
+  "--gap-grid-verticalSpacing": "16px", // from saved theme
+  "--backgroundColor-grid-backgroundColor": "var(--colors-palette-primary)", // from saved theme
+  "--backgroundColor-page-backgroundColor": "var(--colors-palette-background)",
+  "--backgroundColor-page-footer": "#000000",
+  "--maxWidth-grid-maxWidth": "1280px",
+  "--borderRadius-button-borderRadius": "20px",
 };

--- a/src/internal/utils/internalThemeResolver.ts
+++ b/src/internal/utils/internalThemeResolver.ts
@@ -1,16 +1,13 @@
-import {
-  ParentStyle,
-  ThemeConfig,
-  SavedTheme,
-} from "../../utils/themeResolver.ts";
+import { ThemeConfig, ThemeConfigSection } from "../../utils/themeResolver.ts";
+import { ThemeData } from "../types/themeData.ts";
 
 // internalThemeResolver returns a mapping of css variable names to their values
 // using the themeConfig to create the list of variable names and applying the saved value
 // if it exists for each one. If it does not exist, it falls back on the themeConfig's default field.
 export const internalThemeResolver = (
   themeConfig: ThemeConfig,
-  savedTheme: SavedTheme | undefined
-): SavedTheme => {
+  savedTheme: ThemeData | undefined
+): ThemeData => {
   const themeValues = generateCssVariablesFromThemeConfig(themeConfig);
 
   if (!savedTheme) {
@@ -25,65 +22,70 @@ export const internalThemeResolver = (
   return themeValues;
 };
 
-const extractCssVariablesFromThemeConfig = (
-  parentStyle: ParentStyle,
-  parentKey: string,
-  result: SavedTheme
-) => {
-  Object.entries(parentStyle.styles).forEach(([styleKey, style]) => {
-    if ("default" in style) {
-      if (style.type === "number") {
-        result[`--${parentKey}-${styleKey}`] = `${style.default}px`;
-      } else {
-        result[`--${parentKey}-${styleKey}`] = style.default;
-      }
-    } else {
-      extractCssVariablesFromThemeConfig(
-        style,
-        `${parentKey}-${styleKey}`,
-        result
-      );
-    }
-  });
-  return result;
-};
-
 // generateCssVariablesFromThemeConfig flattens the themeConfig, creating an object
 // mapping css variable names to the themeConfig's default values
 export const generateCssVariablesFromThemeConfig = (
   themeConfig: ThemeConfig
 ) => {
-  const result: SavedTheme = {};
-  for (const category in themeConfig) {
-    extractCssVariablesFromThemeConfig(themeConfig[category], category, result);
-  }
-  return result;
-};
+  const defaultValues: ThemeData = {};
+  for (const themeSectionKey in themeConfig) {
+    const themeSection = themeConfig[themeSectionKey].styles;
 
-type PuckThemeFields = {
-  [key: string]: string | PuckThemeFields;
+    for (const styleKey in themeSection) {
+      const style = themeSection[styleKey];
+
+      if ("default" in style) {
+        defaultValues[`--${style.plugin}-${themeSectionKey}-${styleKey}`] =
+          typeof style.default === "number"
+            ? `${style.default}px`
+            : style.default;
+      } else if ("styles" in style) {
+        for (const subkey in style.styles) {
+          defaultValues[
+            `--${style.plugin}-${themeSectionKey}-${styleKey}-${subkey}`
+          ] =
+            typeof style.styles[subkey].default === "number"
+              ? `${style.styles[subkey].default}px`
+              : style.styles[subkey].default;
+        }
+      }
+    }
+  }
+  return defaultValues;
 };
 
 // generateCssVariablesFromPuckFields flattens the puck sidebar fields, creating an object
 // mapping css variable names to the current puck values
 export const generateCssVariablesFromPuckFields = (
-  fields: PuckThemeFields,
-  parentKey = "",
-  result: SavedTheme = {}
+  fields: Record<string, any>,
+  themeSectionKey: string,
+  themeSection: ThemeConfigSection
 ) => {
-  for (const fieldKey in fields) {
-    const fieldValue = fields[fieldKey];
-    if (typeof fieldValue === "object") {
-      generateCssVariablesFromPuckFields(
-        fieldValue,
-        `${parentKey}-${fieldKey}`,
-        result
-      );
-    } else if (typeof fieldValue === "number") {
-      result[`--${parentKey}-${fieldKey}`] = fieldValue + "px";
+  const result: ThemeData = {};
+
+  for (const styleKey in themeSection.styles) {
+    const style = themeSection.styles[styleKey];
+    if ("default" in style) {
+      if (style.type === "number") {
+        result[`--${style.plugin}-${themeSectionKey}-${styleKey}`] =
+          fields[styleKey] + "px";
+      } else {
+        result[`--${style.plugin}-${themeSectionKey}-${styleKey}`] =
+          fields[styleKey];
+      }
     } else {
-      result[`--${parentKey}-${fieldKey}`] = fieldValue;
+      for (const subkey in style.styles) {
+        const substyle = style.styles[subkey];
+        if (substyle.type === "number") {
+          result[`--${style.plugin}-${themeSectionKey}-${styleKey}-${subkey}`] =
+            fields[styleKey][subkey] + "px";
+        } else {
+          result[`--${style.plugin}-${themeSectionKey}-${styleKey}-${subkey}`] =
+            fields[styleKey][subkey];
+        }
+      }
     }
   }
+
   return result;
 };

--- a/src/utils/README.md
+++ b/src/utils/README.md
@@ -35,6 +35,139 @@ Used in a component's render function to pull in the selected entity field's val
 
 See [YextEntityFieldSelector](../editor/README.md#YextEntityFieldSelector)
 
+## ThemeConfig
+
+The ThemeConfig object defines the styles available for editing in Theme Manager. It is used
+by themeResolver, applyTheme, and Editor.
+
+### Defining a ThemeConfig
+
+Each style must specify a label, type, default value, and plugin. The label will be displayed in the
+Theme Manager UI. The type can be "color", "number" or "select". If type "select", an array of options
+must be provided too. The plugin field must contain one of [Tailwind's Theme Extension Keys](https://tailwindcss.com/docs/theme#configuration-reference), which will determine which Tailwind utilities use the style. Styles that share
+a plugin can be nested one level deep together under a shared label.
+
+```ts
+export const themeConfig: ThemeConfig = {
+  sectionA: {
+    label: "Section A",
+    styles: {
+      style1: {
+        label: "Style 1",
+        type: "number",
+        default: 0,
+        plugin: "fontSize",
+      },
+      style2: {
+        label: "Style 2",
+        plugin: "colors",
+        styles: {
+          substyleA: {
+            label: "Sub-Style A"
+            type: "color"
+            default: "#000000"
+          },
+          substyleB: {
+            label: "Sub-Style B"
+            type: "color"
+            default: "#FFFFFF"
+          },
+        },
+      },
+    },
+  },
+  sectionB: {
+    label: "Section B"
+    styles: {
+      style3: {
+        label: "Style 3",
+        type: "select",
+        default: "normal",
+        options: [
+          {value: "normal", label: "Normal"}
+          {value: "bold", label: "Bold"}
+        ]
+        plugin: "fontWeight",
+      },
+    },
+  },
+};
+```
+
+The Theme Manger UI will display the theme configuration fields in the order
+and structure specified in the themeConfig.
+
+### Using Theme Manager Classes
+
+Theme Manger uses Tailwind to create classes of the following form: `[tailwindUtility]-[sectionName]-[styleName]-[subStyleName?]` where `tailwindUtility` is the Tailwind Utility class prefix used by the style's core plugin. These classes should be used in components to apply the Theme Manager styles.
+
+For example, in the themeConfig above, the following classes would be available:
+
+- `text-parentA-style1`
+- `text-parentA-style2-substyleA`
+- `text-parentA-style2-substyleB`
+- ... other color utilities such as `bg-parentA-style2-substyleA`
+- `font-parentB-style3`
+
+### Referencing Other Theme Values
+
+Underlying these classes are a set of CSS variables that follow the form `--[pluginName]-[sectionName]-[styleName]-[subStyleName?]`.
+
+The themeConfig above creates the following CSS variables:
+
+- `--fontSize-parentA-style1`
+- `--colors-parentA-style2-substyleA`
+- `--colors-parentA-style2-substyleB`
+- `--fontWeight-parentB-style3`
+
+It is not necessary to directly use these CSS variables. However, they can be used to link styles together.
+
+#### Example
+
+```ts
+export const themeConfig: ThemeConfig = {
+  palette: {
+    label: "Color Palette",
+    styles: {
+      primary: {
+        label: "Primary",
+        type: "color",
+        default: "black",
+        plugin: "colors",
+      },
+      secondary: {
+        label: "Secondary",
+        type: "color",
+        default: "white",
+        plugin: "colors",
+      },
+    },
+  },
+  headings: {
+    label: "Headings"
+    styles: {
+      textColor: {
+        label: "Text Color",
+        type: "select",
+        default: "var(--colors-palette-primary)",
+        options: [
+          {value: "var(--colors-palette-primary)", label: "Primary"}
+          {value: "var(--colors-palette-secondary)", label: "Secondary"}
+        ]
+        plugin: "colors",
+      },
+    },
+  },
+};
+```
+
+This example creates the following classes:
+
+- `text-palette-primary`
+- `text-palette-secondary`
+- ... other color utilities like bg-palette-primary
+- `text-headings-textColor` - can switch between the primary or secondary color
+
 ## themeResolver
 
 Used in tailwind.config.ts to combine hard-coded styles with editable Theme Manager styles.

--- a/src/utils/applyTheme.test.ts
+++ b/src/utils/applyTheme.test.ts
@@ -10,7 +10,7 @@ describe("buildCssOverridesStyle", () => {
         pagesTheme: [
           {
             themeConfiguration: {
-              data: JSON.stringify({ "--colors-text": "red" }),
+              data: JSON.stringify({ "--colors-palette-text": "red" }),
               siteId: 123,
             },
           },
@@ -21,11 +21,11 @@ describe("buildCssOverridesStyle", () => {
 
     expect(result).toBe(
       '<style id="visual-editor-theme" type="text/css">.components{' +
-        "--colors-text:red !important;" +
-        "--colors-primary-DEFAULT:hsl(0 68% 51%) !important;" +
-        "--colors-primary-foreground:hsl(0 0% 100%) !important;" +
-        "--borderRadius-lg:8px !important;" +
-        "--borderRadius-sm:4px !important" +
+        "--colors-palette-text:red !important;" +
+        "--colors-palette-primary-DEFAULT:hsl(0 68% 51%) !important;" +
+        "--colors-palette-primary-foreground:hsl(0 0% 100%) !important;" +
+        "--borderRadius-border-lg:8px !important;" +
+        "--borderRadius-border-sm:4px !important" +
         "}</style>"
     );
   });
@@ -38,9 +38,9 @@ describe("buildCssOverridesStyle", () => {
           {
             themeConfiguration: {
               data: JSON.stringify({
-                "--colors-primary-DEFAULT": "hsl(0 68% 51%)",
-                "--colors-primary-foreground": "hsl(0 0% 100%)",
-                "--borderRadius-lg": "20px",
+                "--colors-palette-primary-DEFAULT": "hsl(0 68% 51%)",
+                "--colors-palette-primary-foreground": "hsl(0 0% 100%)",
+                "--borderRadius-border-lg": "20px",
               }),
               siteId: 123,
             },
@@ -53,11 +53,11 @@ describe("buildCssOverridesStyle", () => {
 
     expect(result).toBe(
       '<style id="visual-editor-theme" type="text/css">.components{' +
-        "--colors-text:black !important;" +
-        "--colors-primary-DEFAULT:hsl(0 68% 51%) !important;" +
-        "--colors-primary-foreground:hsl(0 0% 100%) !important;" +
-        "--borderRadius-lg:20px !important;" +
-        "--borderRadius-sm:4px !important" +
+        "--colors-palette-text:black !important;" +
+        "--colors-palette-primary-DEFAULT:hsl(0 68% 51%) !important;" +
+        "--colors-palette-primary-foreground:hsl(0 0% 100%) !important;" +
+        "--borderRadius-border-lg:20px !important;" +
+        "--borderRadius-border-sm:4px !important" +
         "}</style>"
     );
   });
@@ -67,11 +67,11 @@ describe("buildCssOverridesStyle", () => {
 
     expect(result).toBe(
       '<style id="visual-editor-theme" type="text/css">.components{' +
-        "--colors-text:black !important;" +
-        "--colors-primary-DEFAULT:hsl(0 68% 51%) !important;" +
-        "--colors-primary-foreground:hsl(0 0% 100%) !important;" +
-        "--borderRadius-lg:8px !important;" +
-        "--borderRadius-sm:4px !important" +
+        "--colors-palette-text:black !important;" +
+        "--colors-palette-primary-DEFAULT:hsl(0 68% 51%) !important;" +
+        "--colors-palette-primary-foreground:hsl(0 0% 100%) !important;" +
+        "--borderRadius-border-lg:8px !important;" +
+        "--borderRadius-border-sm:4px !important" +
         "}</style>"
     );
   });
@@ -97,18 +97,18 @@ describe("buildCssOverridesStyle", () => {
 
     expect(result).toBe(
       '<style id="visual-editor-theme" type="text/css">.components{' +
-        "--colors-text:black !important;" +
-        "--colors-primary-DEFAULT:hsl(0 68% 51%) !important;" +
-        "--colors-primary-foreground:hsl(0 0% 100%) !important;" +
-        "--borderRadius-lg:8px !important;" +
-        "--borderRadius-sm:4px !important" +
+        "--colors-palette-text:black !important;" +
+        "--colors-palette-primary-DEFAULT:hsl(0 68% 51%) !important;" +
+        "--colors-palette-primary-foreground:hsl(0 0% 100%) !important;" +
+        "--borderRadius-border-lg:8px !important;" +
+        "--borderRadius-border-sm:4px !important" +
         "}</style>"
     );
   });
 });
 
 const themeConfig: ThemeConfig = {
-  colors: {
+  palette: {
     label: "Colors",
     styles: {
       text: {
@@ -117,19 +117,17 @@ const themeConfig: ThemeConfig = {
         type: "color",
         default: "black",
       },
-
       primary: {
         label: "Primary",
+        plugin: "colors",
         styles: {
           DEFAULT: {
             label: "Default",
-            plugin: "colors",
             type: "color",
             default: "hsl(0 68% 51%)",
           },
           foreground: {
             label: "Default",
-            plugin: "colors",
             type: "color",
             default: "hsl(0 0% 100%)",
           },
@@ -137,7 +135,7 @@ const themeConfig: ThemeConfig = {
       },
     },
   },
-  borderRadius: {
+  border: {
     label: "Border Radius",
     styles: {
       lg: {

--- a/src/utils/applyTheme.ts
+++ b/src/utils/applyTheme.ts
@@ -1,6 +1,7 @@
+import { ThemeData } from "../internal/types/themeData.ts";
 import { internalThemeResolver } from "../internal/utils/internalThemeResolver.ts";
 import { DevLogger } from "./devLogger.ts";
-import { SavedTheme, ThemeConfig } from "./themeResolver.ts";
+import { ThemeConfig } from "./themeResolver.ts";
 
 export type Document = {
   [key: string]: any;
@@ -41,7 +42,7 @@ export const applyTheme = (
 };
 
 const internalApplyTheme = (
-  savedThemeValues: Record<string, any>,
+  savedThemeValues: ThemeData,
   themeConfig: ThemeConfig
 ): string => {
   devLogger.logFunc("internalApplyTheme");
@@ -66,7 +67,7 @@ const internalApplyTheme = (
 };
 
 export const updateThemeInEditor = async (
-  newTheme: SavedTheme,
+  newTheme: ThemeData,
   themeConfig: ThemeConfig
 ) => {
   devLogger.logFunc("updateThemeInEditor");

--- a/src/utils/themeResolver.test.ts
+++ b/src/utils/themeResolver.test.ts
@@ -18,7 +18,7 @@ describe("themeResolver", () => {
     const result = deepMerge(developerTailwindConfig, marketerTailwindConfig);
     expect(result).toEqual(mergedConfig);
     expect(consoleSpy).toHaveBeenLastCalledWith(
-      "Both theme.config.ts and tailwind.config.ts provided a value for sm. Using the value from theme.config.ts (var(--borderRadius-sm))"
+      "Both theme.config.ts and tailwind.config.ts provided a value for button-primary. Using the value from theme.config.ts (var(--colors-button-primary))"
     );
   });
 
@@ -29,178 +29,364 @@ describe("themeResolver", () => {
       const consoleSpy = vi.spyOn(console, "warn");
       const result = themeResolver(developerTailwindConfig, testThemeConfig);
       expect(result).toEqual(mergedConfig);
-      expect(consoleSpy).toHaveBeenCalledTimes(3);
+      expect(consoleSpy).toHaveBeenCalledTimes(1);
       expect(consoleSpy).toHaveBeenLastCalledWith(
-        "Both theme.config.ts and tailwind.config.ts provided a value for sm. Using the value from theme.config.ts (var(--borderRadius-sm))"
+        "Both theme.config.ts and tailwind.config.ts provided a value for button-primary. Using the value from theme.config.ts (var(--colors-button-primary))"
       );
     }
   );
 });
 
+const getColorOptions = () => {
+  return [
+    { label: "Primary", value: "var(--colors-palette-primary)" },
+    { label: "Secondary", value: "var(--colors-palette-secondary)" },
+    { label: "Accent", value: "var(--colors-palette-accent)" },
+    { label: "Text", value: "var(--colors-palette-text)" },
+    { label: "Background", value: "var(--colors-palette-background)" },
+    { label: "Foreground", value: "var(--colors-palette-foreground)" },
+  ];
+};
+
+const getWeightOptions = () => {
+  return [
+    { label: "Thin", value: "100" },
+    { label: "Extralight", value: "200" },
+    { label: "Light", value: "300" },
+    { label: "Normal", value: "400" },
+    { label: "Medium", value: "500" },
+    { label: "Semibold", value: "600" },
+    { label: "Bold", value: "700" },
+    { label: "Extrabold", value: "800" },
+    { label: "Black", value: "900" },
+  ];
+};
+
 export const testThemeConfig: ThemeConfig = {
-  colors: {
-    label: "Colors",
+  palette: {
+    label: "Color Palette",
     styles: {
+      primary: {
+        label: "Primary",
+        type: "color",
+        default: "#D83B18",
+        plugin: "colors",
+      },
+      secondary: {
+        label: "Secondary",
+        type: "color",
+        default: "#871900",
+        plugin: "colors",
+      },
+      accent: {
+        label: "Accent",
+        type: "color",
+        default: "#FFFFFF",
+        plugin: "colors",
+      },
       text: {
         label: "Text",
-        plugin: "colors",
         type: "color",
-        default: "black",
-      },
-      border: {
-        label: "Border",
+        default: "#000000",
         plugin: "colors",
-        type: "color",
-        default: "hsl(214 100% 39%)",
-      },
-      input: {
-        label: "Input",
-        plugin: "colors",
-        type: "color",
-        default: "hsl(214.3 31.8% 91.4%)",
-      },
-      ring: {
-        label: "Ring",
-        plugin: "colors",
-        type: "color",
-        default: "hsl(215 20.2% 65.1%)",
       },
       background: {
         label: "Background",
         plugin: "colors",
-        type: "color",
-        default: "hsl(0 0% 100%)",
+        styles: {
+          light: {
+            label: "Light",
+            type: "color",
+            default: "#FFFFFF",
+          },
+          DEFAULT: {
+            label: "Default",
+            type: "color",
+            default: "#F7F7F7",
+          },
+          dark: {
+            label: "Dark",
+            type: "color",
+            default: "#F0F0F0",
+          },
+        },
       },
       foreground: {
         label: "Foreground",
-        plugin: "colors",
         type: "color",
-        default: "hsl(0 2% 11%)",
+        plugin: "colors",
+        default: "#000000",
       },
-      primary: {
-        label: "Primary",
-        styles: {
-          DEFAULT: {
-            label: "Default",
-            plugin: "colors",
-            type: "color",
-            default: "hsl(0 68% 51%)",
-          },
-          foreground: {
-            label: "Default",
-            plugin: "colors",
-            type: "color",
-            default: "hsl(0 0% 100%)",
-          },
-        },
+    },
+  },
+  heading1: {
+    label: "Heading 1",
+    styles: {
+      fontSize: {
+        label: "Font Size",
+        type: "number",
+        plugin: "fontSize",
+        default: 24,
       },
-      secondary: {
-        label: "Secondary",
-        styles: {
-          DEFAULT: {
-            label: "Default",
-            plugin: "colors",
-            type: "color",
-            default: "hsl(11 100% 26%)",
-          },
-          foreground: {
-            label: "Default",
-            plugin: "colors",
-            type: "color",
-            default: "hsl(0 0% 100%)",
-          },
-        },
+      fontWeight: {
+        label: "Font Weight",
+        type: "select",
+        plugin: "fontWeight",
+        options: getWeightOptions(),
+        default: "700",
       },
-      destructive: {
-        label: "Destructive",
-        styles: {
-          DEFAULT: {
-            label: "Default",
-            plugin: "colors",
-            type: "color",
-            default: "hsl(0 100% 50%)",
-          },
-          foreground: {
-            label: "Default",
-            plugin: "colors",
-            type: "color",
-            default: "hsl(210 40% 98%)",
-          },
-        },
+      color: {
+        label: "Text Color",
+        type: "select",
+        plugin: "colors",
+        options: getColorOptions(),
+        default: "var(--colors-palette-primary)",
       },
-      muted: {
-        label: "Muted",
-        styles: {
-          DEFAULT: {
-            label: "Default",
-            plugin: "colors",
-            type: "color",
-            default: "hsl(210 40% 96.1%)",
-          },
-          foreground: {
-            label: "Default",
-            plugin: "colors",
-            type: "color",
-            default: "hsl(215.4 16.3% 46.9%)",
-          },
-        },
+    },
+  },
+  heading2: {
+    label: "Heading 2",
+    styles: {
+      fontSize: {
+        label: "Font Size",
+        type: "number",
+        plugin: "fontSize",
+        default: 24,
       },
-      accent: {
-        label: "Accent",
-        styles: {
-          DEFAULT: {
-            label: "Default",
-            plugin: "colors",
-            type: "color",
-            default: "hsl(166 55% 67%)",
-          },
-          foreground: {
-            label: "Default",
-            plugin: "colors",
-            type: "color",
-            default: "hsl(0 0% 0%)",
-          },
-        },
+      fontWeight: {
+        label: "Font Weight",
+        type: "select",
+        plugin: "fontWeight",
+        options: getWeightOptions(),
+        default: "700",
       },
-      popover: {
-        label: "Secondary",
+      color: {
+        label: "Text Color",
+        type: "select",
+        plugin: "colors",
+        options: getColorOptions(),
+        default: "var(--colors-palette-primary)",
+      },
+    },
+  },
+  heading3: {
+    label: "Heading 3",
+    styles: {
+      fontSize: {
+        label: "Font Size",
+        type: "number",
+        plugin: "fontSize",
+        default: 24,
+      },
+      fontWeight: {
+        label: "Font Weight",
+        type: "select",
+        plugin: "fontWeight",
+        options: getWeightOptions(),
+        default: "700",
+      },
+      color: {
+        label: "Text Color",
+        type: "select",
+        plugin: "colors",
+        options: getColorOptions(),
+        default: "var(--colors-palette-primary)",
+      },
+    },
+  },
+  heading4: {
+    label: "Heading 4",
+    styles: {
+      fontSize: {
+        label: "Font Size",
+        type: "number",
+        plugin: "fontSize",
+        default: 24,
+      },
+      fontWeight: {
+        label: "Font Weight",
+        type: "select",
+        plugin: "fontWeight",
+        options: getWeightOptions(),
+        default: "700",
+      },
+      color: {
+        label: "Text Color",
+        type: "select",
+        plugin: "colors",
+        options: getColorOptions(),
+        default: "var(--colors-palette-secondary)",
+      },
+    },
+  },
+  heading5: {
+    label: "Heading 5",
+    styles: {
+      fontSize: {
+        label: "Font Size",
+        type: "number",
+        plugin: "fontSize",
+        default: 24,
+      },
+      fontWeight: {
+        label: "Font Weight",
+        type: "select",
+        plugin: "fontWeight",
+        options: getWeightOptions(),
+        default: "700",
+      },
+      color: {
+        label: "Text Color",
+        type: "select",
+        plugin: "colors",
+        options: getColorOptions(),
+        default: "var(--colors-palette-secondary)",
+      },
+    },
+  },
+  heading6: {
+    label: "Heading 6",
+    styles: {
+      fontSize: {
+        label: "Font Size",
+        type: "number",
+        plugin: "fontSize",
+        default: 24,
+      },
+      fontWeight: {
+        label: "Font Weight",
+        type: "select",
+        plugin: "fontWeight",
+        options: getWeightOptions(),
+        default: "700",
+      },
+      color: {
+        label: "Text Color",
+        type: "select",
+        plugin: "colors",
+        options: getColorOptions(),
+        default: "var(--colors-palette-secondary)",
+      },
+    },
+  },
+  body: {
+    label: "Body Text",
+    styles: {
+      fontSize: {
+        label: "Font Size",
+        type: "number",
+        plugin: "fontSize",
+        default: 12,
+      },
+      fontWeight: {
+        label: "Font Weight",
+        type: "select",
+        plugin: "fontWeight",
+        options: getWeightOptions(),
+        default: "400",
+      },
+      color: {
+        label: "Text Color",
+        plugin: "colors",
         styles: {
-          DEFAULT: {
-            label: "Default",
-            plugin: "colors",
-            type: "color",
-            default: "hsl(225 7% 12%)",
+          light: {
+            label: "Light Mode",
+            type: "select",
+            options: getColorOptions(),
+            default: "var(--colors-palette-text)",
           },
-          foreground: {
-            label: "Default",
-            plugin: "colors",
-            type: "color",
-            default: "hsl(0 0% 100%)",
+          dark: {
+            label: "Dark Mode",
+            type: "select",
+            options: getColorOptions(),
+            default: "var(--colors-palette-text)",
           },
         },
       },
     },
   },
-  borderRadius: {
-    label: "Border Radius",
+  grid: {
+    label: "Grid Section",
     styles: {
-      lg: {
-        label: "Large Border Radius",
-        plugin: "borderRadius",
+      verticalSpacing: {
+        label: "Vertical Spacing",
         type: "number",
+        plugin: "gap",
         default: 8,
       },
-      md: {
-        label: "Medium Border Radius",
-        plugin: "borderRadius",
-        type: "number",
-        default: 6,
+      maxWidth: {
+        label: "Maximum Width",
+        type: "select",
+        plugin: "maxWidth",
+        options: [
+          { label: "2XL", value: "1536px" },
+          { label: "XL", value: "1280px" },
+          { label: "LG", value: "1024px" },
+        ],
+        default: "1280px",
       },
-      sm: {
-        label: "Small Border Radius",
-        plugin: "borderRadius",
+      backgroundColor: {
+        label: "Background Color",
+        type: "select",
+        plugin: "backgroundColor",
+        options: getColorOptions(),
+        default: "var(--colors-palette-background)",
+      },
+    },
+  },
+  button: {
+    label: "Button",
+    styles: {
+      borderRadius: {
+        label: "Border Radius",
         type: "number",
-        default: 4,
+        plugin: "borderRadius",
+        default: 20,
+      },
+      primary: {
+        label: "Primary Color",
+        type: "select",
+        plugin: "colors",
+        options: getColorOptions(),
+        default: "var(--colors-palette-primary)",
+      },
+      primaryForeground: {
+        label: "Primary Foreground Color",
+        type: "select",
+        plugin: "colors",
+        options: getColorOptions(),
+        default: "var(--colors-palette-foreground)",
+      },
+      fontWeight: {
+        label: "Font Weight",
+        type: "select",
+        plugin: "fontWeight",
+        options: getWeightOptions(),
+        default: "400",
+      },
+      fontSize: {
+        label: "Font Size",
+        type: "number",
+        plugin: "fontSize",
+        default: 12,
+      },
+    },
+  },
+  page: {
+    label: "Page",
+    styles: {
+      backgroundColor: {
+        label: "Background Color",
+        type: "select",
+        plugin: "backgroundColor",
+        options: getColorOptions(),
+        default: "var(--colors-palette-background)",
+      },
+      footer: {
+        label: "Footer Background Color",
+        type: "color",
+        plugin: "backgroundColor",
+        default: "#000000",
       },
     },
   },
@@ -208,49 +394,69 @@ export const testThemeConfig: ThemeConfig = {
 
 const marketerTailwindConfig: TailwindConfig = {
   colors: {
-    text: "var(--colors-text)",
-    border: "var(--colors-border)",
-    input: "var(--colors-input)",
-    ring: "var(--colors-ring)",
-    background: "var(--colors-background)",
-    foreground: "var(--colors-foreground)",
-    primary: {
-      DEFAULT: "var(--colors-primary-DEFAULT)",
-      foreground: "var(--colors-primary-foreground)",
+    "palette-primary": "var(--colors-palette-primary)",
+    "palette-secondary": "var(--colors-palette-secondary)",
+    "palette-accent": "var(--colors-palette-accent)",
+    "palette-text": "var(--colors-palette-text)",
+    "palette-background": {
+      light: "var(--colors-palette-background-light)",
+      DEFAULT: "var(--colors-palette-background-DEFAULT)",
+      dark: "var(--colors-palette-background-dark)",
     },
-    secondary: {
-      DEFAULT: "var(--colors-secondary-DEFAULT)",
-      foreground: "var(--colors-secondary-foreground)",
+    "palette-foreground": "var(--colors-palette-foreground)",
+    "heading1-color": "var(--colors-heading1-color)",
+    "heading2-color": "var(--colors-heading2-color)",
+    "heading3-color": "var(--colors-heading3-color)",
+    "heading4-color": "var(--colors-heading4-color)",
+    "heading5-color": "var(--colors-heading5-color)",
+    "heading6-color": "var(--colors-heading6-color)",
+    "body-color": {
+      light: "var(--colors-body-color-light)",
+      dark: "var(--colors-body-color-dark)",
     },
-    destructive: {
-      DEFAULT: "var(--colors-destructive-DEFAULT)",
-      foreground: "var(--colors-destructive-foreground)",
-    },
-    muted: {
-      DEFAULT: "var(--colors-muted-DEFAULT)",
-      foreground: "var(--colors-muted-foreground)",
-    },
-    accent: {
-      DEFAULT: "var(--colors-accent-DEFAULT)",
-      foreground: "var(--colors-accent-foreground)",
-    },
-    popover: {
-      DEFAULT: "var(--colors-popover-DEFAULT)",
-      foreground: "var(--colors-popover-foreground)",
-    },
+    "button-primary": "var(--colors-button-primary)",
+    "button-primaryForeground": "var(--colors-button-primaryForeground)",
+  },
+  fontSize: {
+    "heading1-fontSize": "var(--fontSize-heading1-fontSize)",
+    "heading2-fontSize": "var(--fontSize-heading2-fontSize)",
+    "heading3-fontSize": "var(--fontSize-heading3-fontSize)",
+    "heading4-fontSize": "var(--fontSize-heading4-fontSize)",
+    "heading5-fontSize": "var(--fontSize-heading5-fontSize)",
+    "heading6-fontSize": "var(--fontSize-heading6-fontSize)",
+    "body-fontSize": "var(--fontSize-body-fontSize)",
+    "button-fontSize": "var(--fontSize-button-fontSize)",
+  },
+  fontWeight: {
+    "heading1-fontWeight": "var(--fontWeight-heading1-fontWeight)",
+    "heading2-fontWeight": "var(--fontWeight-heading2-fontWeight)",
+    "heading3-fontWeight": "var(--fontWeight-heading3-fontWeight)",
+    "heading4-fontWeight": "var(--fontWeight-heading4-fontWeight)",
+    "heading5-fontWeight": "var(--fontWeight-heading5-fontWeight)",
+    "heading6-fontWeight": "var(--fontWeight-heading6-fontWeight)",
+    "body-fontWeight": "var(--fontWeight-body-fontWeight)",
+    "button-fontWeight": "var(--fontWeight-button-fontWeight)",
+  },
+  gap: {
+    "grid-verticalSpacing": "var(--gap-grid-verticalSpacing)",
+  },
+  maxWidth: {
+    "grid-maxWidth": "var(--maxWidth-grid-maxWidth)",
+  },
+  backgroundColor: {
+    "grid-backgroundColor": "var(--backgroundColor-grid-backgroundColor)",
+    "page-backgroundColor": "var(--backgroundColor-page-backgroundColor)",
+    "page-footer": "var(--backgroundColor-page-footer)",
   },
   borderRadius: {
-    lg: "var(--borderRadius-lg)",
-    md: "var(--borderRadius-md)",
-    sm: "var(--borderRadius-sm)",
+    "button-borderRadius": "var(--borderRadius-button-borderRadius)",
   },
 };
 
 const developerTailwindConfig: TailwindConfig = {
-  borderRadius: {
-    lg: "0px",
-    md: "0px",
-    sm: "0px",
+  colors: {
+    ring: "var(--colors-ring)",
+    "button-primary": "#000000",
   },
   keyframes: {
     "accordion-down": {
@@ -279,41 +485,63 @@ const developerTailwindConfig: TailwindConfig = {
 
 const mergedConfig: TailwindConfig = {
   colors: {
-    text: "var(--colors-text)",
-    border: "var(--colors-border)",
-    input: "var(--colors-input)",
-    ring: "var(--colors-ring)",
-    background: "var(--colors-background)",
-    foreground: "var(--colors-foreground)",
-    primary: {
-      DEFAULT: "var(--colors-primary-DEFAULT)",
-      foreground: "var(--colors-primary-foreground)",
+    ring: "var(--colors-ring)", // from developer tailwindConfig
+    "palette-primary": "var(--colors-palette-primary)",
+    "palette-secondary": "var(--colors-palette-secondary)",
+    "palette-accent": "var(--colors-palette-accent)",
+    "palette-text": "var(--colors-palette-text)",
+    "palette-background": {
+      light: "var(--colors-palette-background-light)",
+      DEFAULT: "var(--colors-palette-background-DEFAULT)",
+      dark: "var(--colors-palette-background-dark)",
     },
-    secondary: {
-      DEFAULT: "var(--colors-secondary-DEFAULT)",
-      foreground: "var(--colors-secondary-foreground)",
+    "palette-foreground": "var(--colors-palette-foreground)",
+    "heading1-color": "var(--colors-heading1-color)",
+    "heading2-color": "var(--colors-heading2-color)",
+    "heading3-color": "var(--colors-heading3-color)",
+    "heading4-color": "var(--colors-heading4-color)",
+    "heading5-color": "var(--colors-heading5-color)",
+    "heading6-color": "var(--colors-heading6-color)",
+    "body-color": {
+      light: "var(--colors-body-color-light)",
+      dark: "var(--colors-body-color-dark)",
     },
-    destructive: {
-      DEFAULT: "var(--colors-destructive-DEFAULT)",
-      foreground: "var(--colors-destructive-foreground)",
-    },
-    muted: {
-      DEFAULT: "var(--colors-muted-DEFAULT)",
-      foreground: "var(--colors-muted-foreground)",
-    },
-    accent: {
-      DEFAULT: "var(--colors-accent-DEFAULT)",
-      foreground: "var(--colors-accent-foreground)",
-    },
-    popover: {
-      DEFAULT: "var(--colors-popover-DEFAULT)",
-      foreground: "var(--colors-popover-foreground)",
-    },
+    "button-primary": "var(--colors-button-primary)", // theme.config takes priority
+    "button-primaryForeground": "var(--colors-button-primaryForeground)",
+  },
+  fontSize: {
+    "heading1-fontSize": "var(--fontSize-heading1-fontSize)",
+    "heading2-fontSize": "var(--fontSize-heading2-fontSize)",
+    "heading3-fontSize": "var(--fontSize-heading3-fontSize)",
+    "heading4-fontSize": "var(--fontSize-heading4-fontSize)",
+    "heading5-fontSize": "var(--fontSize-heading5-fontSize)",
+    "heading6-fontSize": "var(--fontSize-heading6-fontSize)",
+    "body-fontSize": "var(--fontSize-body-fontSize)",
+    "button-fontSize": "var(--fontSize-button-fontSize)",
+  },
+  fontWeight: {
+    "heading1-fontWeight": "var(--fontWeight-heading1-fontWeight)",
+    "heading2-fontWeight": "var(--fontWeight-heading2-fontWeight)",
+    "heading3-fontWeight": "var(--fontWeight-heading3-fontWeight)",
+    "heading4-fontWeight": "var(--fontWeight-heading4-fontWeight)",
+    "heading5-fontWeight": "var(--fontWeight-heading5-fontWeight)",
+    "heading6-fontWeight": "var(--fontWeight-heading6-fontWeight)",
+    "body-fontWeight": "var(--fontWeight-body-fontWeight)",
+    "button-fontWeight": "var(--fontWeight-button-fontWeight)",
+  },
+  gap: {
+    "grid-verticalSpacing": "var(--gap-grid-verticalSpacing)",
+  },
+  maxWidth: {
+    "grid-maxWidth": "var(--maxWidth-grid-maxWidth)",
+  },
+  backgroundColor: {
+    "grid-backgroundColor": "var(--backgroundColor-grid-backgroundColor)",
+    "page-backgroundColor": "var(--backgroundColor-page-backgroundColor)",
+    "page-footer": "var(--backgroundColor-page-footer)",
   },
   borderRadius: {
-    lg: "var(--borderRadius-lg)", // theme.config takes priority
-    md: "var(--borderRadius-md)", // theme.config takes priority
-    sm: "var(--borderRadius-sm)", // theme.config takes priority
+    "button-borderRadius": "var(--borderRadius-button-borderRadius)",
   },
   keyframes: {
     "accordion-down": {
@@ -331,6 +559,11 @@ const mergedConfig: TailwindConfig = {
   },
   container: {
     center: true,
-    padding: { DEFAULT: "1rem", sm: "2rem", lg: "4rem", xl: "5rem" },
+    padding: {
+      DEFAULT: "1rem",
+      sm: "2rem",
+      lg: "4rem",
+      xl: "5rem",
+    },
   },
 };

--- a/src/utils/themeResolver.ts
+++ b/src/utils/themeResolver.ts
@@ -1,39 +1,41 @@
-export type Style =
+export type CoreStyle =
   | {
       label: string;
-      plugin: string;
       type: "number";
       default: number;
     }
   | {
       label: string;
-      plugin: string;
       type: "select";
       default: string;
       options: StyleSelectOption[];
     }
   | {
       label: string;
-      plugin: string;
       type: "color";
       default: string;
     };
+
+export type Style = CoreStyle & { plugin: string };
 
 export type StyleSelectOption = {
   label: string;
   value: string;
 };
 
-export type ParentStyle = {
+export type StyleGroup = {
   label: string;
-  styles: { [key: string]: Style | ParentStyle };
+  plugin: string;
+  styles: { [key: string]: CoreStyle };
+};
+
+export type ThemeConfigSection = {
+  label: string;
+  styles: { [key: string]: Style | StyleGroup };
 };
 
 export type ThemeConfig = {
-  [key: string]: {
-    label: string;
-    styles: { [key: string]: Style | ParentStyle };
-  };
+  [key: string]: ThemeConfigSection;
 };
 
 export type TailwindConfig = {
@@ -42,37 +44,40 @@ export type TailwindConfig = {
   };
 };
 
-export type SavedTheme = Record<string, string>;
-
-const extractDefaults = (
-  styles: {
-    [key: string]: Style | ParentStyle;
-  },
-  parentKey = ""
-): { [key: string]: string | { [key: string]: string } } => {
-  const result: any = {};
-
-  for (const key in styles) {
-    const style = styles[key];
-
-    if ("default" in style) {
-      // It's a Style, give it a CSS variable
-      result[key] = `var(--${parentKey}-${key})`;
-    } else if ("styles" in style) {
-      // It's a ParentStyle, recurse to children
-      result[key] = extractDefaults(style.styles, `${parentKey}-${key}`);
-    }
-  }
-
-  return result;
-};
-
-export const convertToTailwindConfig = (input: ThemeConfig): TailwindConfig => {
+export const convertToTailwindConfig = (
+  themeConfig: ThemeConfig
+): TailwindConfig => {
   const output: TailwindConfig = {};
 
-  for (const category in input) {
-    const categoryData = input[category];
-    output[category] = extractDefaults(categoryData.styles, category);
+  for (const themeSectionKey in themeConfig) {
+    const themeSectionStyles = themeConfig[themeSectionKey].styles;
+
+    for (const styleKey in themeSectionStyles) {
+      const style = themeSectionStyles[styleKey];
+
+      if (!output[style.plugin]) {
+        // add theme extension to tailwindConfig if it does not exist
+        output[style.plugin] = {};
+      }
+
+      if ("default" in style) {
+        // If it's type Style, assign a class name and CSS variable
+        output[style.plugin][`${themeSectionKey}-${styleKey}`] =
+          `var(--${style.plugin}-${themeSectionKey}-${styleKey})`;
+      } else if ("styles" in style) {
+        // If it's type StyleGroup, construct an object with class names and CSS variables
+        const styleGroupValues: Record<string, any> = {};
+
+        for (const subkey in style.styles) {
+          styleGroupValues[subkey] =
+            `var(--${style.plugin}-${themeSectionKey}-${styleKey}-${subkey})`;
+        }
+
+        // add the object extension to the tailwindConfig
+        output[style.plugin][`${themeSectionKey}-${styleKey}`] =
+          styleGroupValues;
+      }
+    }
   }
 
   return output;


### PR DESCRIPTION
- allows the top level keys of theme.config to be any string -> allows custom organization in the TM UI
- reshapes the theme.config when dumping into tailwind.config, organized by the plugin value 
- no longer allows unlimited depth style objects, each section of the theme.config can only have direct child styles or one-deep StyleGroups if that group shares the same plugin
- classes created follow the format `[tailwindUtility]-[sectionName]-[styleName]-[subStyleName?]`
- css variables created follow the format `--[pluginName]-[sectionName]-[styleName]-[subStyleName?]`

Starter repo PR that uses this: https://github.com/YextSolutions/pages-visual-editor-starter/pull/159

![Screenshot 2024-10-30 at 1 41 37 PM](https://github.com/user-attachments/assets/7ca75bfa-a23b-49c3-ab30-8c6ba8e97f43)
