### PR TITLE
fix: editor returns error 404 when in reseller account

### DIFF
--- a/packages/visual-editor/src/components/editor/Editor.tsx
+++ b/packages/visual-editor/src/components/editor/Editor.tsx
@@ -62,21 +62,13 @@ export const Editor = ({
     });
   };
 
-  // redirect to 404 page when going to /edit page outside of Storm
+  // redirect to 404 page when going to /edit outside of iframe
   useEffect(() => {
     if (typeof window !== "undefined" && !localDev) {
-      const referrer = window.document.referrer;
-
-      if (!referrer) {
-        window.location.assign("/404.html");
-      } else if (
-        !referrer.includes("pagescdn") &&
-        !referrer.includes("yext.com") &&
-        !referrer.includes("localhost")
-      ) {
-        window.location.assign("/404.html");
-      } else {
+      if (window.parent !== window.self) {
         setParentLoaded(true);
+      } else {
+        window.location.assign("/404.html");
       }
     }
   }, []);


### PR DESCRIPTION
Resellers can serve Storm from a white labelled url other than yext.com, so we can't do a simple referrer url check.

This checks if the editor has been loaded in any iframe -- while this is more permissive than the old check, I think the main point is to ensure hitting /edit directly from a browser/crawler returns a 404? 