### PR TITLE
chore: upgrade puck to 0.17.4

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -6608,7 +6608,7 @@ The following npm packages may be included in this product:
 
  - @esbuild/linux-x64@0.23.1
  - @icons/material@0.2.4
- - @measured/puck@0.17.1
+ - @measured/puck@0.17.4
  - @radix-ui/primitive@1.1.0
  - @radix-ui/react-alert-dialog@1.1.2
  - @radix-ui/react-arrow@1.1.0

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "generate-registry": "tsx src/components/puck/registry/build-registry.ts"
   },
   "dependencies": {
-    "@measured/puck": "0.17.1",
+    "@measured/puck": "0.17.4",
     "@radix-ui/react-alert-dialog": "^1.1.1",
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-progress": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@measured/puck':
-        specifier: 0.17.1
-        version: 0.17.1(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 0.17.4
+        version: 0.17.4(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-alert-dialog':
         specifier: ^1.1.1
         version: 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -951,8 +951,8 @@ packages:
       react: ^16.8.5 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.5 || ^17.0.0 || ^18.0.0
 
-  '@measured/puck@0.17.1':
-    resolution: {integrity: sha512-sBvZ4yAgLbR4CFidgZ3tnkAoie5/eNGCgHXuYZjC1Cyb8WvKXNiYvljTA+zH5MeuXMig1cehID+zTlMjyC+khQ==}
+  '@measured/puck@0.17.4':
+    resolution: {integrity: sha512-KPSjOWeRX0CAObYC9aXJx+LUlW1sSJwrMY9PijqiThVF1FumivFQVt+3FdtxvD67Z8k1/6nT5jjQ60ALcsLhGw==}
     peerDependencies:
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -5110,7 +5110,7 @@ snapshots:
       - '@types/react-dom'
       - react-native
 
-  '@measured/puck@0.17.1(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@measured/puck@0.17.4(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@measured/dnd': 16.6.0-canary.4cba1d1(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       deep-diff: 1.0.2


### PR DESCRIPTION
https://github.com/measuredco/puck/compare/v0.17.0...v0.17.4

I think https://github.com/measuredco/puck/commit/e778246e4ae8925f3d04962369a33a9c1a4b6589 means we don't have to do as many null checks as we do in the components, but they won't hurt