### PR TITLE
fix: cannot access before initialization error

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,2 +1,2 @@
-export * from "./puck/index.ts";
 export * from "./editor/index.ts";
+export * from "./puck/index.ts";

--- a/src/components/puck/Address.tsx
+++ b/src/components/puck/Address.tsx
@@ -10,7 +10,6 @@ import {
 import { Section, sectionVariants } from "./atoms/section.js";
 import "@yext/pages-components/style.css";
 import { VariantProps } from "class-variance-authority";
-import { config } from "process";
 import {
   useDocument,
   resolveYextEntityField,
@@ -27,7 +26,7 @@ export type AddressProps = {
 };
 
 const addressFields: Fields<AddressProps> = {
-  address: YextEntityFieldSelector<typeof config, AddressType>({
+  address: YextEntityFieldSelector<any, AddressType>({
     label: "Address",
     filter: { types: ["type.address"] },
   }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export * from "./components/index.ts";
 export * from "./hooks/index.ts";
 export * from "./utils/index.ts";
+export * from "./components/index.ts";


### PR DESCRIPTION
The components were exported before their dependencies, which caused vite to throw an error in the starter.

Also removed `typeof config` from Address.tsx, which was a bad autocompleted import.