### PR TITLE
refactor: rename messengers

### DIFF
--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -36,8 +36,8 @@ export const Editor = ({
   const {
     templateMetadata,
     puckConfig,
-    visualConfigurationData,
-    visualConfigurationDataFetched,
+    layoutData,
+    layoutDataFetched,
     themeData,
     themeDataFetched,
   } = useCommonMessageReceivers(componentRegistry);
@@ -94,7 +94,7 @@ export const Editor = ({
     !puckConfig ||
     !templateMetadata ||
     !document ||
-    !visualConfigurationDataFetched ||
+    !layoutDataFetched ||
     !themeDataFetched;
 
   const progress: number =
@@ -102,7 +102,7 @@ export const Editor = ({
     ((!!puckConfig +
       !!templateMetadata +
       !!document +
-      visualConfigurationDataFetched +
+      layoutDataFetched +
       themeDataFetched) /
       5);
 
@@ -113,7 +113,7 @@ export const Editor = ({
           <ThemeEditor
             puckConfig={puckConfig}
             templateMetadata={templateMetadata}
-            visualConfigurationData={visualConfigurationData!}
+            layoutData={layoutData!}
             themeData={themeData!}
             themeConfig={themeConfig}
           />
@@ -121,7 +121,7 @@ export const Editor = ({
           <LayoutEditor
             puckConfig={puckConfig}
             templateMetadata={templateMetadata}
-            visualConfigurationData={visualConfigurationData!}
+            layoutData={layoutData!}
             themeData={themeData!}
             themeConfig={themeConfig}
           />

--- a/src/internal/components/InternalLayoutEditor.tsx
+++ b/src/internal/components/InternalLayoutEditor.tsx
@@ -24,7 +24,7 @@ type InternalLayoutEditorProps = {
   templateMetadata: TemplateMetadata;
   layoutSaveState: LayoutSaveState | undefined;
   saveLayoutSaveState: (data: any) => void;
-  publishVisualConfiguration: (data: any) => void;
+  publishLayoutConfiguration: (data: any) => void;
   sendDevSaveStateData: (data: any) => void;
   buildVisualConfigLocalStorageKey: () => string;
 };
@@ -38,7 +38,7 @@ export const InternalLayoutEditor = ({
   templateMetadata,
   layoutSaveState,
   saveLayoutSaveState,
-  publishVisualConfiguration,
+  publishLayoutConfiguration,
   sendDevSaveStateData,
   buildVisualConfigLocalStorageKey,
 }: InternalLayoutEditorProps) => {
@@ -96,8 +96,8 @@ export const InternalLayoutEditor = ({
   };
 
   const handlePublishLayout = async (data: Data) => {
-    publishVisualConfiguration({
-      payload: { visualConfigurationData: JSON.stringify(data) },
+    publishLayoutConfiguration({
+      payload: { layoutData: JSON.stringify(data) },
     });
   };
 

--- a/src/internal/components/InternalLayoutEditor.tsx
+++ b/src/internal/components/InternalLayoutEditor.tsx
@@ -24,7 +24,7 @@ type InternalLayoutEditorProps = {
   templateMetadata: TemplateMetadata;
   layoutSaveState: LayoutSaveState | undefined;
   saveLayoutSaveState: (data: any) => void;
-  publishLayoutConfiguration: (data: any) => void;
+  publishLayout: (data: any) => void;
   sendDevSaveStateData: (data: any) => void;
   buildVisualConfigLocalStorageKey: () => string;
 };
@@ -38,7 +38,7 @@ export const InternalLayoutEditor = ({
   templateMetadata,
   layoutSaveState,
   saveLayoutSaveState,
-  publishLayoutConfiguration,
+  publishLayout,
   sendDevSaveStateData,
   buildVisualConfigLocalStorageKey,
 }: InternalLayoutEditorProps) => {
@@ -96,7 +96,7 @@ export const InternalLayoutEditor = ({
   };
 
   const handlePublishLayout = async (data: Data) => {
-    publishLayoutConfiguration({
+    publishLayout({
       payload: { layoutData: JSON.stringify(data) },
     });
   };

--- a/src/internal/components/InternalThemeEditor.tsx
+++ b/src/internal/components/InternalThemeEditor.tsx
@@ -19,7 +19,7 @@ type InternalThemeEditorProps = {
   puckInitialHistory: InitialHistory | undefined;
   isLoading: boolean;
   templateMetadata: TemplateMetadata;
-  publishThemeConfiguration: (data: any) => void;
+  publishTheme: (data: any) => void;
   themeConfig?: ThemeConfig;
   saveThemeSaveState: (data: any) => void;
   themeHistories?: ThemeHistories;
@@ -35,7 +35,7 @@ export const InternalThemeEditor = ({
   puckInitialHistory,
   isLoading,
   templateMetadata,
-  publishThemeConfiguration,
+  publishTheme,
   themeConfig,
   saveThemeSaveState,
   themeHistories,
@@ -59,7 +59,7 @@ export const InternalThemeEditor = ({
 
     const currentThemeHistory = themeHistories.histories[themeHistories.index];
 
-    publishThemeConfiguration({
+    publishTheme({
       payload: {
         saveThemeData: JSON.stringify(currentThemeHistory.data),
       },

--- a/src/internal/components/LayoutEditor.tsx
+++ b/src/internal/components/LayoutEditor.tsx
@@ -18,23 +18,18 @@ const devLogger = new DevLogger();
 type LayoutEditorProps = {
   puckConfig: Config;
   templateMetadata: TemplateMetadata;
-  visualConfigurationData: Data;
+  layoutData: Data;
   themeData: ThemeData;
   themeConfig: ThemeConfig | undefined;
 };
 
 export const LayoutEditor = (props: LayoutEditorProps) => {
-  const {
-    puckConfig,
-    templateMetadata,
-    visualConfigurationData,
-    themeData,
-    themeConfig,
-  } = props;
+  const { puckConfig, templateMetadata, layoutData, themeData, themeConfig } =
+    props;
 
   const {
     saveLayoutSaveState,
-    publishVisualConfiguration,
+    publishLayoutConfiguration,
     deleteLayoutSaveState,
   } = useLayoutMessageSenders();
 
@@ -136,9 +131,9 @@ export const LayoutEditor = (props: LayoutEditorProps) => {
       devLogger.log(
         "Layout Dev Mode - No localStorage. Using layout data from Content"
       );
-      if (visualConfigurationData) {
+      if (layoutData) {
         setPuckInitialHistory({
-          histories: [{ id: "root", state: { data: visualConfigurationData } }],
+          histories: [{ id: "root", state: { data: layoutData } }],
           appendData: false,
         });
       }
@@ -154,9 +149,9 @@ export const LayoutEditor = (props: LayoutEditorProps) => {
       devLogger.log(
         "Layout Prod Mode - No saveState. Using layout data from Content"
       );
-      if (visualConfigurationData) {
+      if (layoutData) {
         setPuckInitialHistory({
-          histories: [{ id: "root", state: { data: visualConfigurationData } }],
+          histories: [{ id: "root", state: { data: layoutData } }],
           appendData: false,
         });
       }
@@ -176,9 +171,9 @@ export const LayoutEditor = (props: LayoutEditorProps) => {
         "Layout Prod Mode - No localStorage. Using layout saveState"
       );
       setPuckInitialHistory({
-        histories: visualConfigurationData
+        histories: layoutData
           ? [
-              { id: "root", state: { data: visualConfigurationData } },
+              { id: "root", state: { data: layoutData } },
               {
                 id: layoutSaveState.hash,
                 state: { data: layoutSaveState.history.data },
@@ -190,7 +185,7 @@ export const LayoutEditor = (props: LayoutEditorProps) => {
                 state: { data: layoutSaveState.history.data },
               },
             ],
-        index: visualConfigurationData ? 1 : 0,
+        index: layoutData ? 1 : 0,
         appendData: false,
       });
       setPuckInitialHistoryFetched(true);
@@ -268,7 +263,7 @@ export const LayoutEditor = (props: LayoutEditorProps) => {
       templateMetadata={templateMetadata}
       layoutSaveState={layoutSaveState}
       saveLayoutSaveState={saveLayoutSaveState}
-      publishVisualConfiguration={publishVisualConfiguration}
+      publishLayoutConfiguration={publishLayoutConfiguration}
       sendDevSaveStateData={sendDevLayoutSaveStateData}
       buildVisualConfigLocalStorageKey={buildVisualConfigLocalStorageKey}
     />

--- a/src/internal/components/LayoutEditor.tsx
+++ b/src/internal/components/LayoutEditor.tsx
@@ -27,11 +27,8 @@ export const LayoutEditor = (props: LayoutEditorProps) => {
   const { puckConfig, templateMetadata, layoutData, themeData, themeConfig } =
     props;
 
-  const {
-    saveLayoutSaveState,
-    publishLayoutConfiguration,
-    deleteLayoutSaveState,
-  } = useLayoutMessageSenders();
+  const { saveLayoutSaveState, publishLayout, deleteLayoutSaveState } =
+    useLayoutMessageSenders();
 
   const { sendDevLayoutSaveStateData, sendDevThemeSaveStateData } =
     useCommonMessageSenders();
@@ -263,7 +260,7 @@ export const LayoutEditor = (props: LayoutEditorProps) => {
       templateMetadata={templateMetadata}
       layoutSaveState={layoutSaveState}
       saveLayoutSaveState={saveLayoutSaveState}
-      publishLayoutConfiguration={publishLayoutConfiguration}
+      publishLayout={publishLayout}
       sendDevSaveStateData={sendDevLayoutSaveStateData}
       buildVisualConfigLocalStorageKey={buildVisualConfigLocalStorageKey}
     />

--- a/src/internal/components/ThemeEditor.tsx
+++ b/src/internal/components/ThemeEditor.tsx
@@ -36,11 +36,8 @@ export const ThemeEditor = (props: ThemeEditorProps) => {
   const { sendDevLayoutSaveStateData, sendDevThemeSaveStateData } =
     useCommonMessageSenders();
 
-  const {
-    saveThemeSaveState,
-    publishThemeConfiguration,
-    deleteThemeSaveState,
-  } = useThemeMessageSenders();
+  const { saveThemeSaveState, publishTheme, deleteThemeSaveState } =
+    useThemeMessageSenders();
 
   const { themeSaveState, themeSaveStateFetched } = useThemeMessageReceivers();
 
@@ -287,7 +284,7 @@ export const ThemeEditor = (props: ThemeEditorProps) => {
       puckInitialHistory={puckInitialHistory}
       isLoading={isLoading}
       templateMetadata={templateMetadata}
-      publishThemeConfiguration={publishThemeConfiguration}
+      publishTheme={publishTheme}
       themeConfig={themeConfig}
       saveThemeSaveState={saveThemeSaveState}
       themeHistories={themeHistories}

--- a/src/internal/components/ThemeEditor.tsx
+++ b/src/internal/components/ThemeEditor.tsx
@@ -24,19 +24,14 @@ const devLogger = new DevLogger();
 type ThemeEditorProps = {
   puckConfig: Config;
   templateMetadata: TemplateMetadata;
-  visualConfigurationData: Data;
+  layoutData: Data;
   themeData: ThemeData;
   themeConfig: ThemeConfig | undefined;
 };
 
 export const ThemeEditor = (props: ThemeEditorProps) => {
-  const {
-    puckConfig,
-    templateMetadata,
-    visualConfigurationData,
-    themeData,
-    themeConfig,
-  } = props;
+  const { puckConfig, templateMetadata, layoutData, themeData, themeConfig } =
+    props;
 
   const { sendDevLayoutSaveStateData, sendDevThemeSaveStateData } =
     useCommonMessageSenders();
@@ -107,19 +102,15 @@ export const ThemeEditor = (props: ThemeEditorProps) => {
     }
 
     // Only load Content data for theme mode
-    if (visualConfigurationData) {
+    if (layoutData) {
       setPuckInitialHistory({
-        histories: [{ id: "root", state: { data: visualConfigurationData } }],
+        histories: [{ id: "root", state: { data: layoutData } }],
         appendData: false,
       });
     }
 
     setPuckInitialHistoryFetched(true);
-  }, [
-    setPuckInitialHistory,
-    setPuckInitialHistoryFetched,
-    visualConfigurationData,
-  ]);
+  }, [setPuckInitialHistory, setPuckInitialHistoryFetched, layoutData]);
 
   /*
    * Determines the initial theme data to send to the editor.
@@ -247,7 +238,7 @@ export const ThemeEditor = (props: ThemeEditorProps) => {
     }
     loadPuckInitialHistory();
     loadThemeHistory();
-  }, [templateMetadata, themeSaveStateFetched, visualConfigurationData]);
+  }, [templateMetadata, themeSaveStateFetched, layoutData]);
 
   // Log PUCK_INITIAL_HISTORY (layout) on load
   useEffect(() => {

--- a/src/internal/hooks/layout/useMessageSenders.ts
+++ b/src/internal/hooks/layout/useMessageSenders.ts
@@ -11,14 +11,14 @@ export const useLayoutMessageSenders = () => {
     TARGET_ORIGINS
   );
 
-  const { sendToParent: publishLayoutConfiguration } = useSendMessageToParent(
-    "publishLayoutConfiguration",
+  const { sendToParent: publishLayout } = useSendMessageToParent(
+    "publishLayout",
     TARGET_ORIGINS
   );
 
   return {
     saveLayoutSaveState,
     deleteLayoutSaveState,
-    publishLayoutConfiguration,
+    publishLayout,
   };
 };

--- a/src/internal/hooks/layout/useMessageSenders.ts
+++ b/src/internal/hooks/layout/useMessageSenders.ts
@@ -2,23 +2,23 @@ import { TARGET_ORIGINS, useSendMessageToParent } from "../useMessage.ts";
 
 export const useLayoutMessageSenders = () => {
   const { sendToParent: saveLayoutSaveState } = useSendMessageToParent(
-    "saveSaveState",
+    "saveLayoutSaveState",
     TARGET_ORIGINS
   );
 
   const { sendToParent: deleteLayoutSaveState } = useSendMessageToParent(
-    "deleteSaveState",
+    "deleteLayoutSaveState",
     TARGET_ORIGINS
   );
 
-  const { sendToParent: publishVisualConfiguration } = useSendMessageToParent(
-    "saveVisualConfigData",
+  const { sendToParent: publishLayoutConfiguration } = useSendMessageToParent(
+    "publishLayoutConfiguration",
     TARGET_ORIGINS
   );
 
   return {
     saveLayoutSaveState,
     deleteLayoutSaveState,
-    publishVisualConfiguration,
+    publishLayoutConfiguration,
   };
 };

--- a/src/internal/hooks/theme/useMessageSenders.ts
+++ b/src/internal/hooks/theme/useMessageSenders.ts
@@ -11,14 +11,14 @@ export const useThemeMessageSenders = () => {
     TARGET_ORIGINS
   );
 
-  const { sendToParent: publishThemeConfiguration } = useSendMessageToParent(
-    "publishThemeConfiguration",
+  const { sendToParent: publishTheme } = useSendMessageToParent(
+    "publishTheme",
     TARGET_ORIGINS
   );
 
   return {
     saveThemeSaveState,
     deleteThemeSaveState,
-    publishThemeConfiguration,
+    publishTheme,
   };
 };

--- a/src/internal/hooks/theme/useMessageSenders.ts
+++ b/src/internal/hooks/theme/useMessageSenders.ts
@@ -12,7 +12,7 @@ export const useThemeMessageSenders = () => {
   );
 
   const { sendToParent: publishThemeConfiguration } = useSendMessageToParent(
-    "saveThemeData",
+    "publishThemeConfiguration",
     TARGET_ORIGINS
   );
 

--- a/src/internal/hooks/useMessageReceivers.ts
+++ b/src/internal/hooks/useMessageReceivers.ts
@@ -24,10 +24,8 @@ export const useCommonMessageReceivers = (
   const [puckConfig, setPuckConfig] = useState<Config>();
 
   // Layout from Content
-  const [visualConfigurationData, setVisualConfigurationData] =
-    useState<Data>();
-  const [visualConfigurationDataFetched, setVisualConfigurationDataFetched] =
-    useState<boolean>(false); // needed because visualConfigurationData can be empty
+  const [layoutData, setLayoutData] = useState<Data>();
+  const [layoutDataFetched, setLayoutDataFetched] = useState<boolean>(false); // needed because layoutData can be empty
 
   // Theme from Content
   const [themeData, setThemeData] = useState<ThemeData>();
@@ -44,22 +42,16 @@ export const useCommonMessageReceivers = (
     send({ status: "success", payload: { message: "payload received" } });
   });
 
-  useReceiveMessage(
-    "getVisualConfigurationData",
-    TARGET_ORIGINS,
-    (send, payload) => {
-      const vcd = jsonFromEscapedJsonString(
-        payload.visualConfigurationData
-      ) as Data;
-      devLogger.logData("VISUAL_CONFIGURATION_DATA", vcd);
-      setVisualConfigurationData(vcd);
-      setVisualConfigurationDataFetched(true);
-      send({
-        status: "success",
-        payload: { message: "getVisualConfigurationData received" },
-      });
-    }
-  );
+  useReceiveMessage("getLayoutData", TARGET_ORIGINS, (send, payload) => {
+    const data = jsonFromEscapedJsonString(payload.layoutData) as Data;
+    devLogger.logData("LAYOUT_DATA", data);
+    setLayoutData(data);
+    setLayoutDataFetched(true);
+    send({
+      status: "success",
+      payload: { message: "getLayoutData received" },
+    });
+  });
 
   useReceiveMessage("getThemeData", TARGET_ORIGINS, (send, payload) => {
     const payloadString = payload as unknown as string;
@@ -76,8 +68,8 @@ export const useCommonMessageReceivers = (
   });
 
   return {
-    visualConfigurationData,
-    visualConfigurationDataFetched,
+    layoutData,
+    layoutDataFetched,
     themeData,
     themeDataFetched,
     templateMetadata,

--- a/src/internal/hooks/useMessageSenders.ts
+++ b/src/internal/hooks/useMessageSenders.ts
@@ -17,7 +17,7 @@ export const useCommonMessageSenders = () => {
   );
 
   const { sendToParent: sendDevLayoutSaveStateData } = useSendMessageToParent(
-    "sendDevSaveStateData",
+    "sendDevLayoutSaveStateData",
     TARGET_ORIGINS
   );
 

--- a/src/utils/devLogger.ts
+++ b/src/utils/devLogger.ts
@@ -3,7 +3,7 @@ export type DevLoggerPrefix =
   | "PUCK_CONFIG"
   | "LAYOUT_SAVE_STATE"
   | "THEME_SAVE_STATE"
-  | "VISUAL_CONFIGURATION_DATA"
+  | "LAYOUT_DATA"
   | "THEME_DATA"
   | "THEME_HISTORIES"
   | "DOCUMENT"


### PR DESCRIPTION
While we are doing breaking changes, we might as well update the message names that were created pre-themes, which can be confusing.

https://gerrit.yext.com/c/alpha/+/278839
