### PR TITLE
fix: undefined footer links

### DIFF
--- a/packages/visual-editor/src/components/puck/Footer.tsx
+++ b/packages/visual-editor/src/components/puck/Footer.tsx
@@ -169,7 +169,7 @@ const FooterSocialIcons = ({ socialLinks }: { socialLinks: socialLink[] }) => {
         socialLink.link ? (
           <Link
             key={idx}
-            href={`${socialLink.prefix}${socialLink.link}`}
+            href={`${socialLink.prefix ?? ""}${socialLink.link}`}
             eventName={socialLink.name}
           >
             {socialLink.label}


### PR DESCRIPTION
Links that didn't have a prefix were showing up as `undefinedhttps:// ...`

<img width="1840" alt="Screenshot 2025-03-05 at 11 33 38 AM" src="https://github.com/user-attachments/assets/85da46ef-33ea-4e33-a5d6-92ca94e0697e" />
