### PR TITLE
feat: get googleTagManagerId from visualEditorConfig instead of theme

### DIFF
--- a/packages/visual-editor/src/utils/applyAnalytics.ts
+++ b/packages/visual-editor/src/utils/applyAnalytics.ts
@@ -3,7 +3,7 @@ export const applyAnalytics = (document: Record<string, any>) => {
     return;
   }
 
-  const googleTagManagerId: string = JSON.parse(document.__.theme)
+  const googleTagManagerId: string = JSON.parse(document.__.siteSettings)
     ?.siteAttributes?.googleTagManagerId;
 
   if (googleTagManagerId) {

--- a/packages/visual-editor/src/utils/applyAnalytics.ts
+++ b/packages/visual-editor/src/utils/applyAnalytics.ts
@@ -1,9 +1,9 @@
 export const applyAnalytics = (document: Record<string, any>) => {
-  if (!document?.__?.theme) {
+  if (!document?.__?.visualEditorConfig) {
     return;
   }
 
-  const googleTagManagerId: string = JSON.parse(document.__.siteSettings)
+  const googleTagManagerId: string = JSON.parse(document.__.visualEditorConfig)
     ?.siteAttributes?.googleTagManagerId;
 
   if (googleTagManagerId) {


### PR DESCRIPTION
To be tested when the VE siteSettings PRs are merged