### PR TITLE
feat: add applyAnalytics

### DIFF
--- a/packages/visual-editor/src/utils/README.md
+++ b/packages/visual-editor/src/utils/README.md
@@ -448,3 +448,23 @@ Returns a list of border radius options to be optionally used in the theme.confi
 | rounded-2xl    | 2XL (16px)    | 16px   |
 | rounded-3xl    | 3XL (24px)    | 24px   |
 | rounded-full   | Full (9999px) | 9999px |
+
+## applyAnalytics
+
+Returns a Google Tag Manager script that uses the Google Tag Manager ID
+set in the Theme Editor.
+
+### Usage
+
+```tsx
+export const getHeadConfig: GetHeadConfig<TemplateRenderProps> = ({
+  document,
+}): HeadConfig => {
+  return {
+    title: document.name,
+    other: [applyAnalytics(document), applyTheme(document, themeConfig)].join(
+      "\n"
+    ),
+  };
+};
+```

--- a/packages/visual-editor/src/utils/applyAnalytics.ts
+++ b/packages/visual-editor/src/utils/applyAnalytics.ts
@@ -1,6 +1,10 @@
 export const applyAnalytics = (document: Record<string, any>) => {
-  const googleTagManagerId: string =
-    document?.__?.theme?.siteAttributes?.googleTagManagerId;
+  if (!document?.__?.theme) {
+    return;
+  }
+
+  const googleTagManagerId: string = JSON.parse(document.__.theme)
+    ?.siteAttributes?.googleTagManagerId;
 
   if (googleTagManagerId) {
     return `<!-- Google tag (gtag.js) -->

--- a/packages/visual-editor/src/utils/applyAnalytics.ts
+++ b/packages/visual-editor/src/utils/applyAnalytics.ts
@@ -1,0 +1,16 @@
+export const applyAnalytics = (document: Record<string, any>) => {
+  const googleTagManagerId: string =
+    document?.__?.theme?.siteAttributes?.googleTagManagerId;
+
+  if (googleTagManagerId) {
+    return `<!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=${googleTagManagerId}"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+    
+      gtag('config', '${googleTagManagerId}');
+    </script>`;
+  }
+};

--- a/packages/visual-editor/src/utils/index.ts
+++ b/packages/visual-editor/src/utils/index.ts
@@ -15,3 +15,4 @@ export {
   getFontSizeOptions,
   getBorderRadiusOptions,
 } from "./themeConfigOptions.ts";
+export { applyAnalytics } from "./applyAnalytics.ts";


### PR DESCRIPTION
Returns a Google Tag Manager script that uses the Google Tag Manager ID set in the Theme Editor