### PR TITLE
fix: footer social media links

### DIFF
--- a/packages/visual-editor/src/components/puck/Footer.tsx
+++ b/packages/visual-editor/src/components/puck/Footer.tsx
@@ -61,37 +61,51 @@ const FooterComponent: React.FC<FooterProps> = (props) => {
   const socialLinks = [
     {
       name: "facebook",
-      link: document?._site?.facebookPageUrl,
+      link: document?._site?.facebookPageUrl
+        ? `https://www.facebook.com/${document._site.facebookPageUrl}`
+        : null,
       label: <FaFacebook className="w-5 h-5 mr-4" />,
     },
     {
       name: "instagram",
-      link: document?._site?.instagramHandle,
+      link: document?._site?.instagramHandle
+        ? `https://www.instagram.com/${document._site.instagramHandle}`
+        : null,
       label: <FaInstagram className="w-5 h-5 mr-4" />,
     },
     {
       name: "youtube",
-      link: document?._site?.youTubeChannelUrl,
+      link: document?._site?.youTubeChannelUrl
+        ? `https://www.youtube.com/${document._site.youTubeChannelUrl}`
+        : null,
       label: <FaYoutube className="w-5 h-5 mr-4" />,
     },
     {
       name: "linkedIn",
-      link: document?._site?.linkedInUrl,
+      link: document?._site?.linkedInUrl
+        ? `https://www.linkedin.com/in/${document._site.linkedInUrl}`
+        : null,
       label: <FaLinkedinIn className="w-5 h-5 mr-4" />,
     },
     {
       name: "twitter",
-      link: document?._site?.twitterHandle,
+      link: document?._site?.twitterHandle
+        ? `https://twitter.com/${document._site.twitterHandle}`
+        : null,
       label: <FaTwitter className="w-5 h-5 mr-4" />,
     },
     {
       name: "pinterest",
-      link: document?._site?.pinterestUrl,
+      link: document?._site?.pinterestUrl
+        ? `https://www.pinterest.com/${document._site.pinterestUrl}`
+        : null,
       label: <FaPinterest className="w-5 h-5 mr-4" />,
     },
     {
-      name: "titok",
-      link: document?._site?.tikTokUrl,
+      name: "tiktok",
+      link: document?._site?.tikTokUrl
+        ? `https://www.tiktok.com/@${document._site.tikTokUrl}`
+        : null,
       label: <FaTiktok className="w-5 h-5 mr-4" />,
     },
   ].filter((link) => link.link);

--- a/packages/visual-editor/src/components/puck/Footer.tsx
+++ b/packages/visual-editor/src/components/puck/Footer.tsx
@@ -61,9 +61,7 @@ const FooterComponent: React.FC<FooterProps> = (props) => {
   const socialLinks = [
     {
       name: "facebook",
-      link: document?._site?.facebookPageUrl
-        ? `https://www.facebook.com/${document._site.facebookPageUrl}`
-        : null,
+      link: document?._site?.facebookPageUrl,
       label: <FaFacebook className="w-5 h-5 mr-4" />,
     },
     {
@@ -75,16 +73,12 @@ const FooterComponent: React.FC<FooterProps> = (props) => {
     },
     {
       name: "youtube",
-      link: document?._site?.youTubeChannelUrl
-        ? `https://www.youtube.com/${document._site.youTubeChannelUrl}`
-        : null,
+      link: document?._site?.youTubeChannelUrl,
       label: <FaYoutube className="w-5 h-5 mr-4" />,
     },
     {
       name: "linkedIn",
-      link: document?._site?.linkedInUrl
-        ? `https://www.linkedin.com/in/${document._site.linkedInUrl}`
-        : null,
+      link: document?._site?.linkedInUrl,
       label: <FaLinkedinIn className="w-5 h-5 mr-4" />,
     },
     {
@@ -96,16 +90,12 @@ const FooterComponent: React.FC<FooterProps> = (props) => {
     },
     {
       name: "pinterest",
-      link: document?._site?.pinterestUrl
-        ? `https://www.pinterest.com/${document._site.pinterestUrl}`
-        : null,
+      link: document?._site?.pinterestUrl,
       label: <FaPinterest className="w-5 h-5 mr-4" />,
     },
     {
-      name: "tiktok",
-      link: document?._site?.tikTokUrl
-        ? `https://www.tiktok.com/@${document._site.tikTokUrl}`
-        : null,
+      name: "titok",
+      link: document?._site?.tikTokUrl,
       label: <FaTiktok className="w-5 h-5 mr-4" />,
     },
   ].filter((link) => link.link);


### PR DESCRIPTION
Prepend the correct base URLs for instagram and twitter as they are handles (rather than URLs)
- Instagram uses instagram.com/{handle}
- Twitter uses twitter.com/{username}

Rest of site entity has URL in the fieldName and takes in a URL. 