### PR TITLE
feat: add page level fields for Title and Description

### DIFF
--- a/packages/visual-editor/src/internal/components/InternalLayoutEditor.tsx
+++ b/packages/visual-editor/src/internal/components/InternalLayoutEditor.tsx
@@ -13,6 +13,7 @@ import { EntityFieldProvider } from "../../components/editor/EntityField.tsx";
 import { LayoutSaveState } from "../types/saveState.ts";
 import { LayoutHeader } from "../puck/components/LayoutHeader.tsx";
 import { DevLogger } from "../../utils/devLogger.ts";
+import { YextEntityFieldSelector } from "../../components/editor/YextEntityFieldSelector.tsx";
 import * as lzstring from "lz-string";
 
 const devLogger = new DevLogger();
@@ -122,7 +123,38 @@ export const InternalLayoutEditor = ({
   return (
     <EntityFieldProvider>
       <Puck
-        config={puckConfig}
+        config={{
+          ...puckConfig,
+          root: {
+            ...puckConfig.root,
+            fields: {
+              title: YextEntityFieldSelector<any, string>({
+                label: "Title",
+                filter: {
+                  types: ["type.string"],
+                },
+              }),
+              description: YextEntityFieldSelector<any, string>({
+                label: "Description",
+                filter: {
+                  types: ["type.string"],
+                },
+              }),
+            },
+            defaultProps: {
+              title: {
+                field: "name",
+                constantValue: "",
+                constantValueEnabled: false,
+              },
+              description: {
+                field: "description",
+                constantValue: "",
+                constantValueEnabled: false,
+              },
+            },
+          },
+        }}
         data={{}} // we use puckInitialHistory instead
         initialHistory={puckInitialHistory}
         onChange={change}


### PR DESCRIPTION
Adds page level fields for title and description in the puck editor.

They can use entity values or constant values.

They are set to use default values pointing to the name and description fields, however these do not seem to work.

I've posted a question on the Puck discord here to determine if this behavior is expected. : https://discord.com/channels/1153376562259951687/1338624057968689243/1338624057968689243

I was not able to get the defaultProps for the root to work with basic text fields either. The label field also does not seem to work.