### PR TITLE
fix: layout editor no longer requires themeId

### DIFF
--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -95,7 +95,7 @@ export const Editor = ({
     !templateMetadata ||
     !document ||
     !visualConfigurationDataFetched ||
-    !themeDataFetched;
+    (templateMetadata?.themeEntityId && !themeDataFetched);
 
   const progress: number =
     60 * // @ts-expect-error adding bools is fine
@@ -103,7 +103,7 @@ export const Editor = ({
       !!templateMetadata +
       !!document +
       visualConfigurationDataFetched +
-      themeDataFetched) /
+      (themeDataFetched || !templateMetadata?.themeEntityId)) /
       5);
 
   return (

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -95,7 +95,7 @@ export const Editor = ({
     !templateMetadata ||
     !document ||
     !visualConfigurationDataFetched ||
-    (templateMetadata?.themeEntityId && !themeDataFetched);
+    !themeDataFetched;
 
   const progress: number =
     60 * // @ts-expect-error adding bools is fine
@@ -103,7 +103,7 @@ export const Editor = ({
       !!templateMetadata +
       !!document +
       visualConfigurationDataFetched +
-      (themeDataFetched || !templateMetadata?.themeEntityId)) /
+      themeDataFetched) /
       5);
 
   return (

--- a/src/internal/components/LayoutEditor.tsx
+++ b/src/internal/components/LayoutEditor.tsx
@@ -64,7 +64,7 @@ export const LayoutEditor = (props: LayoutEditorProps) => {
    * Apply the themes from Content
    */
   useEffect(() => {
-    if (!themeConfig || !templateMetadata?.themeEntityId) {
+    if (!themeConfig) {
       return;
     }
     const localHistoryArray = window.localStorage.getItem(

--- a/src/internal/components/LayoutEditor.tsx
+++ b/src/internal/components/LayoutEditor.tsx
@@ -64,7 +64,7 @@ export const LayoutEditor = (props: LayoutEditorProps) => {
    * Apply the themes from Content
    */
   useEffect(() => {
-    if (!themeConfig) {
+    if (!themeConfig || !templateMetadata?.themeEntityId) {
       return;
     }
     const localHistoryArray = window.localStorage.getItem(

--- a/src/internal/components/LayoutEditor.tsx
+++ b/src/internal/components/LayoutEditor.tsx
@@ -85,7 +85,7 @@ export const LayoutEditor = (props: LayoutEditorProps) => {
     if (themeData) {
       updateThemeInEditor(themeData as ThemeData, themeConfig);
     }
-  }, [themeData, themeConfig]);
+  }, [themeData, themeConfig, templateMetadata]);
 
   /**
    * Determines the initialHistory to send to Puck. It is based on a combination

--- a/src/internal/hooks/theme/useLocalStorage.ts
+++ b/src/internal/hooks/theme/useLocalStorage.ts
@@ -15,7 +15,7 @@ export const useThemeLocalStorage = (
   templateMetadata: TemplateMetadata | undefined
 ) => {
   const buildThemeLocalStorageKey = useCallback(() => {
-    if (!templateMetadata) {
+    if (!templateMetadata?.themeEntityId) {
       return "";
     }
 

--- a/src/internal/hooks/useMessageReceivers.ts
+++ b/src/internal/hooks/useMessageReceivers.ts
@@ -31,13 +31,7 @@ export const useCommonMessageReceivers = (
 
   // Theme from Content
   const [themeData, setThemeData] = useState<ThemeData>();
-  const [themeDataFetched, setThemeDataFetched] = useState<boolean>(
-    !templateMetadata?.themeEntityId
-  ); // needed because themeData can be empty
-
-  useEffect(() => {
-    setThemeDataFetched(!templateMetadata?.themeEntityId);
-  }, [templateMetadata?.themeEntityId, setThemeDataFetched]);
+  const [themeDataFetched, setThemeDataFetched] = useState<boolean>(false); // needed because themeData can be empty
 
   useReceiveMessage("getTemplateMetadata", TARGET_ORIGINS, (send, payload) => {
     const puckConfig = componentRegistry.get(payload.templateId);

--- a/src/internal/hooks/useMessageReceivers.ts
+++ b/src/internal/hooks/useMessageReceivers.ts
@@ -62,7 +62,10 @@ export const useCommonMessageReceivers = (
   );
 
   useReceiveMessage("getThemeData", TARGET_ORIGINS, (send, payload) => {
-    const themeData = jsonFromEscapedJsonString(payload as unknown as string);
+    const payloadString = payload as unknown as string;
+    const themeData = payloadString
+      ? jsonFromEscapedJsonString(payloadString)
+      : {};
     devLogger.logData("THEME_DATA", themeData);
     setThemeData(themeData as ThemeData);
     setThemeDataFetched(true);

--- a/src/internal/hooks/useMessageReceivers.ts
+++ b/src/internal/hooks/useMessageReceivers.ts
@@ -31,7 +31,13 @@ export const useCommonMessageReceivers = (
 
   // Theme from Content
   const [themeData, setThemeData] = useState<ThemeData>();
-  const [themeDataFetched, setThemeDataFetched] = useState<boolean>(false); // needed because themeData can be empty
+  const [themeDataFetched, setThemeDataFetched] = useState<boolean>(
+    !templateMetadata?.themeEntityId
+  ); // needed because themeData can be empty
+
+  useEffect(() => {
+    setThemeDataFetched(!templateMetadata?.themeEntityId);
+  }, [templateMetadata?.themeEntityId, setThemeDataFetched]);
 
   useReceiveMessage("getTemplateMetadata", TARGET_ORIGINS, (send, payload) => {
     const puckConfig = componentRegistry.get(payload.templateId);


### PR DESCRIPTION
If themeId is not present, it will simply not try to apply the theme from local storage.