### PR TITLE
fix: editor flickers when saving state

### DIFF
--- a/packages/visual-editor/src/internal/components/InternalLayoutEditor.tsx
+++ b/packages/visual-editor/src/internal/components/InternalLayoutEditor.tsx
@@ -120,41 +120,45 @@ export const InternalLayoutEditor = ({
     }
   };
 
+  const puckConfigWithRootFields = React.useMemo(() => {
+    return {
+      ...puckConfig,
+      root: {
+        ...puckConfig.root,
+        fields: {
+          title: YextEntityFieldSelector<any, string>({
+            label: "Title",
+            filter: {
+              types: ["type.string"],
+            },
+          }),
+          description: YextEntityFieldSelector<any, string>({
+            label: "Description",
+            filter: {
+              types: ["type.string"],
+            },
+          }),
+        },
+        defaultProps: {
+          title: {
+            field: "name",
+            constantValue: "",
+            constantValueEnabled: false,
+          },
+          description: {
+            field: "description",
+            constantValue: "",
+            constantValueEnabled: false,
+          },
+        },
+      },
+    };
+  }, [puckConfig]);
+
   return (
     <EntityFieldProvider>
       <Puck
-        config={{
-          ...puckConfig,
-          root: {
-            ...puckConfig.root,
-            fields: {
-              title: YextEntityFieldSelector<any, string>({
-                label: "Title",
-                filter: {
-                  types: ["type.string"],
-                },
-              }),
-              description: YextEntityFieldSelector<any, string>({
-                label: "Description",
-                filter: {
-                  types: ["type.string"],
-                },
-              }),
-            },
-            defaultProps: {
-              title: {
-                field: "name",
-                constantValue: "",
-                constantValueEnabled: false,
-              },
-              description: {
-                field: "description",
-                constantValue: "",
-                constantValueEnabled: false,
-              },
-            },
-          },
-        }}
+        config={puckConfigWithRootFields}
         data={{}} // we use puckInitialHistory instead
         initialHistory={puckInitialHistory}
         onChange={change}


### PR DESCRIPTION
I'm not really sure why this fixes the flickering but it does. The problem seemed tied to layoutSaveState finishing and the config shouldn't be related, but Puck's rendering is often a little weird

Non-flickering example: https://www.yext.com/s/4259018/yextsites/153063/editor#pagesetId=newloc5&layoutId=newloc5-default-layout&themeId=ve-5&entityId=1095527880