### PR TITLE
fix: header links fail build

### DIFF
--- a/src/internal/utils/getFilteredEntityFields.ts
+++ b/src/internal/utils/getFilteredEntityFields.ts
@@ -44,13 +44,7 @@ export type EntityFieldTypes =
   | "type.cta"
   | `c_${string}`;
 
-const DEFAULT_DISALLOWED_ENTITY_FIELDS = [
-  "uid",
-  "meta",
-  "slug",
-  "c_visualConfigurations",
-  "c_pages_layouts",
-];
+const DEFAULT_DISALLOWED_ENTITY_FIELDS = ["uid", "meta", "slug"];
 
 // Populate this with fields that aren't allowed to have subfields.
 const TOP_LEVEL_ONLY_FIELD_TYPES: string[] = [];


### PR DESCRIPTION
Calling uuid at build time was causing an error, this only uses uuid at runtime and has better handling of link duplication.