### PR TITLE
feat: add basic result cards

### DIFF
--- a/starter/src/components/Locator.tsx
+++ b/starter/src/components/Locator.tsx
@@ -68,7 +68,7 @@ const Locator: React.FC<LocatorProps> = (props) => {
         kind: "fieldValue",
         fieldId: params.newFilter.fieldId,
         value: params.newFilter.value,
-        matcher: Matcher.Equals,
+        matcher: Matcher.Near,
       },
     };
     searchActions.setStaticFilters([locationFilter]);

--- a/starter/src/components/Locator.tsx
+++ b/starter/src/components/Locator.tsx
@@ -1,22 +1,30 @@
 import { ComponentConfig, Fields } from "@measured/puck";
-import { FilterSearch } from "@yext/search-ui-react";
 import {
-  CloudChoice,
-  CloudRegion,
-  Environment,
-  provideHeadless,
-  SearchHeadlessProvider,
+  FilterSearch,
+  OnSelectParams,
+  StandardCard,
+  VerticalResults,
+} from "@yext/search-ui-react";
+import {
+  Matcher,
+  SelectableStaticFilter,
+  useSearchActions,
+  useSearchState,
 } from "@yext/search-headless-react";
 import * as React from "react";
-import { useDocument } from "@yext/visual-editor";
 
 type LocatorProps = {
-  apiKey: string;
+  fieldApiName: string;
+  entityType: string;
 };
 
 const fields: Fields<LocatorProps> = {
-  apiKey: {
-    label: "API Key",
+  fieldApiName: {
+    label: "Field Name",
+    type: "text",
+  },
+  entityType: {
+    label: "Entity Type",
     type: "text",
   },
 };
@@ -24,36 +32,51 @@ const fields: Fields<LocatorProps> = {
 const LocatorComponent: ComponentConfig<LocatorProps> = {
   fields,
   defaultProps: {
-    apiKey: "Fake Key",
+    fieldApiName: "builtin.location",
+    entityType: "location",
   },
   label: "Locator",
   render: (props) => <Locator {...props} />,
 };
 
-const Locator: React.FC<LocatorProps> = ({ apiKey }) => {
-  const document: {
-    businessId: number;
-  } = useDocument();
-  const config = {
-    apiKey,
-    experienceKey: "jacob-test",
-    locale: "en",
-    experienceVersion: "STAGING",
-    businessId: document.businessId,
-    cloudRegion: CloudRegion.US,
-    cloudChoice: CloudChoice.GLOBAL_MULTI,
-    environment: Environment.PROD,
+const Locator: React.FC<LocatorProps> = ({ fieldApiName, entityType }) => {
+  const resultCount = useSearchState(
+    (state) => state.vertical.resultsCount || 0,
+  );
+
+  const searchActions = useSearchActions();
+  const handleFilterSelect = (params: OnSelectParams) => {
+    const locationFilter: SelectableStaticFilter = {
+      displayName: params.newDisplayName,
+      selected: true,
+      filter: {
+        kind: "fieldValue",
+        fieldId: params.newFilter.fieldId,
+        value: params.newFilter.value,
+        matcher: Matcher.Equals,
+      },
+    };
+    searchActions.setStaticFilters([locationFilter]);
+    searchActions.executeVerticalQuery();
   };
-  const searcher = provideHeadless(config);
-  searcher.setVertical("locations");
+
+  const searchLoading = useSearchState((state) => state.searchStatus.isLoading);
+
   return (
-    <SearchHeadlessProvider searcher={searcher}>
+    <>
       <FilterSearch
-        searchFields={[
-          { fieldApiName: "builtin.location", entityType: "location" },
-        ]}
-      ></FilterSearch>
-    </SearchHeadlessProvider>
+        searchFields={[{ fieldApiName: fieldApiName, entityType: entityType }]}
+        onSelect={(params) => handleFilterSelect(params)}
+      />
+      <div>
+        {resultCount > 0 && <VerticalResults CardComponent={StandardCard} />}
+        {resultCount === 0 && !searchLoading && (
+          <div className="flex items-center justify-center">
+            <p className="pt-4 text-2xl">No results found for this area</p>
+          </div>
+        )}
+      </div>
+    </>
   );
 };
 

--- a/starter/src/components/Locator.tsx
+++ b/starter/src/components/Locator.tsx
@@ -12,34 +12,49 @@ import {
   useSearchState,
 } from "@yext/search-headless-react";
 import * as React from "react";
+import { cva, VariantProps } from "class-variance-authority";
+import { BasicSelector, themeManagerCn } from "@yext/visual-editor";
 
-type LocatorProps = {
-  fieldApiName: string;
-  entityType: string;
-};
+const DEFAULT_FIELD = "builtin.location";
+const DEFAULT_ENTITY_TYPE = "location";
 
-const fields: Fields<LocatorProps> = {
-  fieldApiName: {
-    label: "Field Name",
-    type: "text",
+const locatorVariants = cva("", {
+  variants: {
+    backgroundColor: {
+      default: "bg-locator-backgroundColor",
+      primary: "bg-palette-primary",
+      secondary: "bg-palette-secondary",
+      accent: "bg-palette-accent",
+      text: "bg-palette-text",
+      background: "bg-palette-background",
+    },
   },
-  entityType: {
-    label: "Entity Type",
-    type: "text",
+  defaultVariants: {
+    backgroundColor: "default",
   },
+});
+
+type LocatorProps = VariantProps<typeof locatorVariants>;
+
+const locatorFields: Fields<LocatorProps> = {
+  backgroundColor: BasicSelector("Background Color", [
+    { label: "Default", value: "default" },
+    { label: "Primary", value: "primary" },
+    { label: "Secondary", value: "secondary" },
+    { label: "Accent", value: "accent" },
+    { label: "Text", value: "text" },
+    { label: "Background", value: "background" },
+  ]),
 };
 
 const LocatorComponent: ComponentConfig<LocatorProps> = {
-  fields,
-  defaultProps: {
-    fieldApiName: "builtin.location",
-    entityType: "location",
-  },
+  fields: locatorFields,
   label: "Locator",
   render: (props) => <Locator {...props} />,
 };
 
-const Locator: React.FC<LocatorProps> = ({ fieldApiName, entityType }) => {
+const Locator: React.FC<LocatorProps> = (props) => {
+  const { backgroundColor } = props;
   const resultCount = useSearchState(
     (state) => state.vertical.resultsCount || 0,
   );
@@ -65,13 +80,20 @@ const Locator: React.FC<LocatorProps> = ({ fieldApiName, entityType }) => {
   return (
     <>
       <FilterSearch
-        searchFields={[{ fieldApiName: fieldApiName, entityType: entityType }]}
+        searchFields={[
+          { fieldApiName: DEFAULT_FIELD, entityType: DEFAULT_ENTITY_TYPE },
+        ]}
         onSelect={(params) => handleFilterSelect(params)}
       />
       <div>
         {resultCount > 0 && <VerticalResults CardComponent={StandardCard} />}
         {resultCount === 0 && !searchLoading && (
-          <div className="flex items-center justify-center">
+          <div
+            className={themeManagerCn(
+              "flex items-center justify-center",
+              locatorVariants({ backgroundColor }),
+            )}
+          >
             <p className="pt-4 text-2xl">No results found for this area</p>
           </div>
         )}

--- a/starter/src/templates/dev.tsx
+++ b/starter/src/templates/dev.tsx
@@ -114,7 +114,7 @@ const Dev: Template<TemplateRenderProps> = (props) => {
   const entityFields = devTemplateStream.stream.schema
     .fields as unknown as YextSchemaField[];
   const config = {
-    apiKey: "722d20ad53157666ea2df0d3831433c2",
+    apiKey: "",
     experienceKey: "jacob-test",
     locale: "en",
     experienceVersion: "STAGING",

--- a/starter/src/templates/dev.tsx
+++ b/starter/src/templates/dev.tsx
@@ -125,6 +125,7 @@ const Dev: Template<TemplateRenderProps> = (props) => {
     environment: Environment.PROD,
   };
   const searcher = provideHeadless(config);
+
   return (
     <div>
       <div className={"flex-container"}>

--- a/starter/src/templates/dev.tsx
+++ b/starter/src/templates/dev.tsx
@@ -20,6 +20,13 @@ import { buildSchema } from "../utils/buildSchema.ts";
 import tailwindConfig from "../../tailwind.config";
 import { devTemplateStream } from "../dev.config";
 import React from "react";
+import {
+  CloudChoice,
+  CloudRegion,
+  Environment,
+  provideHeadless,
+  SearchHeadlessProvider,
+} from "@yext/search-headless-react";
 
 export const config = {
   name: "dev-location",
@@ -106,7 +113,18 @@ const Dev: Template<TemplateRenderProps> = (props) => {
   const { document } = props;
   const entityFields = devTemplateStream.stream.schema
     .fields as unknown as YextSchemaField[];
-
+  const config = {
+    apiKey: "722d20ad53157666ea2df0d3831433c2",
+    experienceKey: "jacob-test",
+    locale: "en",
+    experienceVersion: "STAGING",
+    verticalKey: "locations",
+    businessId: document.businessId,
+    cloudRegion: CloudRegion.US,
+    cloudChoice: CloudChoice.GLOBAL_MULTI,
+    environment: Environment.PROD,
+  };
+  const searcher = provideHeadless(config);
   return (
     <div>
       <div className={"flex-container"}>
@@ -120,19 +138,21 @@ const Dev: Template<TemplateRenderProps> = (props) => {
         </button>
       </div>
       <div>
-        <VisualEditorProvider
-          templateProps={props}
-          entityFields={entityFields}
-          tailwindConfig={tailwindConfig}
-        >
-          <Editor
-            document={document}
-            componentRegistry={componentRegistry}
-            themeConfig={themeConfig}
-            localDev={true}
-            forceThemeMode={themeMode}
-          />
-        </VisualEditorProvider>
+        <SearchHeadlessProvider searcher={searcher}>
+          <VisualEditorProvider
+            templateProps={props}
+            entityFields={entityFields}
+            tailwindConfig={tailwindConfig}
+          >
+            <Editor
+              document={document}
+              componentRegistry={componentRegistry}
+              themeConfig={themeConfig}
+              localDev={true}
+              forceThemeMode={themeMode}
+            />
+          </VisualEditorProvider>
+        </SearchHeadlessProvider>
       </div>
     </div>
   );


### PR DESCRIPTION
This PR adds basic result cards, still in need of styling. It also
adjusts how the SearchHeadlessProvider is created, so that the
call to provideHeadless is not inside of a component. This may need
adjusting.

J=WAT-4699
TEST=manual

Results are populated, albeit unstyled. No rerendering issues