### PR TITLE
fix: links open in new tab

### DIFF
--- a/packages/visual-editor/src/components/puck/GetDirections.tsx
+++ b/packages/visual-editor/src/components/puck/GetDirections.tsx
@@ -99,7 +99,9 @@ const GetDirections = ({
         fontSize={fontSize}
         borderRadius={borderRadius}
       >
-        <Link href={searchQuery ?? "#"}>{"Get Directions"}</Link>
+        <Link href={searchQuery ?? "#"} target="_blank">
+          {"Get Directions"}
+        </Link>
       </Button>
     </EntityField>
   );


### PR DESCRIPTION
Now the Get Direction component's link opens in a new tab. This matches how the address component's link already worked. 