### PR TITLE
feat: use selector for heading text level

### DIFF
--- a/packages/visual-editor/src/components/editor/BasicSelector.tsx
+++ b/packages/visual-editor/src/components/editor/BasicSelector.tsx
@@ -16,7 +16,12 @@ export const BasicSelector = (
             defaultValue={
               options.find((option) => option.value === value) ?? options[0]
             }
-            onChange={(option: any) => onChange(option)}
+            // option from onChange is the label of the selected option, but Puck's onChange expects the value
+            onChange={(option: any) =>
+              onChange(
+                (options.find((o) => o.label === option) ?? options[0]).value
+              )
+            }
             options={options}
           />
         </FieldLabel>

--- a/packages/visual-editor/src/components/editor/BasicSelector.tsx
+++ b/packages/visual-editor/src/components/editor/BasicSelector.tsx
@@ -19,7 +19,7 @@ export const BasicSelector = (
             // option from onChange is the label of the selected option, but Puck's onChange expects the value
             onChange={(option: any) =>
               onChange(
-                (options.find((o) => o.label === option) ?? options[0]).value
+                (options.find((o) => o.label === option) ?? options[0])?.value
               )
             }
             options={options}

--- a/packages/visual-editor/src/components/puck/HeadingText.tsx
+++ b/packages/visual-editor/src/components/puck/HeadingText.tsx
@@ -36,7 +36,7 @@ HeadingText.displayName = "HeadingText";
 
 const headingTextFields: Fields<HeadingTextProps> = {
   text: YextEntityFieldSelector({
-    label: "Entity Field",
+    label: "Text",
     filter: {
       types: ["type.string"],
     },

--- a/packages/visual-editor/src/components/puck/HeadingText.tsx
+++ b/packages/visual-editor/src/components/puck/HeadingText.tsx
@@ -1,15 +1,13 @@
 import * as React from "react";
 import { ComponentConfig, Fields } from "@measured/puck";
-import { Heading, HeadingProps } from "./atoms/heading.js";
+import { Heading, headingOptions, HeadingProps } from "./atoms/heading.js";
 import {
   useDocument,
   resolveYextEntityField,
   EntityField,
   YextEntityField,
   YextEntityFieldSelector,
-  FontSizeSelector,
   BasicSelector,
-  getFontWeightOverrideOptions,
 } from "../../index.js";
 
 interface HeadingTextProps extends HeadingProps {
@@ -43,27 +41,7 @@ const headingTextFields: Fields<HeadingTextProps> = {
       types: ["type.string"],
     },
   }),
-  level: {
-    type: "number",
-    label: "Heading Level",
-    min: 1,
-    max: 6,
-  },
-  fontSize: FontSizeSelector(),
-  color: BasicSelector("Font Color", [
-    { label: "Default", value: "default" },
-    { label: "Primary", value: "primary" },
-    { label: "Secondary", value: "secondary" },
-    { label: "Accent", value: "accent" },
-    { label: "Text", value: "text" },
-    { label: "Background", value: "background" },
-  ]),
-  transform: BasicSelector("Text Transform", [
-    { value: "none", label: "None" },
-    { value: "lowercase", label: "Lowercase" },
-    { value: "uppercase", label: "Uppercase" },
-    { value: "capitalize", label: "Capitalize" },
-  ]),
+  level: BasicSelector("Heading Level", headingOptions),
 };
 
 const HeadingTextComponent: ComponentConfig<HeadingTextProps> = {
@@ -77,19 +55,6 @@ const HeadingTextComponent: ComponentConfig<HeadingTextProps> = {
     },
     content: "Heading",
     level: 2,
-    fontSize: "default",
-    weight: "default",
-    color: "default",
-    transform: "none",
-  },
-  resolveFields: async (data) => {
-    const fontWeightOptions = await getFontWeightOverrideOptions({
-      fontCssVariable: `--fontFamily-heading${data.props.level}-fontFamily`,
-    });
-    return {
-      ...headingTextFields,
-      weight: BasicSelector("Font Weight", fontWeightOptions),
-    };
   },
   render: (props) => <HeadingText {...props} />,
 };

--- a/packages/visual-editor/src/components/puck/atoms/heading.tsx
+++ b/packages/visual-editor/src/components/puck/atoms/heading.tsx
@@ -6,11 +6,21 @@ import { themeManagerCn } from "../../../index.ts";
 const headingVariants = cva("components", {
   variants: {
     level: {
-      1: "font-heading1-fontWeight text-heading1-fontSize text-heading1-color font-heading1-fontFamily",
-      2: "font-heading2-fontWeight text-heading2-fontSize text-heading2-color font-heading2-fontFamily",
-      3: "font-heading3-fontWeight text-heading3-fontSize text-heading3-color font-heading3-fontFamily",
-      4: "font-heading4-fontWeight text-heading4-fontSize text-heading4-color font-heading4-fontFamily",
-      5: "font-heading5-fontWeight text-heading5-fontSize text-heading5-color font-heading5-fontFamily",
+      1:
+        "font-heading2-fontWeight text-heading2-fontSize text-heading2-color font-heading2-fontFamily " +
+        "sm:font-heading1-fontWeight sm:text-heading1-fontSize sm:text-heading1-color sm:font-heading1-fontFamily",
+      2:
+        "font-heading3-fontWeight text-heading3-fontSize text-heading3-color font-heading3-fontFamily " +
+        "sm:font-heading2-fontWeight sm:text-heading2-fontSize sm:text-heading2-color sm:font-heading2-fontFamily",
+      3:
+        "font-heading4-fontWeight text-heading4-fontSize text-heading4-color font-heading4-fontFamily " +
+        "sm:font-heading3-fontWeight sm:text-heading3-fontSize sm:text-heading3-color sm:font-heading3-fontFamily",
+      4:
+        "font-heading5-fontWeight text-heading5-fontSize text-heading5-color font-heading5-fontFamily " +
+        "sm:font-heading4-fontWeight sm:text-heading4-fontSize sm:text-heading4-color sm:font-heading4-fontFamily",
+      5:
+        "font-heading6-fontWeight text-heading6-fontSize text-heading6-color font-heading6-fontFamily " +
+        "sm:font-heading5-fontWeight sm:text-heading5-fontSize sm:text-heading5-color sm:font-heading5-fontFamily",
       6: "font-heading6-fontWeight text-heading6-fontSize text-heading6-color font-heading6-fontFamily",
     },
     fontSize: {
@@ -108,30 +118,12 @@ const Heading = React.forwardRef<HTMLHeadingElement, HeadingProps>(
 Heading.displayName = "Heading";
 
 const headingOptions = [
-  {
-    label: "1",
-    value: 1,
-  },
-  {
-    label: "2",
-    value: 2,
-  },
-  {
-    label: "3",
-    value: 3,
-  },
-  {
-    label: "4",
-    value: 4,
-  },
-  {
-    label: "5",
-    value: 5,
-  },
-  {
-    label: "6",
-    value: 6,
-  },
+  { label: "H1", value: 1 },
+  { label: "H2", value: 2 },
+  { label: "H3", value: 3 },
+  { label: "H4", value: 4 },
+  { label: "H5", value: 5 },
+  { label: "H6", value: 6 },
 ];
 
 export { Heading, headingVariants, headingOptions };


### PR DESCRIPTION
This replaces the number input for heading text level with a combobox selector. It also makes the heading use styling for the level below the selected one when viewed on mobile.

<img width="1046" alt="Screenshot 2025-03-20 at 12 23 48 PM" src="https://github.com/user-attachments/assets/d07fb38b-1b74-4f07-9ac7-6d3ecac4b388" />
