### PR TITLE
feat: disable component selection in theme mode

### DIFF
--- a/packages/visual-editor/src/internal/puck/components/ThemeHeader.tsx
+++ b/packages/visual-editor/src/internal/puck/components/ThemeHeader.tsx
@@ -66,19 +66,22 @@ export const ThemeHeader = (props: ThemeHeaderProps) => {
       fieldListTitle.style.display = "none";
     }
     // Disable component selection in the preview
-    const clickBlocker = (event: MouseEvent) => {
-      event.stopPropagation();
-      event.preventDefault();
-    };
+    const abortController = new AbortController();
+    const signal = abortController.signal;
     const puckPreview =
       document.querySelector<HTMLIFrameElement>("#preview-frame");
     if (puckPreview?.contentDocument) {
-      puckPreview.contentDocument.addEventListener("click", clickBlocker);
+      puckPreview.contentDocument.addEventListener(
+        "click",
+        (event: MouseEvent) => {
+          event.stopPropagation();
+          event.preventDefault();
+        },
+        { signal }
+      );
     }
     return () => {
-      if (puckPreview?.contentDocument) {
-        puckPreview.contentDocument.removeEventListener("click", clickBlocker);
-      }
+      abortController.abort();
     };
   }, []);
 

--- a/packages/visual-editor/src/internal/puck/components/ThemeHeader.tsx
+++ b/packages/visual-editor/src/internal/puck/components/ThemeHeader.tsx
@@ -58,6 +58,11 @@ export const ThemeHeader = (props: ThemeHeaderProps) => {
     if (fieldListTitle) {
       fieldListTitle.style.display = "none";
     }
+    // Disable component selection in the preview
+    const puckPreview = document.getElementById("puck-preview");
+    if (puckPreview) {
+      puckPreview.style.pointerEvents = "none";
+    }
   }, []);
 
   const canUndo = (): boolean => {

--- a/packages/visual-editor/src/internal/puck/components/ThemeHeader.tsx
+++ b/packages/visual-editor/src/internal/puck/components/ThemeHeader.tsx
@@ -37,11 +37,18 @@ export const ThemeHeader = (props: ThemeHeaderProps) => {
   } = props;
 
   const {
+    dispatch,
     history: { setHistories },
   } = usePuck();
 
   useEffect(() => {
     setHistories(puckInitialHistory?.histories || []);
+    dispatch({
+      type: "setUi",
+      ui: {
+        previewMode: "interactive",
+      },
+    });
   }, [puckInitialHistory]);
 
   useEffect(() => {
@@ -59,9 +66,13 @@ export const ThemeHeader = (props: ThemeHeaderProps) => {
       fieldListTitle.style.display = "none";
     }
     // Disable component selection in the preview
-    const puckPreview = document.getElementById("puck-preview");
-    if (puckPreview) {
-      puckPreview.style.pointerEvents = "none";
+    const puckPreview =
+      document.querySelector<HTMLIFrameElement>("#preview-frame");
+    if (puckPreview?.contentDocument) {
+      puckPreview.contentDocument.addEventListener("click", (event) => {
+        event.stopPropagation();
+        event.preventDefault();
+      });
     }
   }, []);
 

--- a/packages/visual-editor/src/internal/puck/components/ThemeHeader.tsx
+++ b/packages/visual-editor/src/internal/puck/components/ThemeHeader.tsx
@@ -66,14 +66,20 @@ export const ThemeHeader = (props: ThemeHeaderProps) => {
       fieldListTitle.style.display = "none";
     }
     // Disable component selection in the preview
+    const clickBlocker = (event: MouseEvent) => {
+      event.stopPropagation();
+      event.preventDefault();
+    };
     const puckPreview =
       document.querySelector<HTMLIFrameElement>("#preview-frame");
     if (puckPreview?.contentDocument) {
-      puckPreview.contentDocument.addEventListener("click", (event) => {
-        event.stopPropagation();
-        event.preventDefault();
-      });
+      puckPreview.contentDocument.addEventListener("click", clickBlocker);
     }
+    return () => {
+      if (puckPreview?.contentDocument) {
+        puckPreview.contentDocument.removeEventListener("click", clickBlocker);
+      }
+    };
   }, []);
 
   const canUndo = (): boolean => {


### PR DESCRIPTION
This switches Puck to interactive mode so the overlays go away but then adds a click listener to the iframe so that button/link clicks don't bomb out the editor.


https://github.com/user-attachments/assets/5b931e38-e316-43c8-a5b1-cefb0afc14e4

