### PR TITLE
fix: error in constant text fields

### DIFF
--- a/src/components/editor/YextEntityFieldSelector.tsx
+++ b/src/components/editor/YextEntityFieldSelector.tsx
@@ -193,8 +193,27 @@ const ConstantValueInput = <T extends Record<string, any>>({
     !!filter.includeListsOnly
   );
 
-  return (
-    constantFieldConfig && (
+  if (!constantFieldConfig) {
+    return;
+  }
+
+  return constantFieldConfig.type === "custom" ? (
+    <AutoField
+      onChange={(newConstantValue) =>
+        onChange({
+          field: value?.field ?? "",
+          constantValue: newConstantValue,
+          constantValueEnabled: true,
+        })
+      }
+      value={value?.constantValue}
+      field={constantFieldConfig}
+    />
+  ) : (
+    <FieldLabel
+      label={constantFieldConfig.label ?? "Value"}
+      className="ve-inline-block ve-pt-4 w-full"
+    >
       <AutoField
         onChange={(newConstantValue) =>
           onChange({
@@ -206,7 +225,7 @@ const ConstantValueInput = <T extends Record<string, any>>({
         value={value?.constantValue}
         field={constantFieldConfig}
       />
-    )
+    </FieldLabel>
   );
 };
 

--- a/src/internal/puck/constant-value-fields/ConstantField.tsx
+++ b/src/internal/puck/constant-value-fields/ConstantField.tsx
@@ -17,7 +17,7 @@ export function ConstantFields<T extends Record<string, any>>(
 ): ReactElement {
   const fields: ReactElement[] = [];
   props.fields.forEach((field) => {
-    fields.push(ConstantField(props, field));
+    fields.push(ConstantField<T>(props, field));
   });
 
   return <>{fields}</>;

--- a/src/internal/puck/constant-value-fields/Phone.tsx
+++ b/src/internal/puck/constant-value-fields/Phone.tsx
@@ -1,19 +1,6 @@
-import { CustomField } from "@measured/puck";
-import { ConstantFields } from "./ConstantField.tsx";
+import { TextField } from "@measured/puck";
 
-export const PHONE_CONSTANT_CONFIG: CustomField = {
-  type: "custom",
-  render: ({ onChange, value }) => {
-    return ConstantFields({
-      onChange: onChange,
-      value: value,
-      fields: [
-        {
-          label: "Phone Number",
-          field: "phone",
-          fieldType: "text",
-        },
-      ],
-    });
-  },
+export const PHONE_CONSTANT_CONFIG: TextField = {
+  type: "text",
+  label: "Phone",
 };

--- a/src/internal/puck/constant-value-fields/Text.tsx
+++ b/src/internal/puck/constant-value-fields/Text.tsx
@@ -1,19 +1,6 @@
-import { CustomField } from "@measured/puck";
-import { ConstantFields } from "./ConstantField.tsx";
+import { TextField } from "@measured/puck";
 
-export const TEXT_CONSTANT_CONFIG: CustomField = {
-  type: "custom",
-  render: ({ onChange, value }) => {
-    return ConstantFields({
-      onChange: onChange,
-      value: value,
-      fields: [
-        {
-          label: "Text",
-          field: "text",
-          fieldType: "text",
-        },
-      ],
-    });
-  },
+export const TEXT_CONSTANT_CONFIG: TextField = {
+  type: "text",
+  label: "Text",
 };


### PR DESCRIPTION
Fixes a bug I introduced in #193 
Was trying to use the custom ConstantField styling for all constant value inputs, but missed that the ConstantField function depended on the the field being an object type. This PR reverts Phone and Text to being text types but adds a case to render a styled FieldLabel for them. 