### PR TITLE
fix: adjust breadcrumbs

### DIFF
--- a/packages/visual-editor/src/components/puck/Breadcrumbs.tsx
+++ b/packages/visual-editor/src/components/puck/Breadcrumbs.tsx
@@ -40,7 +40,7 @@ export const BreadcrumbsComponent = (props: BreadcrumbsProps) => {
   const { separator = "/" } = props;
   const { document, relativePrefixToRoot } = useTemplateProps<any>();
   let breadcrumbs = getDirectoryParents(document);
-  if (breadcrumbs) {
+  if (breadcrumbs?.length > 0) {
     // append the current and filter out missing or malformed data
     breadcrumbs = [...breadcrumbs, { name: document.name, slug: "" }].filter(
       (b) => b.name
@@ -50,7 +50,10 @@ export const BreadcrumbsComponent = (props: BreadcrumbsProps) => {
   return (
     <div>
       {breadcrumbs?.length > 0 && (
-        <nav className="my-4" aria-label="Breadcrumb">
+        <nav
+          className="container mx-auto my-4 px-4 sm:px-8 lg:px-16 xl:px-20 items-center"
+          aria-label="Breadcrumb"
+        >
           <ol className="components flex flex-wrap text-link-fontSize text-body-color">
             {breadcrumbs.map(({ name, slug }, idx) => {
               const isLast = idx === breadcrumbs.length - 1;


### PR DESCRIPTION
Adjusted padding so it is aligned with Header / Footer. If no-DM-parents, breadcrumbs wont show up at all (before was showing that entity's name)

<img width="1769" alt="Screenshot 2025-03-21 at 11 52 32 AM" src="https://github.com/user-attachments/assets/d38d6274-073a-4bb4-a56e-ba3dbec54b0e" />
<img width="1769" alt="Screenshot 2025-03-21 at 11 52 28 AM" src="https://github.com/user-attachments/assets/7444944a-abcc-4ea1-a217-92dc666eca1e" />
