### PR TITLE
fix: limit font-size for buttons

### DIFF
--- a/src/components/puck/Card.tsx
+++ b/src/components/puck/Card.tsx
@@ -12,6 +12,7 @@ import {
   BodyProps,
 } from "../../index.js";
 import { Body } from "./atoms/body.js";
+import { ButtonProps } from "./atoms/button.tsx";
 import { CTA, CTAProps } from "./atoms/cta.js";
 import {
   Heading,
@@ -55,7 +56,7 @@ interface CardProps {
   cta: {
     entityField: YextEntityField<CTAProps>;
     variant: CTAProps["variant"];
-    fontSize: HeadingProps["fontSize"];
+    fontSize: ButtonProps["fontSize"];
   };
   backgroundColor:
     | "bg-card-backgroundColor"

--- a/src/components/puck/Card.tsx
+++ b/src/components/puck/Card.tsx
@@ -12,7 +12,6 @@ import {
   BodyProps,
 } from "../../index.js";
 import { Body } from "./atoms/body.js";
-import { ButtonProps } from "./atoms/button.tsx";
 import { CTA, CTAProps } from "./atoms/cta.js";
 import {
   Heading,
@@ -56,7 +55,7 @@ interface CardProps {
   cta: {
     entityField: YextEntityField<CTAProps>;
     variant: CTAProps["variant"];
-    fontSize: ButtonProps["fontSize"];
+    fontSize: CTAProps["fontSize"];
   };
   backgroundColor:
     | "bg-card-backgroundColor"

--- a/src/components/puck/Promo.tsx
+++ b/src/components/puck/Promo.tsx
@@ -11,7 +11,6 @@ import {
   FontSizeSelector,
 } from "../../index.js";
 import { Body } from "./atoms/body.js";
-import { ButtonProps } from "./atoms/button.js";
 import { CTA, CTAProps } from "./atoms/cta.js";
 import { Heading, HeadingProps } from "./atoms/heading.js";
 import { Section } from "./atoms/section.js";
@@ -42,7 +41,7 @@ interface PromoProps {
   cta: {
     entityField: YextEntityField<CTAProps>;
     variant: CTAProps["variant"];
-    fontSize: ButtonProps["fontSize"];
+    fontSize: CTAProps["fontSize"];
   };
 }
 

--- a/src/components/puck/Promo.tsx
+++ b/src/components/puck/Promo.tsx
@@ -11,6 +11,7 @@ import {
   FontSizeSelector,
 } from "../../index.js";
 import { Body } from "./atoms/body.js";
+import { ButtonProps } from "./atoms/button.js";
 import { CTA, CTAProps } from "./atoms/cta.js";
 import { Heading, HeadingProps } from "./atoms/heading.js";
 import { Section } from "./atoms/section.js";
@@ -41,7 +42,7 @@ interface PromoProps {
   cta: {
     entityField: YextEntityField<CTAProps>;
     variant: CTAProps["variant"];
-    fontSize: HeadingProps["fontSize"];
+    fontSize: ButtonProps["fontSize"];
   };
 }
 

--- a/src/components/puck/atoms/button.tsx
+++ b/src/components/puck/atoms/button.tsx
@@ -31,11 +31,6 @@ const buttonVariants = cva(
         "2xl": "text-2xl",
         "3xl": "text-3xl",
         "4xl": "text-4xl",
-        "5xl": "text-5xl",
-        "6xl": "text-6xl",
-        "7xl": "text-7xl",
-        "8xl": "text-8xl",
-        "9xl": "text-9xl",
       },
       borderRadius: {
         default: "",


### PR DESCRIPTION
For buttons, which are used in cta and
Get Directions, selecting a font-size larger than 5xl would make the text bleed out of the button.

This change removes the font size options larger than 4xl per Aaron's request.