### PR TITLE
fix: remove plugin from /starter

### DIFF
--- a/starter/vite.config.js
+++ b/starter/vite.config.js
@@ -1,8 +1,7 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import yextSSG from "@yext/pages/vite-plugin";
-import { yextVisualEditorPlugin } from "@yext/visual-editor/plugin";
 
 export default defineConfig({
-  plugins: [react(), yextSSG(), yextVisualEditorPlugin()],
+  plugins: [react(), yextSSG()],
 });


### PR DESCRIPTION
Accidentally left this in from testing, not needed for this dev starter. 