### PR TITLE
feat: cta component updates

### DIFF
--- a/packages/visual-editor/src/components/puck/CtaWrapper.tsx
+++ b/packages/visual-editor/src/components/puck/CtaWrapper.tsx
@@ -7,7 +7,6 @@ import {
   EntityField,
   YextEntityField,
   YextEntityFieldSelector,
-  BasicSelector,
 } from "../../index.js";
 
 interface CTAWrapperProps {
@@ -24,11 +23,15 @@ const ctaWrapperFields: Fields<CTAWrapperProps> = {
       types: ["type.cta"],
     },
   }),
-  variant: BasicSelector("Variant", [
-    { label: "Primary", value: "primary" },
-    { label: "Outline", value: "secondary" },
-    { label: "Link", value: "link" },
-  ]),
+  variant: {
+    label: "Variant",
+    type: "radio",
+    options: [
+      { label: "Primary", value: "primary" },
+      { label: "Outline", value: "secondary" },
+      { label: "Link", value: "link" },
+    ],
+  },
   linkType: linkTypeFields,
 };
 

--- a/packages/visual-editor/src/components/puck/CtaWrapper.tsx
+++ b/packages/visual-editor/src/components/puck/CtaWrapper.tsx
@@ -7,17 +7,12 @@ import {
   EntityField,
   YextEntityField,
   YextEntityFieldSelector,
-  FontSizeSelector,
-  BorderRadiusSelector,
   BasicSelector,
 } from "../../index.js";
 
 interface CTAWrapperProps {
   entityField: YextEntityField<CTAProps>;
   variant: CTAProps["variant"];
-  size: CTAProps["size"];
-  borderRadius: CTAProps["borderRadius"];
-  fontSize: CTAProps["fontSize"];
   linkType: CTAProps["linkType"];
   className?: CTAProps["className"];
 }
@@ -31,28 +26,16 @@ const ctaWrapperFields: Fields<CTAWrapperProps> = {
   }),
   variant: BasicSelector("Variant", [
     { label: "Primary", value: "primary" },
+    { label: "Outline", value: "secondary" },
     { label: "Link", value: "link" },
   ]),
-  size: {
-    label: "Size",
-    type: "radio",
-    options: [
-      { label: "Small", value: "small" },
-      { label: "Large", value: "large" },
-    ],
-  },
   linkType: linkTypeFields,
-  fontSize: FontSizeSelector("Font Size", false),
-  borderRadius: BorderRadiusSelector(),
 };
 
 const CTAWrapper: React.FC<CTAWrapperProps> = ({
   entityField,
   variant,
   className,
-  fontSize,
-  size,
-  borderRadius,
 }) => {
   const document = useDocument();
   const cta = resolveYextEntityField(document, entityField);
@@ -69,9 +52,7 @@ const CTAWrapper: React.FC<CTAWrapperProps> = ({
         linkType={cta?.linkType}
         variant={variant}
         className={className}
-        fontSize={fontSize}
-        size={size}
-        borderRadius={borderRadius}
+        size={"small"}
       />
     </EntityField>
   );
@@ -88,12 +69,9 @@ const CTAWrapperComponent: ComponentConfig<CTAWrapperProps> = {
       },
     },
     variant: "primary",
-    fontSize: "default",
-    borderRadius: "default",
     linkType: "URL",
-    size: "small",
   },
-  render: (props) => <CTAWrapper {...props} />,
+  render: (props: CTAWrapperProps) => <CTAWrapper {...props} />,
 };
 
 export { CTAWrapperComponent as CTAWrapper, type CTAWrapperProps };

--- a/packages/visual-editor/src/components/puck/CtaWrapper.tsx
+++ b/packages/visual-editor/src/components/puck/CtaWrapper.tsx
@@ -18,7 +18,7 @@ interface CTAWrapperProps {
 
 const ctaWrapperFields: Fields<CTAWrapperProps> = {
   entityField: YextEntityFieldSelector({
-    label: "Entity Field",
+    label: "CTA",
     filter: {
       types: ["type.cta"],
     },

--- a/packages/visual-editor/src/components/puck/atoms/button.tsx
+++ b/packages/visual-editor/src/components/puck/atoms/button.tsx
@@ -13,6 +13,10 @@ const buttonVariants = cva(
         primary:
           "bg-button-backgroundColor text-button-textColor border-2 border-button-backgroundColor hover:border-button-textColor " +
           "focus:border-button-textColor active:bg-button-textColor active:text-button-backgroundColor active:border-button-backgroundColor text-button-fontSize",
+        // TODO: Update to use styles set in the theme
+        seconday:
+          "bg-button-backgroundColor text-button-textColor border-2 border-button-backgroundColor hover:border-button-textColor " +
+          "focus:border-button-textColor active:bg-button-textColor active:text-button-backgroundColor active:border-button-backgroundColor text-button-fontSize",
         link: "text-link-color text-link-fontSize underline-offset-4 underline hover:no-underline",
       },
       size: {

--- a/packages/visual-editor/src/components/puck/atoms/cta.tsx
+++ b/packages/visual-editor/src/components/puck/atoms/cta.tsx
@@ -24,25 +24,9 @@ const linkTypeFields: Field = BasicSelector("Link Type", [
   { label: "Other", value: "OTHER" },
 ]);
 
-const CTA = ({
-  label,
-  link,
-  linkType,
-  variant,
-  size,
-  borderRadius,
-  className,
-  fontSize = "default",
-}: CTAProps) => {
+const CTA = ({ label, link, linkType, variant, size, className }: CTAProps) => {
   return (
-    <Button
-      asChild
-      className={className}
-      variant={variant}
-      size={size}
-      borderRadius={borderRadius}
-      fontSize={fontSize}
-    >
+    <Button asChild className={className} variant={variant} size={size}>
       <Link
         cta={{
           link: link ?? "",


### PR DESCRIPTION
This removes styling options from CtaWrapper and adds a "secondary" button option. This will need to be updated later with the secondary styling settings from the theme.

<img width="1062" alt="Screenshot 2025-03-24 at 11 02 41 AM" src="https://github.com/user-attachments/assets/eb8afcd8-f543-4f8a-8b25-3357a8695937" />
