### PR TITLE
fix: entityField Wrapper

### DIFF
--- a/src/components/editor/EntityField.tsx
+++ b/src/components/editor/EntityField.tsx
@@ -23,7 +23,7 @@ export const EntityField = ({
 }: EntityFieldProps) => {
   const { tooltipsVisible } = useEntityField();
 
-  if (!tooltipsVisible) {
+  if (!tooltipsVisible || constantValueEnabled) {
     return children;
   }
 
@@ -39,7 +39,7 @@ export const EntityField = ({
   return (
     <div>
       <TooltipProvider>
-        <Tooltip open={!!tooltipContent && !constantValueEnabled}>
+        <Tooltip open={!!tooltipContent}>
           <TooltipTrigger asChild>
             <div className="ve-outline-2 ve-outline-dotted ve-outline-[#5A58F2]">
               {children}

--- a/src/components/puck/Address.tsx
+++ b/src/components/puck/Address.tsx
@@ -83,9 +83,8 @@ const Address = ({
         <div>
           <EntityField
             displayName="Address"
-            fieldId={
-              addressField.constantValueEnabled ? "constant value" : "address"
-            }
+            fieldId="address"
+            constantValueEnabled={addressField.constantValueEnabled}
           >
             <RenderAddress
               address={address as AddressType}

--- a/src/components/puck/Address.tsx
+++ b/src/components/puck/Address.tsx
@@ -83,7 +83,7 @@ const Address = ({
         <div>
           <EntityField
             displayName="Address"
-            fieldId="address"
+            fieldId={addressField.field}
             constantValueEnabled={addressField.constantValueEnabled}
           >
             <RenderAddress

--- a/src/components/puck/BodyText.tsx
+++ b/src/components/puck/BodyText.tsx
@@ -22,7 +22,8 @@ const BodyText = React.forwardRef<HTMLParagraphElement, BodyTextProps>(
     return (
       <EntityField
         displayName="Body"
-        fieldId={text.constantValueEnabled ? "constant value" : text.field}
+        fieldId={text.field}
+        constantValueEnabled={text.constantValueEnabled}
       >
         <Body ref={ref} {...bodyProps}>
           {resolveYextEntityField(document, text)}

--- a/src/components/puck/Card.tsx
+++ b/src/components/puck/Card.tsx
@@ -260,23 +260,29 @@ const CardWrapper = ({
         )}
       >
         {resolvedImage && (
-          <EntityField displayName="Image" fieldId={image.image.field}>
-            <div
-              className={themeMangerCn(
-                imageWrapperVariants({
-                  size: image.size,
-                  rounded: image.rounded,
-                  aspectRatio: image.aspectRatio,
-                }),
-                "overflow-hidden"
-              )}
+          <div className="w-full">
+            <EntityField
+              displayName="Image"
+              fieldId={image.image.field}
+              constantValueEnabled={image.image.constantValueEnabled}
             >
-              <Image
-                image={resolvedImage}
-                className="w-full h-full object-cover"
-              />
-            </div>
-          </EntityField>
+              <div
+                className={themeMangerCn(
+                  imageWrapperVariants({
+                    size: image.size,
+                    rounded: image.rounded,
+                    aspectRatio: image.aspectRatio,
+                  }),
+                  "overflow-hidden"
+                )}
+              >
+                <Image
+                  image={resolvedImage}
+                  className="w-full h-full object-cover"
+                />
+              </div>
+            </EntityField>
+          </div>
         )}
         <div className="flex flex-col justify-center gap-y-4 md:gap-y-8 p-4 md:px-16 md:py-0 w-full break-all">
           {heading?.text && (

--- a/src/components/puck/CtaWrapper.tsx
+++ b/src/components/puck/CtaWrapper.tsx
@@ -71,9 +71,8 @@ const CTAWrapper: React.FC<CTAWrapperProps> = ({
   return (
     <EntityField
       displayName="CTA"
-      fieldId={
-        entityField.constantValueEnabled ? "constant value" : entityField.field
-      }
+      fieldId={entityField.field}
+      constantValueEnabled={entityField.constantValueEnabled}
     >
       <CTA
         label={cta?.label}

--- a/src/components/puck/Emails.tsx
+++ b/src/components/puck/Emails.tsx
@@ -137,12 +137,12 @@ const Emails: React.FC<EmailsProps> = ({
     resolvedEmailList = [resolvedEmailList];
   }
 
-  if (resolvedEmailList?.length === 0) {
-    return <></>;
-  }
-
   return (
-    <EntityField displayName="Email List" fieldId={emailListField.field}>
+    <EntityField
+      displayName="Email List"
+      fieldId={emailListField.field}
+      constantValueEnabled={emailListField.constantValueEnabled}
+    >
       <ul
         className={themeMangerCn(
           "components",

--- a/src/components/puck/Emails.tsx
+++ b/src/components/puck/Emails.tsx
@@ -137,6 +137,10 @@ const Emails: React.FC<EmailsProps> = ({
     resolvedEmailList = [resolvedEmailList];
   }
 
+  if (resolvedEmailList?.length === 0) {
+    return <></>;
+  }
+
   return (
     <EntityField displayName="Email List" fieldId={emailListField.field}>
       <ul

--- a/src/components/puck/HeadingText.tsx
+++ b/src/components/puck/HeadingText.tsx
@@ -22,7 +22,8 @@ const HeadingText = React.forwardRef<HTMLHeadingElement, HeadingTextProps>(
     return (
       <EntityField
         displayName={"Heading " + headingProps.level}
-        fieldId={text.constantValueEnabled ? "constant value" : text.field}
+        fieldId={text.field}
+        constantValueEnabled={text.constantValueEnabled}
       >
         <Heading ref={ref} {...headingProps}>
           {resolveYextEntityField(document, text)}

--- a/src/components/puck/HoursStatus.tsx
+++ b/src/components/puck/HoursStatus.tsx
@@ -76,7 +76,11 @@ const HoursStatusWrapper: React.FC<HoursStatusProps> = ({
   }
 
   return (
-    <EntityField displayName="Hours" fieldId={hoursField.field}>
+    <EntityField
+      displayName="Hours"
+      fieldId={hoursField.field}
+      constantValueEnabled={hoursField.constantValueEnabled}
+    >
       <HoursStatus
         hours={hours}
         className={themeMangerCn(

--- a/src/components/puck/HoursTable.tsx
+++ b/src/components/puck/HoursTable.tsx
@@ -100,7 +100,11 @@ const VisualEditorHoursTable = ({
     >
       <div>
         {hours && (
-          <EntityField displayName="Hours" fieldId="hours">
+          <EntityField
+            displayName="Hours"
+            fieldId="hours"
+            constantValueEnabled={hoursField.constantValueEnabled}
+          >
             <HoursTable
               hours={hours}
               startOfWeek={startOfWeek}

--- a/src/components/puck/Image.tsx
+++ b/src/components/puck/Image.tsx
@@ -103,7 +103,11 @@ const ImageWrapper: React.FC<ImageWrapperProps> = ({
   }
 
   return (
-    <EntityField displayName="Image" fieldId={imageField.field}>
+    <EntityField
+      displayName="Image"
+      fieldId={imageField.field}
+      constantValueEnabled={imageField.constantValueEnabled}
+    >
       <div
         className={themeMangerCn(
           imageWrapperVariants({ size, aspectRatio, rounded }),

--- a/src/components/puck/Phone.tsx
+++ b/src/components/puck/Phone.tsx
@@ -126,7 +126,11 @@ const Phone: React.FC<PhoneProps> = ({ phone, format, fontWeight, color }) => {
   }
 
   return (
-    <EntityField displayName="Phone" fieldId={phone.field}>
+    <EntityField
+      displayName="Phone"
+      fieldId={phone.field}
+      constantValueEnabled={phone.constantValueEnabled}
+    >
       <p className={phoneVariants({ fontWeight, color })}>
         <PhoneIcon className="w-4 h-4" />
         {formatPhoneNumber(resolvedPhone, format)}

--- a/src/components/puck/Promo.tsx
+++ b/src/components/puck/Promo.tsx
@@ -217,7 +217,11 @@ const PromoWrapper: React.FC<PromoProps> = ({
         )}
       >
         {resolvedImage && (
-          <EntityField displayName="Image" fieldId={image.image.field}>
+          <EntityField
+            displayName="Image"
+            fieldId={image.image.field}
+            constantValueEnabled={image.image.constantValueEnabled}
+          >
             <div
               className={themeMangerCn(
                 imageWrapperVariants({

--- a/src/components/puck/TextList.tsx
+++ b/src/components/puck/TextList.tsx
@@ -119,7 +119,11 @@ const TextList: React.FC<TextListProps> = ({
   }
 
   return (
-    <EntityField displayName="Text List" fieldId={textListField.field}>
+    <EntityField
+      displayName="Text List"
+      fieldId={textListField.field}
+      constantValueEnabled={textListField.constantValueEnabled}
+    >
       <ul
         className={textListVariants({
           padding,


### PR DESCRIPTION
On empty entityField, keep tooltip

On constant, don't show any tooltip. 

Within Card component, when EntityField is toggled, no changes to sizing 