### PR TITLE
fix: adjust plugin on server start

### DIFF
--- a/packages/visual-editor/src/vite-plugin/plugin.ts
+++ b/packages/visual-editor/src/vite-plugin/plugin.ts
@@ -45,7 +45,19 @@ export const yextVisualEditorPlugin = (): Plugin => {
     config(_, { command }) {
       isBuildMode = command === "build";
     },
+    configureServer(server) {
+      if (isBuildMode) {
+        return;
+      }
+      generateFiles();
+      server.httpServer?.on("close", () => {
+        cleanupFiles();
+      });
+    },
     buildStart() {
+      if (!isBuildMode) {
+        return;
+      }
       generateFiles();
     },
     buildEnd() {


### PR DESCRIPTION
So without these changes, buildStart would occur multiple times (likely due to our vite server start up via express). Changed it to only generateFiles once on server start. 

Past thread: https://github.com/yext/visual-editor/pull/252#discussion_r1993933560

