### PR TITLE
feat: set default field for emails component

### DIFF
--- a/src/components/puck/Emails.tsx
+++ b/src/components/puck/Emails.tsx
@@ -168,7 +168,7 @@ const EmailsComponent: ComponentConfig<EmailsProps> = {
   fields: EmailsFields,
   defaultProps: {
     list: {
-      field: "",
+      field: "emails",
       constantValue: [],
     },
     includeHyperlink: true,


### PR DESCRIPTION
This sets the `emails` field as the default entity field for the Emails component.