### PR TITLE
fix: reset border radius

### DIFF
--- a/src/internal/puck/ui/Tooltip.tsx
+++ b/src/internal/puck/ui/Tooltip.tsx
@@ -18,7 +18,7 @@ const TooltipContent = React.forwardRef<
     ref={ref}
     sideOffset={sideOffset}
     className={cn(
-      "ve-z-50 ve-overflow-hidden ve-rounded-[6px] ve-bg-popover ve-px-3 ve-py-1.5 ve-text-sm" +
+      "ve-z-50 ve-overflow-hidden ve-rounded-md ve-bg-popover ve-px-3 ve-py-1.5 ve-text-sm" +
         " ve-text-popover-foreground",
       className
     )}

--- a/src/internal/puck/ui/button.tsx
+++ b/src/internal/puck/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../../../utils/cn.ts";
 
 const buttonVariants = cva(
-  "ve-inline-flex ve-items-center ve-justify-center ve-whitespace-nowrap ve-rounded-md ve-text-sm" +
+  "ve-inline-flex ve-items-center ve-justify-center ve-whitespace-nowrap ve-rounded-full ve-text-sm" +
     " ve-font-medium ve-ring-offset-background ve-transition-colors focus-visible:ve-outline-none" +
     " focus-visible:ve-ring-2 focus-visible:ve-ring-ring focus-visible:ve-ring-offset-2" +
     " disabled:ve-pointer-events-none disabled:ve-opacity-50",
@@ -24,9 +24,9 @@ const buttonVariants = cva(
         link: "ve-text-primary ve-underline-offset-4 hover:ve-underline",
       },
       size: {
-        default: "ve-h-10 ve-rounded-md ve-px-4 ve-py-2",
-        sm: "ve-h-9 ve-rounded-md ve-px-3",
-        lg: "ve-h-11 ve-rounded-md ve-px-8",
+        default: "ve-h-10 ve-px-4 ve-py-2",
+        sm: "ve-h-9 ve-px-3",
+        lg: "ve-h-11 ve-px-8",
         icon: "ve-h-10 ve-w-10",
       },
     },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -40,11 +40,6 @@ export default {
           foreground: "hsl(0 0% 100%)",
         },
       },
-      borderRadius: {
-        lg: `2rem`,
-        md: `calc(2rem - 2px)`,
-        sm: "calc(2rem - 4px)",
-      },
       container: {
         center: true,
         padding: {


### PR DESCRIPTION
From the bug bash:
"This modal doesn't seem to be from our design system; its corner radius is way too rounded; it should be 12px or radius-xl"

This change removes the tailwind border radius overrides we had and updates some usages to better match mana styles

New screenshots:
![rounded-2](https://github.com/user-attachments/assets/756362ed-2dca-47b0-b4e8-1bb79339dd67)
![rounded-1](https://github.com/user-attachments/assets/9dfab094-9861-48f7-8d27-d5883d260770)
