### PR TITLE
fix: use constantValue if no entity field is selected

### DIFF
--- a/src/utils/resolveYextEntityField.ts
+++ b/src/utils/resolveYextEntityField.ts
@@ -13,11 +13,8 @@ export const resolveYextEntityField = <T>(
     return undefined;
   }
 
-  if (entityField.constantValueEnabled) {
+  if (entityField.constantValueEnabled || !entityField.field) {
     return entityField.constantValue as T;
-  }
-  if (entityField.field === "") {
-    return undefined;
   }
 
   try {


### PR DESCRIPTION
If no entity field is selected or constantValueEnabled is true, then use the constant value.

Tested on dev account.