### PR TITLE
fix: update button font size options

### DIFF
--- a/packages/visual-editor/src/components/editor/BorderRadiusSelector.tsx
+++ b/packages/visual-editor/src/components/editor/BorderRadiusSelector.tsx
@@ -4,8 +4,7 @@ import { useTailwindConfig } from "../../hooks/useTailwindConfig.tsx";
 import { TailwindConfig } from "../../utils/themeResolver.ts";
 import { ChevronDown } from "lucide-react";
 
-const borderRadiusOptions = [
-  { label: "Default", value: "default", px: "" },
+export const borderRadiusOptions = [
   { label: "None", value: "none", px: "0" },
   { label: "XS", value: "xs", px: "2" },
   { label: "SM", value: "sm", px: "4" },
@@ -107,7 +106,10 @@ export const BorderRadiusSelector = (label?: string): Field => {
             field={{
               type: "select",
               options: convertDefaultBorderRadiusToOptions(
-                borderRadiusOptions,
+                [
+                  { label: "Default", value: "default", px: "" },
+                  ...borderRadiusOptions,
+                ],
                 tailwindConfig
               ),
             }}

--- a/packages/visual-editor/src/components/editor/FontSizeSelector.tsx
+++ b/packages/visual-editor/src/components/editor/FontSizeSelector.tsx
@@ -4,22 +4,29 @@ import { useTailwindConfig } from "../../hooks/useTailwindConfig.tsx";
 import { TailwindConfig } from "../../utils/themeResolver.ts";
 import { ChevronDown } from "lucide-react";
 
-const fontSizeOptions = [
-  { label: "Default", value: "default", px: "" },
-  { label: "XS", value: "xs", px: "12" },
-  { label: "SM", value: "sm", px: "14" },
-  { label: "Base", value: "base", px: "16" },
-  { label: "LG", value: "lg", px: "18" },
-  { label: "XL", value: "xl", px: "20" },
-  { label: "2XL", value: "2xl", px: "24" },
-  { label: "3XL", value: "3xl", px: "30" },
-  { label: "4XL", value: "4xl", px: "36" },
-  { label: "5XL", value: "5xl", px: "48" },
-  { label: "6XL", value: "6xl", px: "60" },
-  { label: "7XL", value: "7xl", px: "72" },
-  { label: "8XL", value: "8xl", px: "96" },
-  { label: "9XL", value: "9xl", px: "128" },
-];
+const fontSizeOptions = (isButton = false) => {
+  const fontSizeOptions = [
+    { label: "Default", value: "default", px: "" },
+    { label: "XS", value: "xs", px: "12" },
+    { label: "SM", value: "sm", px: "14" },
+    { label: "Base", value: "base", px: "16" },
+    { label: "LG", value: "lg", px: "18" },
+    { label: "XL", value: "xl", px: "20" },
+    { label: "2XL", value: "2xl", px: "24" },
+    { label: "3XL", value: "3xl", px: "30" },
+    { label: "4XL", value: "4xl", px: "36" },
+  ];
+  const largeFontSizeOptions = [
+    { label: "5XL", value: "5xl", px: "48" },
+    { label: "6XL", value: "6xl", px: "60" },
+    { label: "7XL", value: "7xl", px: "72" },
+    { label: "8XL", value: "8xl", px: "96" },
+    { label: "9XL", value: "9xl", px: "128" },
+  ];
+  return isButton
+    ? fontSizeOptions
+    : [...fontSizeOptions, ...largeFontSizeOptions];
+};
 
 export const convertToPixels = (fontSize: string): number => {
   // If the font size is already in px, just extract the number
@@ -85,7 +92,7 @@ export const convertDefaultFontSizesToOptions = (
   });
 };
 
-export const FontSizeSelector = (label?: string): Field => {
+export const FontSizeSelector = (label?: string, isButton?: boolean): Field => {
   return {
     type: "custom",
     render: ({ value, onChange }) => {
@@ -102,7 +109,7 @@ export const FontSizeSelector = (label?: string): Field => {
             field={{
               type: "select",
               options: convertDefaultFontSizesToOptions(
-                fontSizeOptions,
+                fontSizeOptions(isButton),
                 tailwindConfig
               ),
             }}

--- a/packages/visual-editor/src/components/editor/FontSizeSelector.tsx
+++ b/packages/visual-editor/src/components/editor/FontSizeSelector.tsx
@@ -4,9 +4,8 @@ import { useTailwindConfig } from "../../hooks/useTailwindConfig.tsx";
 import { TailwindConfig } from "../../utils/themeResolver.ts";
 import { ChevronDown } from "lucide-react";
 
-const fontSizeOptions = (isButton = false) => {
+export const fontSizeOptions = (includeLargeSizes = true) => {
   const fontSizeOptions = [
-    { label: "Default", value: "default", px: "" },
     { label: "XS", value: "xs", px: "12" },
     { label: "SM", value: "sm", px: "14" },
     { label: "Base", value: "base", px: "16" },
@@ -23,9 +22,9 @@ const fontSizeOptions = (isButton = false) => {
     { label: "8XL", value: "8xl", px: "96" },
     { label: "9XL", value: "9xl", px: "128" },
   ];
-  return isButton
-    ? fontSizeOptions
-    : [...fontSizeOptions, ...largeFontSizeOptions];
+  return includeLargeSizes
+    ? [...fontSizeOptions, ...largeFontSizeOptions]
+    : fontSizeOptions;
 };
 
 export const convertToPixels = (fontSize: string): number => {
@@ -92,7 +91,10 @@ export const convertDefaultFontSizesToOptions = (
   });
 };
 
-export const FontSizeSelector = (label?: string, isButton?: boolean): Field => {
+export const FontSizeSelector = (
+  label?: string,
+  includeLargeSizes = true
+): Field => {
   return {
     type: "custom",
     render: ({ value, onChange }) => {
@@ -109,7 +111,10 @@ export const FontSizeSelector = (label?: string, isButton?: boolean): Field => {
             field={{
               type: "select",
               options: convertDefaultFontSizesToOptions(
-                fontSizeOptions(isButton),
+                [
+                  { label: "Default", value: "default", px: "" },
+                  ...fontSizeOptions(includeLargeSizes),
+                ],
                 tailwindConfig
               ),
             }}

--- a/packages/visual-editor/src/components/puck/CtaWrapper.tsx
+++ b/packages/visual-editor/src/components/puck/CtaWrapper.tsx
@@ -43,7 +43,7 @@ const ctaWrapperFields: Fields<CTAWrapperProps> = {
       { label: "Large", value: "large" },
     ],
   },
-  fontSize: FontSizeSelector(),
+  fontSize: FontSizeSelector("Font Size", true),
   borderRadius: BorderRadiusSelector(),
 };
 

--- a/packages/visual-editor/src/components/puck/CtaWrapper.tsx
+++ b/packages/visual-editor/src/components/puck/CtaWrapper.tsx
@@ -43,7 +43,7 @@ const ctaWrapperFields: Fields<CTAWrapperProps> = {
       { label: "Large", value: "large" },
     ],
   },
-  fontSize: FontSizeSelector("Font Size", true),
+  fontSize: FontSizeSelector("Font Size", false),
   borderRadius: BorderRadiusSelector(),
 };
 

--- a/packages/visual-editor/src/components/puck/GetDirections.tsx
+++ b/packages/visual-editor/src/components/puck/GetDirections.tsx
@@ -57,7 +57,7 @@ const getDirectionsFields: Fields<GetDirectionsProps> = {
       { label: "Large", value: "large" },
     ],
   },
-  fontSize: FontSizeSelector(),
+  fontSize: FontSizeSelector("Font Size", true),
   borderRadius: BorderRadiusSelector(),
 };
 

--- a/packages/visual-editor/src/components/puck/GetDirections.tsx
+++ b/packages/visual-editor/src/components/puck/GetDirections.tsx
@@ -57,7 +57,7 @@ const getDirectionsFields: Fields<GetDirectionsProps> = {
       { label: "Large", value: "large" },
     ],
   },
-  fontSize: FontSizeSelector("Font Size", true),
+  fontSize: FontSizeSelector("Font Size", false),
   borderRadius: BorderRadiusSelector(),
 };
 

--- a/packages/visual-editor/src/utils/README.md
+++ b/packages/visual-editor/src/utils/README.md
@@ -415,6 +415,14 @@ Allowed special characters: `( ) [ ] _ ~ : @ ; = / $ * - . &`
 
 ## getFontSizeOptions
 
+### Props
+
+| Name              | Type     | Description                                               |
+| ----------------- | -------- | --------------------------------------------------------- |
+| includeLargeSizes | boolean? | Defaults to true. If set to false, only returns XS to 4XL |
+
+### Usage
+
 Returns a list of font size options to be optionally used in the theme.config. The labels and values correspond to tailwind's default classes.
 
 | Tailwind Class | Label       | Value |

--- a/packages/visual-editor/src/utils/themeConfigOptions.ts
+++ b/packages/visual-editor/src/utils/themeConfigOptions.ts
@@ -1,31 +1,20 @@
-export const getFontSizeOptions = () => {
-  return [
-    { label: "XS (12px)", value: "12px" },
-    { label: "SM (14px)", value: "14px" },
-    { label: "Base (16px)", value: "16px" },
-    { label: "LG (18px)", value: "18px" },
-    { label: "XL (20px)", value: "20px" },
-    { label: "2XL (24px)", value: "24px" },
-    { label: "3XL (30px)", value: "30px" },
-    { label: "4XL (36px)", value: "36px" },
-    { label: "5XL (48px)", value: "48px" },
-    { label: "6XL (60px)", value: "60px" },
-    { label: "7XL (72px)", value: "72px" },
-    { label: "8XL (96px)", value: "96px" },
-    { label: "9XL (128px)", value: "128px" },
-  ];
+import { borderRadiusOptions } from "../components/editor/BorderRadiusSelector.tsx";
+import { fontSizeOptions } from "../components/editor/FontSizeSelector.tsx";
+
+export const getFontSizeOptions = (includeLargeSizes = true) => {
+  return fontSizeOptions(includeLargeSizes).map((option) => {
+    return {
+      label: option.label + ` (${option.px}px)`,
+      value: `${option.px}px`,
+    };
+  });
 };
 
 export const getBorderRadiusOptions = () => {
-  return [
-    { label: "None (0px)", value: "0px" },
-    { label: "XS (2px)", value: "2px" },
-    { label: "SM (4px)", value: "4px" },
-    { label: "MD (6px)", value: "6px" },
-    { label: "LG (8px)", value: "8px" },
-    { label: "XL (12px)", value: "12px" },
-    { label: "2XL (16px)", value: "16px" },
-    { label: "3XL (24px)", value: "24px" },
-    { label: "Full (9999px)", value: "9999px" },
-  ];
+  return borderRadiusOptions.map((option) => {
+    return {
+      label: option.label + ` (${option.px}px)`,
+      value: `${option.px}px`,
+    };
+  });
 };

--- a/starter/theme.config.ts
+++ b/starter/theme.config.ts
@@ -366,16 +366,7 @@ export const themeConfig: ThemeConfig = {
         label: "Font Size",
         type: "select",
         plugin: "fontSize",
-        options: [
-          { label: "XS (12px)", value: "12px" },
-          { label: "SM (14px)", value: "14px" },
-          { label: "Base (16px)", value: "16px" },
-          { label: "LG (18px)", value: "18px" },
-          { label: "XL (20px)", value: "20px" },
-          { label: "2XL (24px)", value: "24px" },
-          { label: "3XL (30px)", value: "30px" },
-          { label: "4XL (36px)", value: "36px" },
-        ],
+        options: getFontSizeOptions(false),
         default: "12px",
       },
       backgroundColor: {

--- a/starter/theme.config.ts
+++ b/starter/theme.config.ts
@@ -366,7 +366,16 @@ export const themeConfig: ThemeConfig = {
         label: "Font Size",
         type: "select",
         plugin: "fontSize",
-        options: getFontSizeOptions(),
+        options: [
+          { label: "XS (12px)", value: "12px" },
+          { label: "SM (14px)", value: "14px" },
+          { label: "Base (16px)", value: "16px" },
+          { label: "LG (18px)", value: "18px" },
+          { label: "XL (20px)", value: "20px" },
+          { label: "2XL (24px)", value: "24px" },
+          { label: "3XL (30px)", value: "30px" },
+          { label: "4XL (36px)", value: "36px" },
+        ],
         default: "12px",
       },
       backgroundColor: {


### PR DESCRIPTION
<img width="316" alt="Screenshot 2025-02-05 at 4 00 20 PM" src="https://github.com/user-attachments/assets/8bdef7a5-67e9-4c14-98bf-c559e7c2a218" />

fixed it so that 5xl, 6xl, 7xl... doesn't show up anymore. There's a separate CR to update the starter's theme.config