### PR TITLE
fix: prevent loading bar from going backwards

### DIFF
--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -73,6 +73,7 @@
     "@eslint/js": "^9.8.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^16.0.1",
+    "@testing-library/react-hooks": "^8.0.1",
     "@types/fs-extra": "^11.0.4",
     "@types/minimist": "^1.2.5",
     "@types/node": "^20.14.11",

--- a/packages/visual-editor/src/components/editor/Editor.tsx
+++ b/packages/visual-editor/src/components/editor/Editor.tsx
@@ -13,6 +13,7 @@ import { useCommonMessageReceivers } from "../../internal/hooks/useMessageReceiv
 import { LayoutEditor } from "../../internal/components/LayoutEditor.tsx";
 import { ThemeEditor } from "../../internal/components/ThemeEditor.tsx";
 import { useCommonMessageSenders } from "../../internal/hooks/useMessageSenders.ts";
+import { useProgress } from "../../internal/hooks/useProgress.ts";
 
 const devLogger = new DevLogger();
 
@@ -104,28 +105,22 @@ export const Editor = ({
     }
   }, [templateMetadata?.isDevMode, devPageSets]);
 
-  const isLoading =
-    !puckConfig ||
-    !templateMetadata ||
-    !document ||
-    !layoutDataFetched ||
-    !themeDataFetched ||
-    entityFields === null;
-
-  const progress: number =
-    60 * // @ts-expect-error adding bools is fine
-    ((!!puckConfig +
-      !!templateMetadata +
-      !!document +
-      layoutDataFetched +
-      themeDataFetched +
-      (entityFields === null)) /
-      6);
+  const { isLoading, progress } = useProgress({
+    maxProgress: 60,
+    completionCriteria: [
+      !!puckConfig,
+      !!templateMetadata,
+      !!document,
+      layoutDataFetched,
+      themeDataFetched,
+      entityFields !== null,
+    ],
+  });
 
   return (
     <ErrorBoundary fallback={<></>} onError={logError}>
-      {!isLoading ? (
-        templateMetadata.isThemeMode || forceThemeMode ? (
+      {!isLoading && puckConfig && templateMetadata ? (
+        templateMetadata?.isThemeMode || forceThemeMode ? (
           <ThemeEditor
             puckConfig={puckConfig}
             templateMetadata={templateMetadata}

--- a/packages/visual-editor/src/components/editor/Editor.tsx
+++ b/packages/visual-editor/src/components/editor/Editor.tsx
@@ -119,11 +119,11 @@ export const Editor = ({
 
   return (
     <ErrorBoundary fallback={<></>} onError={logError}>
-      {!isLoading && puckConfig && templateMetadata ? (
+      {!isLoading ? (
         templateMetadata?.isThemeMode || forceThemeMode ? (
           <ThemeEditor
-            puckConfig={puckConfig}
-            templateMetadata={templateMetadata}
+            puckConfig={puckConfig!}
+            templateMetadata={templateMetadata!}
             layoutData={layoutData!}
             themeData={themeData!}
             themeConfig={themeConfig}
@@ -131,8 +131,8 @@ export const Editor = ({
           />
         ) : (
           <LayoutEditor
-            puckConfig={puckConfig}
-            templateMetadata={templateMetadata}
+            puckConfig={puckConfig!}
+            templateMetadata={templateMetadata!}
             layoutData={layoutData!}
             themeData={themeData!}
             themeConfig={themeConfig}

--- a/packages/visual-editor/src/internal/components/LayoutEditor.tsx
+++ b/packages/visual-editor/src/internal/components/LayoutEditor.tsx
@@ -12,6 +12,7 @@ import { ThemeConfig } from "../../utils/themeResolver.ts";
 import { updateThemeInEditor } from "../../utils/applyTheme.ts";
 import { useThemeLocalStorage } from "../hooks/theme/useLocalStorage.ts";
 import { useCommonMessageSenders } from "../hooks/useMessageSenders.ts";
+import { useProgress } from "../hooks/useProgress.ts";
 import * as lzstring from "lz-string";
 
 const devLogger = new DevLogger();
@@ -230,9 +231,10 @@ export const LayoutEditor = (props: LayoutEditorProps) => {
     });
   }, [puckInitialHistoryFetched, puckInitialHistory, templateMetadata]);
 
-  const isLoading = !puckInitialHistoryFetched || !layoutSaveStateFetched;
-  const progress = // @ts-expect-error adding bools is fine
-    60 + (puckInitialHistoryFetched + layoutSaveStateFetched) * 20;
+  const { isLoading, progress } = useProgress({
+    minProgress: 60,
+    completionCriteria: [puckInitialHistoryFetched, layoutSaveStateFetched],
+  });
 
   return !isLoading ? (
     <InternalLayoutEditor

--- a/packages/visual-editor/src/internal/components/ThemeEditor.tsx
+++ b/packages/visual-editor/src/internal/components/ThemeEditor.tsx
@@ -18,6 +18,7 @@ import { LoadingScreen } from "../puck/components/LoadingScreen.tsx";
 import { ThemeHistories, ThemeHistory, ThemeData } from "../types/themeData.ts";
 import { useLayoutLocalStorage } from "../hooks/layout/useLocalStorage.ts";
 import { useCommonMessageSenders } from "../hooks/useMessageSenders.ts";
+import { useProgress } from "../hooks/useProgress.ts";
 import * as lzstring from "lz-string";
 
 const devLogger = new DevLogger();
@@ -253,15 +254,14 @@ export const ThemeEditor = (props: ThemeEditorProps) => {
     });
   }, [themeHistoryFetched, themeHistories, templateMetadata]);
 
-  const isLoading =
-    !puckInitialHistoryFetched ||
-    !themeHistoryFetched ||
-    !themeSaveStateFetched;
-
-  const progress =
-    60 + // @ts-expect-error adding bools is fine
-    (puckInitialHistoryFetched + themeHistoryFetched + themeSaveStateFetched) *
-      13.33;
+  const { isLoading, progress } = useProgress({
+    minProgress: 60,
+    completionCriteria: [
+      puckInitialHistoryFetched,
+      themeHistoryFetched,
+      themeSaveStateFetched,
+    ],
+  });
 
   return !isLoading ? (
     <InternalThemeEditor

--- a/packages/visual-editor/src/internal/hooks/useProgress.test.ts
+++ b/packages/visual-editor/src/internal/hooks/useProgress.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react-hooks";
+import { useProgress } from "./useProgress.ts";
+
+describe("useProgress", () => {
+  it("should return 100% progress when all criteria are true", () => {
+    const { result } = renderHook(() =>
+      useProgress({ completionCriteria: [true, true, true] })
+    );
+    expect(result.current.progress).toBe(100);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("should return 0% progress when all criteria are false", () => {
+    const { result } = renderHook(() =>
+      useProgress({ completionCriteria: [false, false, false] })
+    );
+    expect(result.current.progress).toBe(0);
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("should use default minProgress (0) and maxProgress (100) when not provided", () => {
+    const { result } = renderHook(() =>
+      useProgress({ completionCriteria: [true, false, true] })
+    );
+    expect(result.current.progress).toBe(67);
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("should respect custom minProgress value", () => {
+    const { result } = renderHook(() =>
+      useProgress({ minProgress: 20, completionCriteria: [true, false, true] })
+    );
+    expect(result.current.progress).toBe(73);
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("should respect custom maxProgress value", () => {
+    const { result } = renderHook(() =>
+      useProgress({ maxProgress: 80, completionCriteria: [true, false, true] })
+    );
+    expect(result.current.progress).toBe(53);
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("should respect custom minProgress and maxProgress values", () => {
+    const { result } = renderHook(() =>
+      useProgress({
+        minProgress: 20,
+        maxProgress: 80,
+        completionCriteria: [true, false, true],
+      })
+    );
+    expect(result.current.progress).toBe(60);
+    expect(result.current.isLoading).toBe(true);
+  });
+});

--- a/packages/visual-editor/src/internal/hooks/useProgress.ts
+++ b/packages/visual-editor/src/internal/hooks/useProgress.ts
@@ -1,0 +1,39 @@
+import { useMemo } from "react";
+
+interface UseProgressProps {
+  minProgress?: number;
+  maxProgress?: number;
+  completionCriteria: boolean[];
+}
+
+/**
+ * A custom hook that calculates the progress as a percentage based on an array of boolean values.
+ * It returns whether the process is loading (`isLoading`) and the progress percentage (`progress`).
+ *
+ * @param minProgress - The minimum value for progress (default is 0).
+ * @param maxProgress - The maximum value for progress (default is 100).
+ * @param completionCriteria - An array of boolean values representing the criteria for the loading process completion.
+ *
+ * @returns {Object} - { isLoading: boolean, progress: number }
+ */
+export const useProgress = ({
+  minProgress = 0,
+  maxProgress = 100,
+  completionCriteria,
+}: UseProgressProps) => {
+  // Check if any value is false to determine if loading is true
+  const isLoading = useMemo(
+    () => completionCriteria.includes(false),
+    [completionCriteria]
+  );
+
+  // Calculate the progress as the fraction of 'true' values, scaled from minProgress to maxProgress
+  const progress = useMemo(() => {
+    const trueCount = completionCriteria.filter(Boolean).length;
+    const totalCount = completionCriteria.length;
+    const fraction = totalCount > 0 ? trueCount / totalCount : 0;
+    return Math.round(minProgress + fraction * (maxProgress - minProgress));
+  }, [completionCriteria, minProgress, maxProgress]);
+
+  return { isLoading, progress };
+};

--- a/packages/visual-editor/src/internal/puck/components/LoadingScreen.tsx
+++ b/packages/visual-editor/src/internal/puck/components/LoadingScreen.tsx
@@ -8,9 +8,17 @@ export type LoadingScreenProps = {
 };
 
 export function LoadingScreen({ progress }: LoadingScreenProps) {
+  // This ensures that the progress bar never goes backwards.
+  const [maxProgress, setMaxProgress] = React.useState(0);
+  React.useEffect(() => {
+    if (progress > maxProgress) {
+      setMaxProgress(progress);
+    }
+  }, [progress, maxProgress]);
+
   return (
     <div className="ve-flex ve-h-screen ve-loading-wrapper ve-w-screen ve-flex-col ve-items-center ve-justify-center">
-      <Progress className="ve-w-1/3 ve-loading-progress" value={progress} />
+      <Progress className="ve-w-1/3 ve-loading-progress" value={maxProgress} />
       <div>Loading Visual Editor...</div>
     </div>
   );

--- a/packages/visual-editor/src/internal/puck/components/LoadingScreen.tsx
+++ b/packages/visual-editor/src/internal/puck/components/LoadingScreen.tsx
@@ -8,17 +8,9 @@ export type LoadingScreenProps = {
 };
 
 export function LoadingScreen({ progress }: LoadingScreenProps) {
-  // This ensures that the progress bar never goes backwards.
-  const [maxProgress, setMaxProgress] = React.useState(0);
-  React.useEffect(() => {
-    if (progress > maxProgress) {
-      setMaxProgress(progress);
-    }
-  }, [progress, maxProgress]);
-
   return (
     <div className="ve-flex ve-h-screen ve-loading-wrapper ve-w-screen ve-flex-col ve-items-center ve-justify-center">
-      <Progress className="ve-w-1/3 ve-loading-progress" value={maxProgress} />
+      <Progress className="ve-w-1/3 ve-loading-progress" value={progress} />
       <div>Loading Visual Editor...</div>
     </div>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,6 +194,9 @@ importers:
       "@testing-library/react":
         specifier: ^16.0.1
         version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@testing-library/react-hooks":
+        specifier: ^8.0.1
+        version: 8.0.1(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       "@types/fs-extra":
         specifier: ^11.0.4
         version: 11.0.4
@@ -3118,6 +3121,25 @@ packages:
         integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==,
       }
     engines: { node: ">=18" }
+
+  "@testing-library/react-hooks@8.0.1":
+    resolution:
+      {
+        integrity: sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==,
+      }
+    engines: { node: ">=12" }
+    peerDependencies:
+      "@types/react": ^16.9.0 || ^17.0.0
+      react: ^16.9.0 || ^17.0.0
+      react-dom: ^16.9.0 || ^17.0.0
+      react-test-renderer: ^16.9.0 || ^17.0.0
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      react-dom:
+        optional: true
+      react-test-renderer:
+        optional: true
 
   "@testing-library/react@16.0.1":
     resolution:
@@ -11958,6 +11980,15 @@ snapshots:
       dom-accessibility-api: 0.5.16
       lz-string: 1.5.0
       pretty-format: 27.5.1
+
+  "@testing-library/react-hooks@8.0.1(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
+    dependencies:
+      "@babel/runtime": 7.26.0
+      react: 18.3.1
+      react-error-boundary: 3.1.4(react@18.3.1)
+    optionalDependencies:
+      "@types/react": 18.3.12
+      react-dom: 18.3.1(react@18.3.1)
 
   "@testing-library/react@16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
     dependencies:


### PR DESCRIPTION
This fixes an issue that caused the progress bar to go backwards at times. It also adds a new `useProgress` hook that provides `isLoading` and `progress` values when given a set of completion criteria so we can more easily work with the progress bars in the future.

https://github.com/user-attachments/assets/4daf5508-d844-4d31-9c12-eb096bf4f879