### PR TITLE
fix: themeSaveState didn't match data from messenger

### DIFF
--- a/src/internal/hooks/theme/useMessageReceivers.ts
+++ b/src/internal/hooks/theme/useMessageReceivers.ts
@@ -27,7 +27,7 @@ export const useThemeMessageReceivers = () => {
     if (payload?.history) {
       receivedThemeSaveState = {
         hash: payload.hash,
-        history: jsonFromEscapedJsonString(payload.history),
+        history: { data: jsonFromEscapedJsonString(payload.history) },
       } as ThemeSaveState;
     }
     devLogger.logData("THEME_SAVE_STATE", receivedThemeSaveState);


### PR DESCRIPTION
themeSaveState from alpha was formatted a bit differently. Fixed it so themeSaveState works and now after "publish" the theme is correct (even when u switch entities) 