### PR TITLE
fix: prevent re-renders on entity field tooltip toggle

### DIFF
--- a/packages/visual-editor/src/components/editor/EntityField.tsx
+++ b/packages/visual-editor/src/components/editor/EntityField.tsx
@@ -8,12 +8,13 @@ import {
 } from "../../internal/puck/ui/Tooltip.tsx";
 import React from "react";
 
-const MemoizedChildren = React.memo(
-  ({ children }: { children: React.ReactNode }) => {
-    return <>{children}</>;
-  }
-);
-MemoizedChildren.displayName = "MemoizedChildren";
+const MemoizedChildren = React.memo(function MemoizedChildren({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+});
 
 type EntityFieldProps = {
   displayName?: string;

--- a/packages/visual-editor/src/components/editor/EntityField.tsx
+++ b/packages/visual-editor/src/components/editor/EntityField.tsx
@@ -8,6 +8,13 @@ import {
 } from "../../internal/puck/ui/Tooltip.tsx";
 import React from "react";
 
+const MemoizedChildren = React.memo(
+  ({ children }: { children: React.ReactNode }) => {
+    return <>{children}</>;
+  }
+);
+MemoizedChildren.displayName = "MemoizedChildren";
+
 type EntityFieldProps = {
   displayName?: string;
   fieldId?: string;
@@ -23,7 +30,7 @@ export const EntityField = ({
 }: EntityFieldProps) => {
   const { tooltipsVisible } = useEntityField();
 
-  if (!tooltipsVisible || constantValueEnabled) {
+  if (constantValueEnabled) {
     return children;
   }
 
@@ -39,10 +46,16 @@ export const EntityField = ({
   return (
     <div>
       <TooltipProvider>
-        <Tooltip open={!!tooltipContent}>
+        <Tooltip open={!!tooltipContent && tooltipsVisible}>
           <TooltipTrigger asChild>
-            <div className="ve-outline-2 ve-outline-dotted ve-outline-[#5A58F2]">
-              {children}
+            <div
+              className={
+                tooltipsVisible
+                  ? "ve-outline-2 ve-outline-dotted ve-outline-[#5A58F2]"
+                  : ""
+              }
+            >
+              <MemoizedChildren>{children}</MemoizedChildren>
             </div>
           </TooltipTrigger>
           <TooltipContent>


### PR DESCRIPTION
This memoizes the children that are passed into the entity field tooltip so that they do not re-render when the entity field tooltip toggle is enabled or disabled.

I tested the change locally and confirmed that nothing re-renders, and the tooltips are cleanly added and removed as expected.