### PR TITLE
fix: hide constant value option if not defined

### DIFF
--- a/src/components/editor/YextEntityFieldSelector.tsx
+++ b/src/components/editor/YextEntityFieldSelector.tsx
@@ -38,14 +38,14 @@ const TYPE_TO_CONSTANT_CONFIG: Record<string, Field<any>> = {
 const getConstantConfigFromType = (
   type: EntityFieldTypes,
   isList: boolean
-): Field<any> => {
+): Field<any> | undefined => {
   if (isList) {
     return TEXT_LIST_CONSTANT_CONFIG;
   }
   const constantConfig = TYPE_TO_CONSTANT_CONFIG[type];
   if (!constantConfig) {
     devLogger.log(`No constant configuration for ${type}`);
-    return TEXT_CONSTANT_CONFIG;
+    return;
   }
   return constantConfig;
 };


### PR DESCRIPTION
Hides the constant value option if we don't have a configuration for it defined.
    
For hours, we specifically do not want to allow constant values.
    
Verified that constant value can be chosen for expected types, but not for hours.

