### PR TITLE
refactor: remove uuid from Header and Footer

### DIFF
--- a/src/components/puck/Header.tsx
+++ b/src/components/puck/Header.tsx
@@ -10,7 +10,6 @@ import {
   YextEntityFieldSelector,
 } from "../../index.ts";
 import { cva, VariantProps } from "class-variance-authority";
-import { v4 as uuidv4 } from "uuid";
 
 const PLACEHOLDER_LOGO_URL = "https://placehold.co/50";
 
@@ -34,7 +33,7 @@ export interface HeaderProps extends VariantProps<typeof headerVariants> {
   logo: {
     image: YextEntityField<ImageType>;
   };
-  links: { cta: YextEntityField<CTA>; id?: string }[];
+  links: { cta: YextEntityField<CTA> }[];
 }
 
 const headerFields: Fields<HeaderProps> = {
@@ -124,33 +123,6 @@ export const Header: ComponentConfig<HeaderProps> = {
   },
   label: "Header",
   render: (props) => <HeaderComponent {...props} />,
-  resolveData: ({ props }, { lastData }) => {
-    // generate a unique id for each of the links
-    if (lastData?.props.links.length === props.links.length) {
-      return { props };
-    }
-
-    // handle duplication by assigning a new id
-    const ids: string[] = [];
-    const resolveId = (id?: string) => {
-      if (!id || ids.includes(id)) {
-        const newId = uuidv4();
-        ids.push(newId);
-        return id;
-      }
-      return id;
-    };
-
-    return {
-      props: {
-        ...props,
-        links: props.links.map((link) => ({
-          ...link,
-          id: resolveId(link.id),
-        })),
-      },
-    };
-  },
 };
 
 const HeaderComponent: React.FC<HeaderProps> = (props) => {
@@ -158,16 +130,9 @@ const HeaderComponent: React.FC<HeaderProps> = (props) => {
   const { logo, links, backgroundColor } = props;
 
   const resolvedLogo = resolveYextEntityField<ImageType>(document, logo.image);
+
   const resolvedLinks = links
-    ?.map((link) => {
-      const resolvedCTA = resolveYextEntityField<CTA>(document, link.cta);
-      if (resolvedCTA) {
-        return {
-          id: link.id,
-          ...resolvedCTA,
-        };
-      }
-    })
+    ?.map((link) => resolveYextEntityField<CTA>(document, link.cta))
     .filter((link) => link !== undefined);
 
   return (
@@ -194,7 +159,7 @@ const HeaderComponent: React.FC<HeaderProps> = (props) => {
           <ul className="flex space-x-8">
             {resolvedLinks?.map((item, idx) => (
               <li
-                key={item.id ?? idx}
+                key={idx}
                 className="cursor-pointer font-bold text-palette-primary hover:text-palette-secondary"
               >
                 {item.link && (


### PR DESCRIPTION
Originally added for the React key to work properly but I guess the original issue was something with combining the existing footer with arrays from the Puck demo because it doesn't seem necessary. 

This PR simplifies Header/Footer by just using the array index as the key, and it seems to work totally fine with add/remove/duplicate/reorder.