### PR TITLE
fix: clear local changes closes on save state update

### DIFF
--- a/src/internal/components/InternalLayoutEditor.tsx
+++ b/src/internal/components/InternalLayoutEditor.tsx
@@ -43,6 +43,8 @@ export const InternalLayoutEditor = ({
   buildVisualConfigLocalStorageKey,
 }: InternalLayoutEditorProps) => {
   const [canEdit, setCanEdit] = useState<boolean>(false); // helps sync puck preview and save state
+  const [clearLocalChangesModalOpen, setClearLocalChangesModalOpen] =
+    useState<boolean>(false);
   const historyIndex = useRef<number>(0);
 
   /**
@@ -121,6 +123,8 @@ export const InternalLayoutEditor = ({
         overrides={{
           header: () => (
             <LayoutHeader
+              clearLocalChangesModalOpen={clearLocalChangesModalOpen}
+              setClearLocalChangesModalOpen={setClearLocalChangesModalOpen}
               onClearLocalChanges={handleClearLocalChanges}
               onHistoryChange={handleHistoryChange}
               onPublishLayout={handlePublishLayout}

--- a/src/internal/components/InternalThemeEditor.tsx
+++ b/src/internal/components/InternalThemeEditor.tsx
@@ -45,6 +45,8 @@ export const InternalThemeEditor = ({
   buildThemeLocalStorageKey,
 }: InternalThemeEditorProps) => {
   const [canEdit, setCanEdit] = useState<boolean>(false); // helps sync puck preview and save state
+  const [clearLocalChangesModalOpen, setClearLocalChangesModalOpen] =
+    useState<boolean>(false);
   const themeHistoriesRef = useRef(themeHistories);
 
   useEffect(() => {
@@ -172,6 +174,8 @@ export const InternalThemeEditor = ({
               setThemeHistories={setThemeHistories}
               clearThemeHistory={clearThemeHistory}
               puckInitialHistory={puckInitialHistory}
+              clearLocalChangesModalOpen={clearLocalChangesModalOpen}
+              setClearLocalChangesModalOpen={setClearLocalChangesModalOpen}
             />
           ),
           actionBar: () => <></>,

--- a/src/internal/puck/components/LayoutHeader.tsx
+++ b/src/internal/puck/components/LayoutHeader.tsx
@@ -14,11 +14,19 @@ type LayoutHeaderProps = {
   onHistoryChange: (histories: History[], index: number) => void;
   onPublishLayout: (data: Data) => Promise<void>;
   isDevMode: boolean;
+  clearLocalChangesModalOpen: boolean;
+  setClearLocalChangesModalOpen: (newValue: boolean) => void;
 };
 
 export const LayoutHeader = (props: LayoutHeaderProps) => {
-  const { onClearLocalChanges, onHistoryChange, onPublishLayout, isDevMode } =
-    props;
+  const {
+    onClearLocalChanges,
+    onHistoryChange,
+    onPublishLayout,
+    isDevMode,
+    clearLocalChangesModalOpen,
+    setClearLocalChangesModalOpen,
+  } = props;
 
   const {
     appState,
@@ -63,6 +71,8 @@ export const LayoutHeader = (props: LayoutHeaderProps) => {
           <RotateCw className="sm-icon" />
         </Button>
         <ClearLocalChangesButton
+          modalOpen={clearLocalChangesModalOpen}
+          setModalOpen={setClearLocalChangesModalOpen}
           disabled={histories.length === 1}
           onClearLocalChanges={() => {
             onClearLocalChanges();

--- a/src/internal/puck/components/ThemeHeader.tsx
+++ b/src/internal/puck/components/ThemeHeader.tsx
@@ -18,6 +18,8 @@ type ThemeHeaderProps = {
   themeHistories?: ThemeHistories;
   clearThemeHistory: () => void;
   puckInitialHistory: InitialHistory | undefined;
+  clearLocalChangesModalOpen: boolean;
+  setClearLocalChangesModalOpen: (newValue: boolean) => void;
 };
 
 export const ThemeHeader = (props: ThemeHeaderProps) => {
@@ -29,6 +31,8 @@ export const ThemeHeader = (props: ThemeHeaderProps) => {
     themeHistories,
     clearThemeHistory,
     puckInitialHistory,
+    clearLocalChangesModalOpen,
+    setClearLocalChangesModalOpen,
   } = props;
 
   const {
@@ -64,6 +68,8 @@ export const ThemeHeader = (props: ThemeHeaderProps) => {
       <div className="header-center"></div>
       <div className="actions">
         <ClearLocalChangesButton
+          modalOpen={clearLocalChangesModalOpen}
+          setModalOpen={setClearLocalChangesModalOpen}
           disabled={themeHistories?.histories?.length === 1}
           onClearLocalChanges={() => {
             clearThemeHistory();

--- a/src/internal/puck/ui/ClearLocalChangesButton.tsx
+++ b/src/internal/puck/ui/ClearLocalChangesButton.tsx
@@ -16,21 +16,23 @@ import "../../../components/editor/index.css";
 type ClearLocalChangesButtonProps = {
   disabled: boolean;
   onClearLocalChanges: () => void;
+  modalOpen: boolean;
+  setModalOpen: (newValue: boolean) => void;
 };
 
 export const ClearLocalChangesButton = ({
   disabled,
   onClearLocalChanges,
+  modalOpen,
+  setModalOpen,
 }: ClearLocalChangesButtonProps) => {
-  const [dialogOpen, setDialogOpen] = React.useState<boolean>(false);
-
   const handleClearLocalChanges = () => {
     onClearLocalChanges();
-    setDialogOpen(false);
+    setModalOpen(false);
   };
 
   return (
-    <AlertDialog open={dialogOpen} onOpenChange={setDialogOpen}>
+    <AlertDialog open={modalOpen} onOpenChange={setModalOpen}>
       <AlertDialogTrigger disabled={disabled} asChild>
         <Button variant="outline">Clear Local Changes</Button>
       </AlertDialogTrigger>


### PR DESCRIPTION
Since `onClearLocalChanges()` depends on the `histories` object, whenever save state was updated, the `<ClearLocalChangesButton>` would have new props, resetting its state. So, if you clicked ClearLocalChangesButton while a save state was in-progress, it would close itself once the save state finished.

I don't love the prop drilling here but `useCallback` didn't work because `onClearLocalChanges` does actually depend on `histories` and it didn't seem worth spending a lot of time on