### PR TITLE
refactor: update components to use Link

### DIFF
--- a/packages/visual-editor/src/components/puck/Address.tsx
+++ b/packages/visual-editor/src/components/puck/Address.tsx
@@ -93,7 +93,7 @@ const Address = ({
                 cta={{
                   link: coordinates,
                   label: "Get Directions",
-                  linkType: "URL",
+                  linkType: "DRIVING_DIRECTIONS",
                 }}
                 target="_blank"
                 className="font-bold text-link-color text-link-fontSize underline hover:no-underline md:px-4;"

--- a/packages/visual-editor/src/components/puck/Card.tsx
+++ b/packages/visual-editor/src/components/puck/Card.tsx
@@ -382,7 +382,7 @@ const CardWrapper = ({
             <CTA
               variant={cta.variant}
               label={resolvedCTA.label ?? ""}
-              link={resolvedCTA?.link || "#"}
+              link={resolvedCTA.link || "#"}
               fontSize={cta.fontSize}
               linkType={cta.linkType}
             />

--- a/packages/visual-editor/src/components/puck/Card.tsx
+++ b/packages/visual-editor/src/components/puck/Card.tsx
@@ -13,7 +13,7 @@ import {
   getFontWeightOverrideOptions,
 } from "../../index.js";
 import { Body } from "./atoms/body.js";
-import { CTA, CTAProps } from "./atoms/cta.js";
+import { CTA, CTAProps, linkTypeFields } from "./atoms/cta.js";
 import {
   Heading,
   HeadingProps,
@@ -58,6 +58,7 @@ interface CardProps {
   };
   cta: {
     entityField: YextEntityField<CTAProps>;
+    linkType: CTAProps["linkType"];
     variant: CTAProps["variant"];
     fontSize: CTAProps["fontSize"];
   };
@@ -271,6 +272,7 @@ const cardFields: Fields<CardProps> = {
         ],
       },
       fontSize: FontSizeSelector(),
+      linkType: linkTypeFields,
     },
   },
   backgroundColor: {
@@ -379,9 +381,10 @@ const CardWrapper = ({
           {resolvedCTA && (
             <CTA
               variant={cta.variant}
-              label={resolvedCTA.name}
-              link={resolvedCTA.link ?? "#"}
+              label={resolvedCTA.label ?? ""}
+              link={resolvedCTA?.link || "#"}
               fontSize={cta.fontSize}
+              linkType={cta.linkType}
             />
           )}
         </div>
@@ -454,6 +457,7 @@ export const CardComponent: ComponentConfig<CardProps> = {
       },
       fontSize: "default",
       variant: "primary",
+      linkType: "URL",
     },
     backgroundColor: "bg-card-backgroundColor",
   },

--- a/packages/visual-editor/src/components/puck/CtaWrapper.tsx
+++ b/packages/visual-editor/src/components/puck/CtaWrapper.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { ComponentConfig, Fields } from "@measured/puck";
-import { CTA, CTAProps } from "./atoms/cta.js";
+import { CTA, CTAProps, linkTypeFields } from "./atoms/cta.js";
 import {
   useDocument,
   resolveYextEntityField,
@@ -17,6 +17,7 @@ interface CTAWrapperProps {
   size: CTAProps["size"];
   borderRadius: CTAProps["borderRadius"];
   fontSize: CTAProps["fontSize"];
+  linkType: CTAProps["linkType"];
   className?: CTAProps["className"];
 }
 
@@ -43,6 +44,7 @@ const ctaWrapperFields: Fields<CTAWrapperProps> = {
       { label: "Large", value: "large" },
     ],
   },
+  linkType: linkTypeFields,
   fontSize: FontSizeSelector("Font Size", false),
   borderRadius: BorderRadiusSelector(),
 };
@@ -91,6 +93,7 @@ const CTAWrapperComponent: ComponentConfig<CTAWrapperProps> = {
     variant: "primary",
     fontSize: "default",
     borderRadius: "default",
+    linkType: "URL",
     size: "small",
   },
   render: (props) => <CTAWrapper {...props} />,

--- a/packages/visual-editor/src/components/puck/GetDirections.tsx
+++ b/packages/visual-editor/src/components/puck/GetDirections.tsx
@@ -1,10 +1,9 @@
 import * as React from "react";
 import { ComponentConfig, Fields } from "@measured/puck";
-import { Button, ButtonProps } from "./atoms/button.js";
+import { ButtonProps } from "./atoms/button.js";
 import {
   getDirections,
   GetDirectionsConfig,
-  Link,
   Coordinate,
 } from "@yext/pages-components";
 import "@yext/pages-components/style.css";
@@ -16,6 +15,7 @@ import {
   FontSizeSelector,
   EntityField,
   BorderRadiusSelector,
+  CTA,
 } from "../../index.js";
 
 type GetDirectionsProps = {
@@ -92,17 +92,15 @@ const GetDirections = ({
       fieldId={coordinateField.field}
       constantValueEnabled={coordinateField.constantValueEnabled}
     >
-      <Button
-        asChild
-        variant={variant}
+      <CTA
+        label={"Get Directions"}
+        link={searchQuery ?? "#"}
+        linkType={"URL"}
         size={size}
+        variant={variant}
         fontSize={fontSize}
         borderRadius={borderRadius}
-      >
-        <Link href={searchQuery ?? "#"} target="_blank">
-          {"Get Directions"}
-        </Link>
-      </Button>
+      />
     </EntityField>
   );
 };

--- a/packages/visual-editor/src/components/puck/GetDirections.tsx
+++ b/packages/visual-editor/src/components/puck/GetDirections.tsx
@@ -94,8 +94,8 @@ const GetDirections = ({
     >
       <CTA
         label={"Get Directions"}
-        link={searchQuery ?? "#"}
-        linkType={"URL"}
+        link={searchQuery || "#"}
+        linkType={"DRIVING_DIRECTIONS"}
         size={size}
         variant={variant}
         fontSize={fontSize}

--- a/packages/visual-editor/src/components/puck/Promo.tsx
+++ b/packages/visual-editor/src/components/puck/Promo.tsx
@@ -11,7 +11,7 @@ import {
   FontSizeSelector,
 } from "../../index.js";
 import { Body } from "./atoms/body.js";
-import { CTA, CTAProps } from "./atoms/cta.js";
+import { CTA, CTAProps, linkTypeFields } from "./atoms/cta.js";
 import { Heading, HeadingProps } from "./atoms/heading.js";
 import { Section } from "./atoms/section.js";
 import { imageWrapperVariants, ImageWrapperProps } from "./Image.js";
@@ -42,6 +42,7 @@ interface PromoProps {
     entityField: YextEntityField<CTAProps>;
     variant: CTAProps["variant"];
     fontSize: CTAProps["fontSize"];
+    linkType: CTAProps["linkType"];
   };
 }
 
@@ -186,6 +187,7 @@ const promoFields: Fields<PromoProps> = {
         ],
       },
       fontSize: FontSizeSelector(),
+      linkType: linkTypeFields,
     },
   },
 };
