### PR TITLE
fix: dev mode previews don't match puck iframe

### DIFF
--- a/src/internal/components/LayoutEditor.tsx
+++ b/src/internal/components/LayoutEditor.tsx
@@ -11,6 +11,7 @@ import { ThemeData, ThemeHistory } from "../types/themeData.ts";
 import { ThemeConfig } from "../../utils/themeResolver.ts";
 import { updateThemeInEditor } from "../../utils/applyTheme.ts";
 import { useThemeLocalStorage } from "../hooks/theme/useLocalStorage.ts";
+import { useCommonMessageSenders } from "../hooks/useMessageSenders.ts";
 
 const devLogger = new DevLogger();
 
@@ -32,11 +33,13 @@ export const LayoutEditor = (props: LayoutEditorProps) => {
   } = props;
 
   const {
-    sendDevLayoutSaveStateData,
     saveLayoutSaveState,
     publishVisualConfiguration,
     deleteLayoutSaveState,
   } = useLayoutMessageSenders();
+
+  const { sendDevLayoutSaveStateData, sendDevThemeSaveStateData } =
+    useCommonMessageSenders();
 
   const { layoutSaveState, layoutSaveStateFetched } =
     useLayoutMessageReceivers();
@@ -77,6 +80,9 @@ export const LayoutEditor = (props: LayoutEditorProps) => {
       if (localHistories.length > 0) {
         const localThemeData = localHistories[localHistories.length - 1].data;
         devLogger.log("Layout Dev Mode - Using theme data from local storage");
+        sendDevThemeSaveStateData({
+          payload: { devThemeSaveStateData: JSON.stringify(localThemeData) },
+        });
         updateThemeInEditor(localThemeData, themeConfig);
         return;
       }

--- a/src/internal/components/ThemeEditor.tsx
+++ b/src/internal/components/ThemeEditor.tsx
@@ -17,6 +17,7 @@ import { useThemeMessageReceivers } from "../hooks/theme/useMessageReceivers.ts"
 import { LoadingScreen } from "../puck/components/LoadingScreen.tsx";
 import { ThemeHistories, ThemeHistory, ThemeData } from "../types/themeData.ts";
 import { useLayoutLocalStorage } from "../hooks/layout/useLocalStorage.ts";
+import { useCommonMessageSenders } from "../hooks/useMessageSenders.ts";
 
 const devLogger = new DevLogger();
 
@@ -37,8 +38,10 @@ export const ThemeEditor = (props: ThemeEditorProps) => {
     themeConfig,
   } = props;
 
+  const { sendDevLayoutSaveStateData, sendDevThemeSaveStateData } =
+    useCommonMessageSenders();
+
   const {
-    sendDevThemeSaveStateData,
     saveThemeSaveState,
     publishThemeConfiguration,
     deleteThemeSaveState,
@@ -91,6 +94,12 @@ export const ThemeEditor = (props: ThemeEditorProps) => {
           }),
           index: localHistoryIndex,
           appendData: false,
+        });
+        const layoutToSend =
+          puckInitialHistory?.histories[puckInitialHistory.histories.length - 1]
+            .state.data;
+        sendDevLayoutSaveStateData({
+          payload: { devSaveStateData: JSON.stringify(layoutToSend) },
         });
       }
       setPuckInitialHistoryFetched(true);

--- a/src/internal/hooks/layout/useMessageSenders.ts
+++ b/src/internal/hooks/layout/useMessageSenders.ts
@@ -16,15 +16,9 @@ export const useLayoutMessageSenders = () => {
     TARGET_ORIGINS
   );
 
-  const { sendToParent: sendDevLayoutSaveStateData } = useSendMessageToParent(
-    "sendDevSaveStateData",
-    TARGET_ORIGINS
-  );
-
   return {
     saveLayoutSaveState,
     deleteLayoutSaveState,
     publishVisualConfiguration,
-    sendDevLayoutSaveStateData,
   };
 };

--- a/src/internal/hooks/theme/useMessageSenders.ts
+++ b/src/internal/hooks/theme/useMessageSenders.ts
@@ -16,15 +16,9 @@ export const useThemeMessageSenders = () => {
     TARGET_ORIGINS
   );
 
-  const { sendToParent: sendDevThemeSaveStateData } = useSendMessageToParent(
-    "sendDevThemeSaveStateData",
-    TARGET_ORIGINS
-  );
-
   return {
     saveThemeSaveState,
     deleteThemeSaveState,
     publishThemeConfiguration,
-    sendDevThemeSaveStateData,
   };
 };

--- a/src/internal/hooks/useMessageSenders.ts
+++ b/src/internal/hooks/useMessageSenders.ts
@@ -16,9 +16,21 @@ export const useCommonMessageSenders = () => {
     TARGET_ORIGINS
   );
 
+  const { sendToParent: sendDevLayoutSaveStateData } = useSendMessageToParent(
+    "sendDevSaveStateData",
+    TARGET_ORIGINS
+  );
+
+  const { sendToParent: sendDevThemeSaveStateData } = useSendMessageToParent(
+    "sendDevThemeSaveStateData",
+    TARGET_ORIGINS
+  );
+
   return {
     iFrameLoaded,
     pushPageSets,
     openQuickFind,
+    sendDevLayoutSaveStateData,
+    sendDevThemeSaveStateData,
   };
 };


### PR DESCRIPTION
We're now sharing the local save state between theme and layout dev mode, but dev previews were not set up to receive both so the generated preview did not match the iframe preview.

Together with https://gerrit.yext.com/c/alpha/+/276311
