### PR TITLE
fix: grid columns on mobile

### DIFF
--- a/packages/visual-editor/src/components/puck/Grid.tsx
+++ b/packages/visual-editor/src/components/puck/Grid.tsx
@@ -48,6 +48,7 @@ const GridSection = React.forwardRef<HTMLDivElement, GridProps>(
           className={themeManagerCn(
             layoutVariants({ gap }),
             innerLayoutVariants({ maxContentWidth }),
+            "flex flex-col md:grid md:grid-cols-12",
             className
           )}
           ref={ref}


### PR DESCRIPTION
Fixed Grid columns so on mobile there's only one column. Confirmed theme padding works as expected.

