### PR TITLE
fix: format phone numbers correctly

### DIFF
--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -92,6 +92,7 @@
     "generate-license-file": "^3.5.0",
     "husky": "^9.1.4",
     "jsdom": "^24.1.1",
+    "libphonenumber-js": "^1.11.19",
     "lint-staged": "^15.2.7",
     "minimist": "^1.2.8",
     "semver": "^7.6.3",

--- a/packages/visual-editor/src/components/puck/Phone.tsx
+++ b/packages/visual-editor/src/components/puck/Phone.tsx
@@ -10,6 +10,7 @@ import {
   getFontWeightOverrideOptions,
 } from "../../index.js";
 import { Phone as PhoneIcon } from "lucide-react";
+import parsePhoneNumber from "libphonenumber-js";
 
 const phoneVariants = cva(
   "components flex gap-2 items-center text-body-fontSize font-body-fontFamily",
@@ -59,17 +60,16 @@ const formatPhoneNumber = (
   phoneNumberString: string,
   format: string = "domestic"
 ): string => {
-  const cleaned = ("" + phoneNumberString).replace(/\D/g, "");
-  const match = cleaned.match(/^(?:\+?(\d{1,3}))?(\d{3})(\d{3})(\d{4})$/);
+  const parsedPhoneNumber = parsePhoneNumber(phoneNumberString);
+  console.log(parsePhoneNumber);
 
-  if (match) {
-    const countryCode = match[1] ? `+${match[1]} ` : "";
-    return format === "international"
-      ? `${countryCode}(${match[2]}) ${match[3]}-${match[4]}`
-      : `(${match[2]}) ${match[3]}-${match[4]}`;
+  if (!parsedPhoneNumber) {
+    return phoneNumberString;
   }
 
-  return phoneNumberString;
+  return format === "international"
+    ? parsedPhoneNumber.formatInternational()
+    : parsedPhoneNumber.formatNational();
 };
 
 const PhoneFields: Fields<PhoneProps> = {

--- a/packages/visual-editor/src/components/puck/Phone.tsx
+++ b/packages/visual-editor/src/components/puck/Phone.tsx
@@ -61,8 +61,6 @@ const formatPhoneNumber = (
   format: string = "domestic"
 ): string => {
   const parsedPhoneNumber = parsePhoneNumber(phoneNumberString);
-  console.log(parsePhoneNumber);
-
   if (!parsedPhoneNumber) {
     return phoneNumberString;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,6 +251,9 @@ importers:
       jsdom:
         specifier: ^24.1.1
         version: 24.1.3
+      libphonenumber-js:
+        specifier: ^1.11.19
+        version: 1.11.19
       lint-staged:
         specifier: ^15.2.7
         version: 15.2.10
@@ -6585,6 +6588,12 @@ packages:
       }
     engines: { node: ">=16" }
     hasBin: true
+
+  libphonenumber-js@1.11.19:
+    resolution:
+      {
+        integrity: sha512-bW/Yp/9dod6fmyR+XqSUL1N5JE7QRxQ3KrBIbYS1FTv32e5i3SEtQVX+71CYNv8maWNSOgnlCoNp9X78f/cKiA==,
+      }
 
   lilconfig@2.1.0:
     resolution:
@@ -14341,6 +14350,8 @@ snapshots:
   lib0@0.2.99:
     dependencies:
       isomorphic.js: 0.2.5
+
+  libphonenumber-js@1.11.19: {}
 
   lilconfig@2.1.0: {}
 


### PR DESCRIPTION
This change makes the Phone component correctly format phone numbers based on the country code. This uses the `libphonenumber-js` library to automatically parse the phone number and then format it in either the domestic or international format. Tested locally and ensured that phone numbers with various country codes were formatted as expected.