### PR TITLE
fix: read relativePrefixToRoot from templateProps

### DIFF
--- a/packages/visual-editor/src/components/puck/Breadcrumbs.tsx
+++ b/packages/visual-editor/src/components/puck/Breadcrumbs.tsx
@@ -22,7 +22,10 @@ export const BreadcrumbsComponent = (props: BreadcrumbsProps) => {
   const { document, relativePrefixToRoot } = useTemplateProps<any>();
   let breadcrumbs = getDirectoryParents(document);
   if (breadcrumbs) {
-    breadcrumbs = [...breadcrumbs, { name: document.name, slug: "" }];
+    // append the current and filter out missing or malformed data
+    breadcrumbs = [...breadcrumbs, { name: document.name, slug: "" }].filter(
+      (b) => b.name
+    );
   }
 
   return (

--- a/packages/visual-editor/src/components/puck/Breadcrumbs.tsx
+++ b/packages/visual-editor/src/components/puck/Breadcrumbs.tsx
@@ -1,4 +1,4 @@
-import { useDocument } from "../../index.js";
+import { useTemplateProps } from "../../index.js";
 import { ComponentConfig } from "@measured/puck";
 import { MaybeLink } from "./atoms/maybeLink.js";
 
@@ -19,7 +19,7 @@ const getDirectoryParents = (
 
 export const BreadcrumbsComponent = (props: BreadcrumbsProps) => {
   const { separator = "/" } = props;
-  const document = useDocument<any>();
+  const { document, relativePrefixToRoot } = useTemplateProps<any>();
   const breadcrumbs = getDirectoryParents(document);
 
   return (
@@ -29,8 +29,8 @@ export const BreadcrumbsComponent = (props: BreadcrumbsProps) => {
           <ol className="components flex flex-wrap text-link-fontSize text-body-color">
             {breadcrumbs.map(({ name, slug }, idx) => {
               const isLast = idx === breadcrumbs.length - 1;
-              const href = document.relativePrefixToRoot
-                ? document.relativePrefixToRoot + slug
+              const href = relativePrefixToRoot
+                ? relativePrefixToRoot + slug
                 : slug;
               return (
                 <li key={idx}>

--- a/packages/visual-editor/src/components/puck/Breadcrumbs.tsx
+++ b/packages/visual-editor/src/components/puck/Breadcrumbs.tsx
@@ -20,7 +20,10 @@ const getDirectoryParents = (
 export const BreadcrumbsComponent = (props: BreadcrumbsProps) => {
   const { separator = "/" } = props;
   const { document, relativePrefixToRoot } = useTemplateProps<any>();
-  const breadcrumbs = getDirectoryParents(document);
+  let breadcrumbs = getDirectoryParents(document);
+  if (breadcrumbs) {
+    breadcrumbs = [...breadcrumbs, { name: document.name, slug: "" }];
+  }
 
   return (
     <div>

--- a/packages/visual-editor/src/components/puck/Directory.tsx
+++ b/packages/visual-editor/src/components/puck/Directory.tsx
@@ -1,11 +1,10 @@
-import { useDocument } from "../../hooks/useDocument.tsx";
+import { useTemplateProps, themeManagerCn } from "../../index.js";
 import { BreadcrumbsComponent } from "./Breadcrumbs.tsx";
 import { ComponentConfig } from "@measured/puck";
 import { MaybeLink } from "./atoms/maybeLink.tsx";
 import { Address, HoursStatus } from "@yext/pages-components";
 import { innerLayoutVariants, layoutVariants } from "./Layout.tsx";
 import { Section } from "./atoms/section.tsx";
-import { themeManagerCn } from "../../utils/index.ts";
 
 // isDirectoryGrid indicates whether the children should appear in
 // DirectoryGrid or DirectoryList dependent on the dm_directoryChildren type.
@@ -145,7 +144,7 @@ const DirectoryList = ({
 
 const DirectoryComponent = (props: DirectoryProps) => {
   const { separator = "/" } = props;
-  const document = useDocument<any>();
+  const { document, relativePrefixToRoot } = useTemplateProps<any>();
 
   return (
     <>
@@ -156,14 +155,14 @@ const DirectoryComponent = (props: DirectoryProps) => {
         isDirectoryGrid(document.dm_directoryChildren) && (
           <DirectoryGrid
             directoryChildren={document.dm_directoryChildren}
-            relativePrefixToRoot={document.relativePrefixToRoot}
+            relativePrefixToRoot={relativePrefixToRoot}
           />
         )}
       {document.dm_directoryChildren &&
         !isDirectoryGrid(document.dm_directoryChildren) && (
           <DirectoryList
             directoryChildren={document.dm_directoryChildren}
-            relativePrefixToRoot={document.relativePrefixToRoot}
+            relativePrefixToRoot={relativePrefixToRoot}
           />
         )}
     </>


### PR DESCRIPTION
relativePrefixToRoot is a property of TemplateProps instead of document

Consulting also has a sneaky addition of the current entity to the breadcrumbs [here](https://github.com/yextconsulting/pages-starter-react-consulting/blob/main/src/layouts/region/transformProps.tsx) that we were missing 

If directory parents come back without name fields, filter those items out so that undefined does not appear 