@@ -261,8 +263,9 @@ const PromoWrapper: React.FC<PromoProps> = ({
           {resolvedCTA && (
             <CTA
               variant={cta.variant}
-              label={resolvedCTA.name}
-              link={resolvedCTA.link ?? "#"}
+              label={resolvedCTA.label ?? ""}
+              link={resolvedCTA?.link || "#"}
+              linkType={cta.linkType}
               fontSize={cta.fontSize}
             />
           )}
@@ -321,6 +324,7 @@ export const PromoComponent: ComponentConfig<PromoProps> = {
       },
       fontSize: "default",
       variant: "primary",
+      linkType: "URL",
     },
   },
   render: (props) => <PromoWrapper {...props} />,

--- a/packages/visual-editor/src/components/puck/Promo.tsx
+++ b/packages/visual-editor/src/components/puck/Promo.tsx
@@ -264,7 +264,7 @@ const PromoWrapper: React.FC<PromoProps> = ({
             <CTA
               variant={cta.variant}
               label={resolvedCTA.label ?? ""}
-              link={resolvedCTA?.link || "#"}
+              link={resolvedCTA.link || "#"}
               linkType={cta.linkType}
               fontSize={cta.fontSize}
             />

--- a/packages/visual-editor/src/components/puck/atoms/cta.tsx
+++ b/packages/visual-editor/src/components/puck/atoms/cta.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Link, LinkType } from "@yext/pages-components";
 import { Button, ButtonProps } from "./button.js";
+import { Field } from "@measured/puck";
 
 export interface CTAProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -12,6 +13,19 @@ export interface CTAProps
   borderRadius?: ButtonProps["borderRadius"];
   fontSize?: ButtonProps["fontSize"];
 }
+
+const linkTypeFields: Field = {
+  type: "select",
+  label: "Link Type",
+  options: [
+    { label: "URL", value: "URL" },
+    { label: "Email", value: "EMAIL" },
+    { label: "Phone", value: "PHONE" },
+    { label: "Driving Directions", value: "DRIVING_DIRECTIONS" },
+    { label: "Click to Website", value: "CLICK_TO_WEBSITE" },
+    { label: "Other", value: "OTHER" },
+  ],
+};
 
 const CTA = ({
   label,
@@ -46,4 +60,4 @@ const CTA = ({
 
 CTA.displayName = "CTA";
 
-export { CTA };
+export { CTA, linkTypeFields };

--- a/starter/src/ve.config.tsx
+++ b/starter/src/ve.config.tsx
@@ -38,6 +38,8 @@ import {
   FooterProps,
   Breadcrumbs,
   BreadcrumbsProps,
+  Promo,
+  PromoProps,
 } from "@yext/visual-editor";
 
 type MainProps = {
@@ -58,6 +60,7 @@ type MainProps = {
   HoursStatus: HoursStatusProps;
   ImageWrapper: ImageWrapperProps;
   Phone: PhoneProps;
+  Promo: PromoProps;
   TextList: TextListProps;
 };
 
@@ -81,6 +84,7 @@ export const mainConfig: Config<MainProps> = {
     HoursStatus,
     ImageWrapper,
     Phone,
+    Promo,
     TextList,
   },
   root: {


### PR DESCRIPTION
Updates GetDirections to use CTA instead of a Button + Link combo.

Updates various other components to add a Link Type prop or set one by default.

Fixes a VE crash when entering a blank constant value for Promo or Card CTA link.

Verified that the appearance and functionality of the components are not any different than before.