### PR TITLE
fix: useEntityFields must be used within VisualEditorProvider

### DIFF
--- a/packages/visual-editor/src/components/editor/Editor.tsx
+++ b/packages/visual-editor/src/components/editor/Editor.tsx
@@ -5,6 +5,7 @@ import { LoadingScreen } from "../../internal/puck/components/LoadingScreen.tsx"
 import { Toaster } from "../../internal/puck/ui/Toaster.tsx";
 import { type Config } from "@measured/puck";
 import "@measured/puck/puck.css";
+import { useEntityFields } from "../../hooks/useEntityFields.tsx";
 import { DevLogger } from "../../utils/devLogger.ts";
 import { ThemeConfig } from "../../utils/themeResolver.ts";
 import { useQuickFindShortcut } from "../../internal/hooks/useQuickFindShortcut.ts";
@@ -37,6 +38,7 @@ export const Editor = ({
   const [devPageSets, setDevPageSets] = useState<any>(undefined);
   const [devSiteStream, setDevSiteStream] = useState<any>(undefined);
   const [parentLoaded, setParentLoaded] = useState<boolean>(false);
+  const entityFields = useEntityFields();
 
   const {
     templateMetadata,
@@ -107,7 +109,8 @@ export const Editor = ({
     !templateMetadata ||
     !document ||
     !layoutDataFetched ||
-    !themeDataFetched;
+    !themeDataFetched ||
+    entityFields === null;
 
   const progress: number =
     60 * // @ts-expect-error adding bools is fine
@@ -115,8 +118,9 @@ export const Editor = ({
       !!templateMetadata +
       !!document +
       layoutDataFetched +
-      themeDataFetched) /
-      5);
+      themeDataFetched +
+      (entityFields === null)) /
+      6);
 
   return (
     <ErrorBoundary fallback={<></>} onError={logError}>

--- a/packages/visual-editor/src/hooks/useEntityFields.tsx
+++ b/packages/visual-editor/src/hooks/useEntityFields.tsx
@@ -11,7 +11,7 @@ import { YextSchemaField } from "../types/entityFields.ts";
  * hooks with a more user-friendly name.
  */
 export const usePlatformBridgeEntityFields = () => {
-  const [entityFields, setEntityFields] = useState<any>(undefined);
+  const [entityFields, setEntityFields] = useState<any>([]);
 
   useReceiveMessage("getTemplateStream", TARGET_ORIGINS, (send, payload) => {
     setEntityFields(payload.stream.schema.fields);

--- a/packages/visual-editor/src/hooks/useEntityFields.tsx
+++ b/packages/visual-editor/src/hooks/useEntityFields.tsx
@@ -11,7 +11,9 @@ import { YextSchemaField } from "../types/entityFields.ts";
  * hooks with a more user-friendly name.
  */
 export const usePlatformBridgeEntityFields = () => {
-  const [entityFields, setEntityFields] = useState<any>([]);
+  const [entityFields, setEntityFields] = useState<YextSchemaField[] | null>(
+    null
+  );
 
   useReceiveMessage("getTemplateStream", TARGET_ORIGINS, (send, payload) => {
     setEntityFields(payload.stream.schema.fields);
@@ -29,7 +31,7 @@ export const usePlatformBridgeEntityFields = () => {
     });
   });
 
-  return entityFields as YextSchemaField[];
+  return entityFields;
 };
 
 const assignDefinitions = (entityFields: any): YextSchemaField[] => {
@@ -51,13 +53,15 @@ const assignDefinitions = (entityFields: any): YextSchemaField[] => {
   });
 };
 
-const EntityFieldsContext = React.createContext<YextSchemaField[] | undefined>(
-  undefined
-);
+const EntityFieldsContext = React.createContext<
+  YextSchemaField[] | null | undefined
+>(undefined);
 
 const useEntityFields = () => {
   const context = React.useContext(EntityFieldsContext);
-  if (!context) {
+  // context === undefined means useEntityFields outside VisualEditorProvider
+  // context === null means usePlatformBridgeEntityFields has not received a message yet
+  if (context === undefined) {
     throw new Error("useEntityFields must be used within VisualEditorProvider");
   }
 

--- a/packages/visual-editor/src/internal/utils/getFilteredEntityFields.ts
+++ b/packages/visual-editor/src/internal/utils/getFilteredEntityFields.ts
@@ -140,6 +140,9 @@ export const getFilteredEntityFields = <T extends Record<string, any>>(
   filter: RenderEntityFieldFilter<T>
 ) => {
   const entityFields = useEntityFields();
+  if (!entityFields) {
+    return [];
+  }
 
   let filteredEntityFields = entityFields.filter(
     (field) => !DEFAULT_DISALLOWED_ENTITY_FIELDS.includes(field.name)

--- a/packages/visual-editor/src/utils/VisualEditorProvider.tsx
+++ b/packages/visual-editor/src/utils/VisualEditorProvider.tsx
@@ -15,7 +15,7 @@ type UniversalProps<T> = {
 };
 
 type EditorProps = {
-  entityFields: YextSchemaField[];
+  entityFields: YextSchemaField[] | null;
   tailwindConfig: TailwindConfig;
 };
 


### PR DESCRIPTION
usePlatformBridgeEntityFields was undefined until the platform sent down the stream information, which would occasionally happen after all the other data was sent down. The other data was checked before loading the editor but this wasn't because it's set as context outside of the normal loading flow. `useEntityFields must be used within VisualEditorProvider` was thrown when the entityFields are undefined and useEntityFields is called, which is now immediately after loading because we render a YextEntityField selector for the root fields.

This fix distinguishes between not-in-provider and no-loaded-yet and checks that entity fields have loaded before loading the editor