### PR TITLE
feat: pass themeData from content to layoutEditor

### DIFF
--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -38,6 +38,8 @@ export const Editor = ({
     puckConfig,
     visualConfigurationData,
     visualConfigurationDataFetched,
+    themeData,
+    themeDataFetched,
   } = useCommonMessageReceivers(componentRegistry);
 
   const { pushPageSets } = useCommonMessageSenders();
@@ -92,15 +94,17 @@ export const Editor = ({
     !puckConfig ||
     !templateMetadata ||
     !document ||
-    !visualConfigurationDataFetched;
+    !visualConfigurationDataFetched ||
+    !themeDataFetched;
 
   const progress: number =
     60 * // @ts-expect-error adding bools is fine
     ((!!puckConfig +
       !!templateMetadata +
       !!document +
-      visualConfigurationDataFetched) /
-      4);
+      visualConfigurationDataFetched +
+      themeDataFetched) /
+      5);
 
   return (
     <>
@@ -110,6 +114,7 @@ export const Editor = ({
             puckConfig={puckConfig}
             templateMetadata={templateMetadata}
             visualConfigurationData={visualConfigurationData!}
+            themeData={themeData!}
             themeConfig={themeConfig}
           />
         ) : (
@@ -117,6 +122,8 @@ export const Editor = ({
             puckConfig={puckConfig}
             templateMetadata={templateMetadata}
             visualConfigurationData={visualConfigurationData!}
+            themeData={themeData!}
+            themeConfig={themeConfig}
           />
         )
       ) : (

--- a/src/internal/components/LayoutEditor.tsx
+++ b/src/internal/components/LayoutEditor.tsx
@@ -7,6 +7,9 @@ import { DevLogger } from "../../utils/devLogger.ts";
 import { useLayoutMessageSenders } from "../hooks/layout/useMessageSenders.ts";
 import { useLayoutMessageReceivers } from "../hooks/layout/useMessageReceivers.ts";
 import { LoadingScreen } from "../puck/components/LoadingScreen.tsx";
+import { ThemeData } from "../types/themeData.ts";
+import { ThemeConfig } from "../../utils/themeResolver.ts";
+import { updateThemeInEditor } from "../../utils/applyTheme.ts";
 
 const devLogger = new DevLogger();
 
@@ -14,10 +17,18 @@ type LayoutEditorProps = {
   puckConfig: Config;
   templateMetadata: TemplateMetadata;
   visualConfigurationData: Data;
+  themeData: ThemeData;
+  themeConfig: ThemeConfig | undefined;
 };
 
 export const LayoutEditor = (props: LayoutEditorProps) => {
-  const { puckConfig, templateMetadata, visualConfigurationData } = props;
+  const {
+    puckConfig,
+    templateMetadata,
+    visualConfigurationData,
+    themeData,
+    themeConfig,
+  } = props;
 
   const {
     sendDevLayoutSaveStateData,
@@ -46,6 +57,16 @@ export const LayoutEditor = (props: LayoutEditorProps) => {
     clearVisualConfigLocalStorage();
     deleteLayoutSaveState();
   };
+
+  /**
+   * Apply the themes from Content
+   */
+  useEffect(() => {
+    devLogger.logData("THEME_DATA", themeData);
+    if (themeData && themeConfig) {
+      updateThemeInEditor(themeData as ThemeData, themeConfig);
+    }
+  }, [themeData, themeConfig]);
 
   /**
    * Determines the initialHistory to send to Puck. It is based on a combination

--- a/src/internal/components/ThemeEditor.tsx
+++ b/src/internal/components/ThemeEditor.tsx
@@ -17,12 +17,18 @@ type ThemeEditorProps = {
   puckConfig: Config;
   templateMetadata: TemplateMetadata;
   visualConfigurationData: Data;
+  themeData: ThemeData;
   themeConfig: ThemeConfig | undefined;
 };
 
 export const ThemeEditor = (props: ThemeEditorProps) => {
-  const { puckConfig, templateMetadata, visualConfigurationData, themeConfig } =
-    props;
+  const {
+    puckConfig,
+    templateMetadata,
+    visualConfigurationData,
+    themeData,
+    themeConfig,
+  } = props;
 
   const {
     sendDevThemeSaveStateData,
@@ -31,8 +37,7 @@ export const ThemeEditor = (props: ThemeEditorProps) => {
     deleteThemeSaveState,
   } = useThemeMessageSenders();
 
-  const { themeData, themeDataFetched, themeSaveState, themeSaveStateFetched } =
-    useThemeMessageReceivers();
+  const { themeSaveState, themeSaveStateFetched } = useThemeMessageReceivers();
 
   const { buildThemeLocalStorageKey, clearThemeLocalStorage } =
     useThemeLocalStorage(templateMetadata);
@@ -194,17 +199,12 @@ export const ThemeEditor = (props: ThemeEditorProps) => {
   }, [themeHistories, themeConfig]);
 
   useEffect(() => {
-    if (!themeSaveStateFetched || !themeDataFetched) {
+    if (!themeSaveStateFetched) {
       return;
     }
     loadPuckInitialHistory();
     loadThemeHistory();
-  }, [
-    templateMetadata,
-    themeSaveStateFetched,
-    themeDataFetched,
-    visualConfigurationData,
-  ]);
+  }, [templateMetadata, themeSaveStateFetched, visualConfigurationData]);
 
   // Log PUCK_INITIAL_HISTORY (layout) on load
   useEffect(() => {
@@ -240,16 +240,12 @@ export const ThemeEditor = (props: ThemeEditorProps) => {
   const isLoading =
     !puckInitialHistoryFetched ||
     !themeHistoryFetched ||
-    !themeDataFetched ||
     !themeSaveStateFetched;
 
   const progress =
     60 + // @ts-expect-error adding bools is fine
-    (puckInitialHistoryFetched +
-      themeHistoryFetched +
-      themeDataFetched +
-      themeSaveStateFetched) *
-      10;
+    (puckInitialHistoryFetched + themeHistoryFetched + themeSaveStateFetched) *
+      13.33;
 
   return !isLoading ? (
     <InternalThemeEditor

--- a/src/internal/hooks/theme/useMessageReceivers.ts
+++ b/src/internal/hooks/theme/useMessageReceivers.ts
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { DevLogger } from "../../../utils/devLogger.ts";
-import { ThemeData, ThemeSaveState } from "../../types/themeData.ts";
-import { jsonFromEscapedJsonString } from "../../utils/jsonFromEscapedJsonString.ts";
+import { ThemeSaveState } from "../../types/themeData.ts";
 import { useReceiveMessage, TARGET_ORIGINS } from "../useMessage.ts";
 import { useCommonMessageSenders } from "../useMessageSenders.ts";
 
@@ -14,10 +13,6 @@ export const useThemeMessageReceivers = () => {
   useEffect(() => {
     iFrameLoaded({ payload: { message: "Theme Editor is loaded" } });
   }, []);
-
-  // Theme from Content
-  const [themeData, setThemeData] = useState<ThemeData>();
-  const [themeDataFetched, setThemeDataFetched] = useState<boolean>(false); // needed because themeData can be empty
 
   // Theme from DB
   const [themeSaveState, setThemeSaveState] = useState<
@@ -36,20 +31,7 @@ export const useThemeMessageReceivers = () => {
     });
   });
 
-  useReceiveMessage("getThemeData", TARGET_ORIGINS, (send, payload) => {
-    const themeData = jsonFromEscapedJsonString(payload as unknown as string);
-    devLogger.logData("THEME_DATA", themeData);
-    setThemeData(themeData as ThemeData);
-    setThemeDataFetched(true);
-    send({
-      status: "success",
-      payload: { message: "getThemeData received" },
-    });
-  });
-
   return {
-    themeData,
-    themeDataFetched,
     themeSaveState,
     themeSaveStateFetched,
   };

--- a/src/internal/hooks/useMessageReceivers.ts
+++ b/src/internal/hooks/useMessageReceivers.ts
@@ -5,6 +5,7 @@ import { DevLogger } from "../../utils/devLogger.ts";
 import { Config, Data } from "@measured/puck";
 import { jsonFromEscapedJsonString } from "../utils/jsonFromEscapedJsonString.ts";
 import { useCommonMessageSenders } from "./useMessageSenders.ts";
+import { ThemeData } from "../types/themeData.ts";
 
 const devLogger = new DevLogger();
 
@@ -27,6 +28,10 @@ export const useCommonMessageReceivers = (
     useState<Data>();
   const [visualConfigurationDataFetched, setVisualConfigurationDataFetched] =
     useState<boolean>(false); // needed because visualConfigurationData can be empty
+
+  // Theme from Content
+  const [themeData, setThemeData] = useState<ThemeData>();
+  const [themeDataFetched, setThemeDataFetched] = useState<boolean>(false); // needed because themeData can be empty
 
   useReceiveMessage("getTemplateMetadata", TARGET_ORIGINS, (send, payload) => {
     const puckConfig = componentRegistry.get(payload.templateId);
@@ -56,9 +61,22 @@ export const useCommonMessageReceivers = (
     }
   );
 
+  useReceiveMessage("getThemeData", TARGET_ORIGINS, (send, payload) => {
+    const themeData = jsonFromEscapedJsonString(payload as unknown as string);
+    devLogger.logData("THEME_DATA", themeData);
+    setThemeData(themeData as ThemeData);
+    setThemeDataFetched(true);
+    send({
+      status: "success",
+      payload: { message: "getThemeData received" },
+    });
+  });
+
   return {
     visualConfigurationData,
     visualConfigurationDataFetched,
+    themeData,
+    themeDataFetched,
     templateMetadata,
     puckConfig,
   };


### PR DESCRIPTION
Passes the themeData from content and applies it when in layoutEditor mode.

This required moving getThemeData to the UniversalReceivers.

This change makes the themes in layout editor update to match the published theme instantly.