### PR TITLE
feat: set up error boundary and send errors to parent

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -9947,11 +9947,12 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -----------
 
-The following npm package may be included in this product:
+The following npm packages may be included in this product:
 
  - react-error-boundary@3.1.4
+ - react-error-boundary@5.0.0
 
-This package contains the following license:
+These packages each contain the following license:
 
 The MIT License (MIT)
 Copyright (c) 2020 Brian Vaughn

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "prettier": "^3.3.3",
     "prompts": "^2.4.2",
     "react-color": "^2.19.3",
+    "react-error-boundary": "^5.0.0",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.4.0",
     "tsx": "^4.16.3"
@@ -99,14 +100,14 @@
     "tailwindcss": "^3.4.6",
     "tsup": "8.3.5",
     "typescript": "^5.5.4",
-    "vite": "^5.3.5",
     "uuid": "11.0.3",
+    "vite": "^5.3.5",
     "vitest": "^2.0.5",
     "zod": "^3.23.8"
   },
   "peerDependencies": {
+    "@yext/pages-components": "^1.0.0",
     "react": "^17.0.2 || ^18.2.0",
-    "react-dom": "^17.0.2 || ^18.2.0",
-    "@yext/pages-components": "^1.0.0"
+    "react-dom": "^17.0.2 || ^18.2.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       react-dom:
         specifier: ^17.0.2 || ^18.2.0
         version: 18.3.1(react@18.3.1)
+      react-error-boundary:
+        specifier: ^5.0.0
+        version: 5.0.0(react@18.3.1)
       sonner:
         specifier: ^1.5.0
         version: 1.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3567,6 +3570,11 @@ packages:
   react-error-boundary@3.1.4:
     resolution: {integrity: sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==}
     engines: {node: '>=10', npm: '>=6'}
+    peerDependencies:
+      react: '>=16.13.1'
+
+  react-error-boundary@5.0.0:
+    resolution: {integrity: sha512-tnjAxG+IkpLephNcePNA7v6F/QpWLH8He65+DmedchDwg162JZqx4NmbXj0mlAYVVEd81OW7aFhmbsScYfiAFQ==}
     peerDependencies:
       react: '>=16.13.1'
 
@@ -8142,6 +8150,11 @@ snapshots:
       scheduler: 0.23.2
 
   react-error-boundary@3.1.4(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.26.0
+      react: 18.3.1
+
+  react-error-boundary@5.0.0(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.26.0
       react: 18.3.1

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -1,5 +1,6 @@
 import "./index.css";
-import React, { useEffect, useState } from "react";
+import React, { ErrorInfo, useEffect, useState } from "react";
+import { ErrorBoundary } from "react-error-boundary";
 import { LoadingScreen } from "../../internal/puck/components/LoadingScreen.tsx";
 import { Toaster } from "../../internal/puck/ui/Toaster.tsx";
 import { type Config } from "@measured/puck";
@@ -42,9 +43,15 @@ export const Editor = ({
     themeDataFetched,
   } = useCommonMessageReceivers(componentRegistry);
 
-  const { pushPageSets } = useCommonMessageSenders();
+  const { pushPageSets, sendError } = useCommonMessageSenders();
 
   useQuickFindShortcut();
+
+  const logError = (error: Error, info: ErrorInfo) => {
+    sendError({
+      payload: { error, info },
+    });
+  };
 
   // redirect to 404 page when going to /edit page outside of Storm
   useEffect(() => {
@@ -107,7 +114,7 @@ export const Editor = ({
       5);
 
   return (
-    <>
+    <ErrorBoundary fallback={<></>} onError={logError}>
       {!isLoading ? (
         templateMetadata.isThemeMode ? (
           <ThemeEditor
@@ -130,6 +137,6 @@ export const Editor = ({
         parentLoaded && <LoadingScreen progress={progress} />
       )}
       <Toaster closeButton richColors />
-    </>
+    </ErrorBoundary>
   );
 };

--- a/src/internal/hooks/useMessageSenders.ts
+++ b/src/internal/hooks/useMessageSenders.ts
@@ -26,11 +26,17 @@ export const useCommonMessageSenders = () => {
     TARGET_ORIGINS
   );
 
+  const { sendToParent: sendError } = useSendMessageToParent(
+    "sendError",
+    TARGET_ORIGINS
+  );
+
   return {
     iFrameLoaded,
     pushPageSets,
     openQuickFind,
     sendDevLayoutSaveStateData,
     sendDevThemeSaveStateData,
+    sendError,
   };
 };


### PR DESCRIPTION
Capture errors in the editor and send to parent

Receiver in YSS coming soon but I wanted to get this in before we do a release

I have the fallback just set to <></> because I was presuming we'd want a mana ui error state which needs to be rendered by the parent