### PR TITLE
fix: google tag manager id path

### DIFF
--- a/packages/visual-editor/src/utils/applyAnalytics.ts
+++ b/packages/visual-editor/src/utils/applyAnalytics.ts
@@ -3,8 +3,9 @@ export const applyAnalytics = (document: Record<string, any>) => {
     return;
   }
 
-  const googleTagManagerId: string = JSON.parse(document.__.visualEditorConfig)
-    ?.siteAttributes?.googleTagManagerId;
+  const googleTagManagerId: string = JSON.parse(
+    document.__.visualEditorConfig
+  )?.googleTagManagerId;
 
   if (googleTagManagerId) {
     return `<!-- Google tag (gtag.js) -->


### PR DESCRIPTION
The field is directly on visualEditorConfig rather than under siteAttributes like it was for theme