### PR TITLE
refactor: update save state receivers

### DIFF
--- a/src/internal/hooks/layout/useMessageReceivers.ts
+++ b/src/internal/hooks/layout/useMessageReceivers.ts
@@ -22,7 +22,7 @@ export const useLayoutMessageReceivers = () => {
 
   useReceiveMessage("getLayoutSaveState", TARGET_ORIGINS, (send, payload) => {
     let receivedLayoutSaveState;
-    if (payload && payload.history) {
+    if (payload?.history) {
       receivedLayoutSaveState = {
         hash: payload.hash,
         history: jsonFromEscapedJsonString(payload.history),

--- a/src/internal/hooks/layout/useMessageReceivers.ts
+++ b/src/internal/hooks/layout/useMessageReceivers.ts
@@ -20,18 +20,21 @@ export const useLayoutMessageReceivers = () => {
   const [layoutSaveStateFetched, setLayoutSaveStateFetched] =
     useState<boolean>(false); // needed because saveState can be empty
 
-  useReceiveMessage("getSaveState", TARGET_ORIGINS, (send, payload) => {
-    let layoutSaveState;
-    if (payload) {
-      layoutSaveState = {
-        ...payload,
+  useReceiveMessage("getLayoutSaveState", TARGET_ORIGINS, (send, payload) => {
+    let receivedLayoutSaveState;
+    if (payload && payload.history) {
+      receivedLayoutSaveState = {
+        hash: payload.hash,
         history: jsonFromEscapedJsonString(payload.history),
       } as LayoutSaveState;
     }
-    devLogger.logData("SAVE_STATE", layoutSaveState);
-    setLayoutSaveState(layoutSaveState);
+    devLogger.logData("LAYOUT_SAVE_STATE", receivedLayoutSaveState);
+    setLayoutSaveState(receivedLayoutSaveState);
     setLayoutSaveStateFetched(true);
-    send({ status: "success", payload: { message: "saveState received" } });
+    send({
+      status: "success",
+      payload: { message: "layoutSaveState received" },
+    });
   });
 
   return {

--- a/src/internal/hooks/theme/useMessageReceivers.ts
+++ b/src/internal/hooks/theme/useMessageReceivers.ts
@@ -22,8 +22,15 @@ export const useThemeMessageReceivers = () => {
     useState<boolean>(false); // needed because themeSaveState can be empty
 
   useReceiveMessage("getThemeSaveState", TARGET_ORIGINS, (send, payload) => {
-    devLogger.logData("THEME_SAVE_STATE", payload);
-    setThemeSaveState(payload as ThemeSaveState);
+    let receivedThemeSaveState;
+    if (payload && payload.history) {
+      receivedThemeSaveState = {
+        hash: payload.hash,
+        history: payload.history,
+      } as ThemeSaveState;
+    }
+    devLogger.logData("THEME_SAVE_STATE", receivedThemeSaveState);
+    setThemeSaveState(receivedThemeSaveState);
     setThemeSaveStateFetched(true);
     send({
       status: "success",

--- a/src/internal/hooks/theme/useMessageReceivers.ts
+++ b/src/internal/hooks/theme/useMessageReceivers.ts
@@ -3,6 +3,7 @@ import { DevLogger } from "../../../utils/devLogger.ts";
 import { ThemeSaveState } from "../../types/themeData.ts";
 import { useReceiveMessage, TARGET_ORIGINS } from "../useMessage.ts";
 import { useCommonMessageSenders } from "../useMessageSenders.ts";
+import { jsonFromEscapedJsonString } from "../../utils/jsonFromEscapedJsonString.ts";
 
 const devLogger = new DevLogger();
 
@@ -26,7 +27,7 @@ export const useThemeMessageReceivers = () => {
     if (payload && payload.history) {
       receivedThemeSaveState = {
         hash: payload.hash,
-        history: payload.history,
+        history: jsonFromEscapedJsonString(payload.history),
       } as ThemeSaveState;
     }
     devLogger.logData("THEME_SAVE_STATE", receivedThemeSaveState);

--- a/src/internal/hooks/theme/useMessageReceivers.ts
+++ b/src/internal/hooks/theme/useMessageReceivers.ts
@@ -24,7 +24,7 @@ export const useThemeMessageReceivers = () => {
 
   useReceiveMessage("getThemeSaveState", TARGET_ORIGINS, (send, payload) => {
     let receivedThemeSaveState;
-    if (payload && payload.history) {
+    if (payload?.history) {
       receivedThemeSaveState = {
         hash: payload.hash,
         history: jsonFromEscapedJsonString(payload.history),

--- a/src/utils/devLogger.ts
+++ b/src/utils/devLogger.ts
@@ -1,7 +1,7 @@
 export type DevLoggerPrefix =
   | "TEMPLATE_METADATA"
   | "PUCK_CONFIG"
-  | "SAVE_STATE"
+  | "LAYOUT_SAVE_STATE"
   | "THEME_SAVE_STATE"
   | "VISUAL_CONFIGURATION_DATA"
   | "THEME_DATA"


### PR DESCRIPTION
The new data structure is that the save state always exists for a layout, but the history is null/"" if we should just be using the published data.

Also standardizes the theme/layout save state receivers.
