### PR TITLE
feat: add undo/redo buttons to theme manager

### DIFF
--- a/packages/visual-editor/src/internal/components/InternalThemeEditor.tsx
+++ b/packages/visual-editor/src/internal/components/InternalThemeEditor.tsx
@@ -98,10 +98,13 @@ export const InternalThemeEditor = ({
 
     const newHistory = {
       histories: [
-        ...themeHistoriesRef.current.histories,
+        ...themeHistoriesRef.current.histories.slice(
+          0,
+          themeHistoriesRef.current.index + 1
+        ),
         { id: uuidv4(), data: newThemeValues },
       ] as ThemeHistory[],
-      index: themeHistoriesRef.current.histories.length,
+      index: themeHistoriesRef.current.index + 1,
     };
 
     if (localDev) {

--- a/packages/visual-editor/src/internal/puck/components/ThemeHeader.tsx
+++ b/packages/visual-editor/src/internal/puck/components/ThemeHeader.tsx
@@ -64,10 +64,7 @@ export const ThemeHeader = (props: ThemeHeaderProps) => {
     if (!themeHistories) {
       return false;
     }
-    if (themeHistories.index === 0) {
-      return false;
-    }
-    return true;
+    return themeHistories.index > 0;
   };
 
   const undo = () => {
@@ -75,8 +72,8 @@ export const ThemeHeader = (props: ThemeHeaderProps) => {
       return;
     }
     setThemeHistories({
-      histories: themeHistories?.histories,
-      index: themeHistories?.index - 1,
+      histories: themeHistories.histories,
+      index: themeHistories.index - 1,
     });
   };
 
@@ -84,10 +81,7 @@ export const ThemeHeader = (props: ThemeHeaderProps) => {
     if (!themeHistories) {
       return false;
     }
-    if (themeHistories.index === themeHistories.histories.length - 1) {
-      return false;
-    }
-    return true;
+    return themeHistories.index < themeHistories.histories.length - 1;
   };
 
   const redo = () => {
@@ -95,8 +89,8 @@ export const ThemeHeader = (props: ThemeHeaderProps) => {
       return;
     }
     setThemeHistories({
-      histories: themeHistories?.histories,
-      index: themeHistories?.index + 1,
+      histories: themeHistories.histories,
+      index: themeHistories.index + 1,
     });
   };
 

--- a/packages/visual-editor/src/internal/puck/components/ThemeHeader.tsx
+++ b/packages/visual-editor/src/internal/puck/components/ThemeHeader.tsx
@@ -9,6 +9,7 @@ import { UIButtonsToggle } from "../ui/UIButtonsToggle.tsx";
 import { ClearLocalChangesButton } from "../ui/ClearLocalChangesButton.tsx";
 import { InitialHistory, usePuck } from "@measured/puck";
 import { ThemeData, ThemeHistories } from "../../types/themeData.ts";
+import { RotateCcw, RotateCw } from "lucide-react";
 
 type ThemeHeaderProps = {
   onPublishTheme: () => Promise<void>;
@@ -59,6 +60,46 @@ export const ThemeHeader = (props: ThemeHeaderProps) => {
     }
   }, []);
 
+  const canUndo = (): boolean => {
+    if (!themeHistories) {
+      return false;
+    }
+    if (themeHistories.index === 0) {
+      return false;
+    }
+    return true;
+  };
+
+  const undo = () => {
+    if (!themeHistories) {
+      return false;
+    }
+    setThemeHistories({
+      histories: themeHistories?.histories,
+      index: themeHistories?.index - 1,
+    });
+  };
+
+  const canRedo = (): boolean => {
+    if (!themeHistories) {
+      return false;
+    }
+    if (themeHistories.index === themeHistories.histories.length - 1) {
+      return false;
+    }
+    return true;
+  };
+
+  const redo = () => {
+    if (!themeHistories) {
+      return;
+    }
+    setThemeHistories({
+      histories: themeHistories?.histories,
+      index: themeHistories?.index + 1,
+    });
+  };
+
   return (
     <header className="puck-header">
       <div className="header-left">
@@ -67,6 +108,23 @@ export const ThemeHeader = (props: ThemeHeaderProps) => {
       </div>
       <div className="header-center"></div>
       <div className="actions">
+        <Button
+          variant="ghost"
+          size="icon"
+          disabled={!canUndo()}
+          onClick={undo}
+        >
+          <RotateCcw className="sm-icon" />
+        </Button>
+
+        <Button
+          variant="ghost"
+          size="icon"
+          disabled={!canRedo()}
+          onClick={redo}
+        >
+          <RotateCw className="sm-icon" />
+        </Button>
         <ClearLocalChangesButton
           modalOpen={clearLocalChangesModalOpen}
           setModalOpen={setClearLocalChangesModalOpen}

--- a/packages/visual-editor/src/internal/puck/components/ThemeHeader.tsx
+++ b/packages/visual-editor/src/internal/puck/components/ThemeHeader.tsx
@@ -72,7 +72,7 @@ export const ThemeHeader = (props: ThemeHeaderProps) => {
 
   const undo = () => {
     if (!themeHistories) {
-      return false;
+      return;
     }
     setThemeHistories({
       histories: themeHistories?.histories,
@@ -113,6 +113,7 @@ export const ThemeHeader = (props: ThemeHeaderProps) => {
           size="icon"
           disabled={!canUndo()}
           onClick={undo}
+          aria-label="Undo"
         >
           <RotateCcw className="sm-icon" />
         </Button>
@@ -122,6 +123,7 @@ export const ThemeHeader = (props: ThemeHeaderProps) => {
           size="icon"
           disabled={!canRedo()}
           onClick={redo}
+          aria-label="Redo"
         >
           <RotateCw className="sm-icon" />
         </Button>


### PR DESCRIPTION
This adds undo and redo buttons to theme manager. Confirmed locally that the undo and redo buttons work as expected; they are disabled when there is nothing to go back to or go forward to, and they correctly update the index of the theme history. Making an edit while there are changes to "redo" erases those changes and moves the index to the end of the history with the new edit.