### PR TITLE
feat: autogenerated theme colors

### DIFF
--- a/packages/visual-editor/src/components/puck/Footer.tsx
+++ b/packages/visual-editor/src/components/puck/Footer.tsx
@@ -18,8 +18,8 @@ import {
   FaYoutube,
 } from "react-icons/fa";
 import {
-  BackgroundColorOption,
-  getBackgroundColorOptions,
+  type BackgroundStyle,
+  backgroundColors,
 } from "../../utils/themeConfigOptions.ts";
 
 type socialLink = {
@@ -30,20 +30,20 @@ type socialLink = {
 };
 
 type FooterProps = {
-  backgroundColor?: BackgroundColorOption;
+  backgroundColor?: BackgroundStyle;
 };
 
 const footerFields: Fields<FooterProps> = {
   backgroundColor: BasicSelector(
     "Background Color",
-    getBackgroundColorOptions()
+    Object.values(backgroundColors)
   ),
 };
 
 const Footer: ComponentConfig<FooterProps> = {
   fields: footerFields,
   defaultProps: {
-    backgroundColor: getBackgroundColorOptions()[0].value,
+    backgroundColor: backgroundColors.background1.value,
   },
   label: "Footer",
   render: (props) => <FooterComponent {...props} />,

--- a/packages/visual-editor/src/components/puck/Footer.tsx
+++ b/packages/visual-editor/src/components/puck/Footer.tsx
@@ -8,7 +8,6 @@ import {
   useDocument,
   BasicSelector,
 } from "../../index.ts";
-import { cva, VariantProps } from "class-variance-authority";
 import {
   FaFacebook,
   FaInstagram,
@@ -18,6 +17,10 @@ import {
   FaTwitter,
   FaYoutube,
 } from "react-icons/fa";
+import {
+  BackgroundColorOption,
+  getBackgroundColorOptions,
+} from "../../utils/themeConfigOptions.ts";
 
 type socialLink = {
   name: string;
@@ -26,37 +29,22 @@ type socialLink = {
   prefix?: string;
 };
 
-const footerVariants = cva("", {
-  variants: {
-    backgroundColor: {
-      default: "bg-footer-backgroundColor",
-      primary: "bg-palette-primary",
-      secondary: "bg-palette-secondary",
-      accent: "bg-palette-accent",
-      text: "bg-palette-text",
-      background: "bg-palette-background",
-    },
-  },
-  defaultVariants: {
-    backgroundColor: "default",
-  },
-});
-
-type FooterProps = VariantProps<typeof footerVariants>;
+type FooterProps = {
+  backgroundColor?: BackgroundColorOption;
+};
 
 const footerFields: Fields<FooterProps> = {
-  backgroundColor: BasicSelector("Background Color", [
-    { label: "Default", value: "default" },
-    { label: "Primary", value: "primary" },
-    { label: "Secondary", value: "secondary" },
-    { label: "Accent", value: "accent" },
-    { label: "Text", value: "text" },
-    { label: "Background", value: "background" },
-  ]),
+  backgroundColor: BasicSelector(
+    "Background Color",
+    getBackgroundColorOptions()
+  ),
 };
 
 const Footer: ComponentConfig<FooterProps> = {
   fields: footerFields,
+  defaultProps: {
+    backgroundColor: getBackgroundColorOptions()[0].value,
+  },
   label: "Footer",
   render: (props) => <FooterComponent {...props} />,
 };
@@ -111,7 +99,7 @@ const FooterComponent: React.FC<FooterProps> = (props) => {
     <footer
       className={themeManagerCn(
         "w-full bg-white components",
-        footerVariants({ backgroundColor })
+        backgroundColor?.bgColor
       )}
     >
       <div className="container mx-auto flex flex-col px-4 pt-4 pb-3">
@@ -134,7 +122,9 @@ const FooterComponent: React.FC<FooterProps> = (props) => {
           )}
         </div>
         {copyrightMessage && (
-          <div className="text-body-fontSize text-body-color text-center sm:text-left">
+          <div
+            className={`text-body-fontSize text-center sm:text-left ${backgroundColor?.textColor}`}
+          >
             <EntityField
               displayName="Copyright Text"
               fieldId="site.copyrightMessage"

--- a/packages/visual-editor/src/components/puck/Header.tsx
+++ b/packages/visual-editor/src/components/puck/Header.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { Link, CTA, Image, ComplexImageType } from "@yext/pages-components";
 import { ComponentConfig, Fields } from "@measured/puck";
-import { cva, VariantProps } from "class-variance-authority";
 import { EntityField, useDocument, BasicSelector } from "../../index.ts";
 import { MaybeLink } from "./atoms/maybeLink.tsx";
 import { FaTimes, FaBars } from "react-icons/fa";
@@ -15,23 +14,7 @@ const PLACEHOLDER_IMAGE: ComplexImageType = {
   },
 };
 
-const headerVariants = cva("", {
-  variants: {
-    backgroundColor: {
-      default: "bg-header-backgroundColor",
-      primary: "bg-palette-primary",
-      secondary: "bg-palette-secondary",
-      accent: "bg-palette-accent",
-      text: "bg-palette-text",
-      background: "bg-palette-background",
-    },
-  },
-  defaultVariants: {
-    backgroundColor: "default",
-  },
-});
-
-export type HeaderProps = VariantProps<typeof headerVariants>;
+export type HeaderProps = object;
 
 const headerFields: Fields<HeaderProps> = {
   backgroundColor: BasicSelector("Background Color", [
@@ -50,7 +33,7 @@ export const Header: ComponentConfig<HeaderProps> = {
   render: (props) => <HeaderComponent {...props} />,
 };
 
-const HeaderComponent: React.FC<HeaderProps> = (props) => {
+const HeaderComponent: React.FC<HeaderProps> = () => {
   const document: {
     _site?: {
       header?: {
@@ -59,13 +42,10 @@ const HeaderComponent: React.FC<HeaderProps> = (props) => {
       logo?: ComplexImageType;
     };
   } = useDocument();
-  const { backgroundColor } = props;
   const links = document._site?.header?.links ?? [];
   const logo = document._site?.logo ?? PLACEHOLDER_IMAGE;
 
-  return (
-    <HeaderLayout links={links} logo={logo} backgroundColor={backgroundColor} />
-  );
+  return <HeaderLayout links={links} logo={logo} />;
 };
 
 interface HeaderLayoutProps extends HeaderProps {
@@ -76,13 +56,18 @@ interface HeaderLayoutProps extends HeaderProps {
 
 const HeaderLayout = (props: HeaderLayoutProps) => {
   const [menuOpen, setMenuOpen] = React.useState(false);
-  const { logo, logoLink, links, backgroundColor } = props;
+  const { logo, logoLink, links } = props;
 
   return (
     <header
-      className={`components font-body-fontFamily relative ${headerVariants({ backgroundColor })}`}
+      className={`components font-body-fontFamily relative bg-white text-black`}
     >
-      <div className="container mx-auto py-5 flex justify-start md:justify-between px-4 sm:px-8 lg:px-16 xl:px-20 items-center">
+      <div
+        className={
+          "container mx-auto py-5 flex justify-start md:justify-between " +
+          "px-4 sm:px-8 lg:px-16 xl:px-20 items-center"
+        }
+      >
         {logo && (
           <EntityField
             displayName="Business Logo"
@@ -116,11 +101,7 @@ const HeaderLayout = (props: HeaderLayoutProps) => {
       </div>
 
       {links?.length > 0 && (
-        <HeaderMobileMenu
-          isOpen={menuOpen}
-          links={links}
-          backgroundColor={backgroundColor}
-        />
+        <HeaderMobileMenu isOpen={menuOpen} links={links} />
       )}
     </header>
   );
@@ -161,19 +142,18 @@ const HeaderLinks = (props: { links: CTA[] }) => {
 type HeaderMobileMenuProps = {
   isOpen?: boolean;
   links: CTA[];
-  backgroundColor: VariantProps<typeof headerVariants>["backgroundColor"];
 };
 
 const HeaderMobileMenu = (props: HeaderMobileMenuProps) => {
-  const { isOpen, backgroundColor, links } = props;
+  const { isOpen, links } = props;
   return (
     <div
       className={
-        `${isOpen ? "visible" : "hidden"} ${headerVariants({ backgroundColor })}` +
+        `${isOpen ? "visible" : "hidden"} bg-white text-black` +
         "components absolute top-full left-0 right-0 h-screen z-50"
       }
     >
-      <div className={`container ${headerVariants({ backgroundColor })}`}>
+      <div className={`container bg-white text-black`}>
         <ul className="flex flex-col px-4">
           {links.map((item: CTA, idx) => (
             <li key={item.link}>

--- a/packages/visual-editor/src/components/puck/Header.tsx
+++ b/packages/visual-editor/src/components/puck/Header.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Link, CTA, Image, ComplexImageType } from "@yext/pages-components";
-import { ComponentConfig, Fields } from "@measured/puck";
-import { EntityField, useDocument, BasicSelector } from "../../index.ts";
+import { ComponentConfig } from "@measured/puck";
+import { EntityField, useDocument } from "../../index.ts";
 import { MaybeLink } from "./atoms/maybeLink.tsx";
 import { FaTimes, FaBars } from "react-icons/fa";
 
@@ -14,23 +14,11 @@ const PLACEHOLDER_IMAGE: ComplexImageType = {
   },
 };
 
-export type HeaderProps = object;
-
-const headerFields: Fields<HeaderProps> = {
-  backgroundColor: BasicSelector("Background Color", [
-    { label: "Default", value: "default" },
-    { label: "Primary", value: "primary" },
-    { label: "Secondary", value: "secondary" },
-    { label: "Accent", value: "accent" },
-    { label: "Text", value: "text" },
-    { label: "Background", value: "background" },
-  ]),
-};
+export type HeaderProps = Record<string, never>;
 
 export const Header: ComponentConfig<HeaderProps> = {
-  fields: headerFields,
   label: "Header",
-  render: (props) => <HeaderComponent {...props} />,
+  render: () => <HeaderComponent />,
 };
 
 const HeaderComponent: React.FC<HeaderProps> = () => {
@@ -48,7 +36,7 @@ const HeaderComponent: React.FC<HeaderProps> = () => {
   return <HeaderLayout links={links} logo={logo} />;
 };
 
-interface HeaderLayoutProps extends HeaderProps {
+interface HeaderLayoutProps {
   links: CTA[];
   logoLink?: string;
   logo?: ComplexImageType;

--- a/packages/visual-editor/src/utils/README.md
+++ b/packages/visual-editor/src/utils/README.md
@@ -531,6 +531,29 @@ Returns a list of spacing options to be optionally used in the theme.config. It 
 | 20 (80px)  | 20    |
 | 24 (96px)  | 24    |
 
+## backgroundColors
+
+An object of the following shape containing the seven auto-generated background styles.
+
+```js
+{
+  backgroundKey: {
+    label: "Background Label",
+    value: "Background Tailwind Classes"
+  }
+}
+```
+
+| Key         | Label        | Background Color | Text Color |
+| ----------- | ------------ | ---------------- | ---------- |
+| background1 | Background 1 | white            | black      |
+| background2 | Background 2 | primary-light    | black      |
+| background3 | Background 3 | secondary-light  | black      |
+| background4 | Background 4 | tertiary-light   | black      |
+| background5 | Background 5 | quaternary-light | black      |
+| background6 | Background 6 | primary-dark     | white      |
+| background7 | Background 7 | secondary-dark   | white      |
+
 ## applyAnalytics
 
 Returns a Google Tag Manager script that uses the Google Tag Manager ID

--- a/packages/visual-editor/src/utils/README.md
+++ b/packages/visual-editor/src/utils/README.md
@@ -531,6 +531,19 @@ Returns a list of spacing options to be optionally used in the theme.config. It 
 | 20 (80px)  | 20    |
 | 24 (96px)  | 24    |
 
+## defaultThemeTailwindExtensions
+
+A set of Tailwind extensions to complement the default theme.config, including additional auto-generated colors.
+
+#### Usage
+
+```tsx
+// tailwind.config.ts
+theme: {
+  extend: themeResolver(defaultThemeTailwindExtensions, themeConfig),
+},
+```
+
 ## backgroundColors
 
 An object of the following shape containing the seven auto-generated background styles.

--- a/packages/visual-editor/src/utils/index.ts
+++ b/packages/visual-editor/src/utils/index.ts
@@ -15,6 +15,8 @@ export {
   getFontSizeOptions,
   getBorderRadiusOptions,
   getSpacingOptions,
+  backgroundColors,
+  defaultThemeTailwindExtensions,
 } from "./themeConfigOptions.ts";
 export { applyAnalytics } from "./applyAnalytics.ts";
 export { getPageMetadata } from "./getPageMetadata.ts";

--- a/packages/visual-editor/src/utils/index.ts
+++ b/packages/visual-editor/src/utils/index.ts
@@ -17,6 +17,7 @@ export {
   getSpacingOptions,
   backgroundColors,
   defaultThemeTailwindExtensions,
+  type BackgroundStyle,
 } from "./themeConfigOptions.ts";
 export { applyAnalytics } from "./applyAnalytics.ts";
 export { getPageMetadata } from "./getPageMetadata.ts";

--- a/packages/visual-editor/src/utils/themeConfigOptions.ts
+++ b/packages/visual-editor/src/utils/themeConfigOptions.ts
@@ -29,60 +29,61 @@ export const getSpacingOptions = () => {
   });
 };
 
-export type BackgroundColorOption = {
+export type BackgroundStyle = {
   bgColor: string;
   textColor: string;
 };
 
-export const getBackgroundColorOptions = () => {
-  return backgroundColors;
+type BackgroundOption = {
+  label: string;
+  value: BackgroundStyle;
 };
 
-const backgroundColors: { label: string; value: BackgroundColorOption }[] = [
-  {
+export const backgroundColors: Record<string, BackgroundOption> = {
+  background1: {
     label: "Background 1",
     value: { bgColor: "bg-white", textColor: "text-black" },
   },
-  {
+  background2: {
     label: "Background 2",
     value: {
       bgColor: "bg-palette-primary-light",
       textColor: "text-black",
     },
   },
-  {
+  background3: {
     label: "Background 3",
     value: {
       bgColor: "bg-palette-secondary-light",
       textColor: "text-black",
     },
   },
-  {
+  background4: {
     label: "Background 4",
     value: {
       bgColor: "bg-palette-tertiary-light",
       textColor: "text-black",
     },
   },
-  {
+  background5: {
     label: "Background 5",
     value: {
       bgColor: "bg-palette-quaternary-light",
       textColor: "text-black",
     },
   },
-  {
+  background6: {
     label: "Background 6",
     value: {
       bgColor: "bg-palette-primary-dark",
       textColor: "text-white",
     },
   },
-  {
+  background7: {
     label: "Background 7",
     value: {
       bgColor: "bg-palette-secondary-dark",
       textColor: "text-white",
     },
   },
-];
+};

--- a/packages/visual-editor/src/utils/themeConfigOptions.ts
+++ b/packages/visual-editor/src/utils/themeConfigOptions.ts
@@ -28,3 +28,61 @@ export const getSpacingOptions = () => {
     };
   });
 };
+
+export type BackgroundColorOption = {
+  bgColor: string;
+  textColor: string;
+};
+
+export const getBackgroundColorOptions = () => {
+  return backgroundColors;
+};
+
+const backgroundColors: { label: string; value: BackgroundColorOption }[] = [
+  {
+    label: "Background 1",
+    value: { bgColor: "bg-white", textColor: "text-black" },
+  },
+  {
+    label: "Background 2",
+    value: {
+      bgColor: "bg-palette-primary-light",
+      textColor: "text-black",
+    },
+  },
+  {
+    label: "Background 3",
+    value: {
+      bgColor: "bg-palette-secondary-light",
+      textColor: "text-black",
+    },
+  },
+  {
+    label: "Background 4",
+    value: {
+      bgColor: "bg-palette-tertiary-light",
+      textColor: "text-black",
+    },
+  },
+  {
+    label: "Background 5",
+    value: {
+      bgColor: "bg-palette-quaternary-light",
+      textColor: "text-black",
+    },
+  },
+  {
+    label: "Background 6",
+    value: {
+      bgColor: "bg-palette-primary-dark",
+      textColor: "text-white",
+    },
+  },
+  {
+    label: "Background 7",
+    value: {
+      bgColor: "bg-palette-secondary-dark",
+      textColor: "text-white",
+    },
+  },
+];

--- a/packages/visual-editor/src/utils/themeConfigOptions.ts
+++ b/packages/visual-editor/src/utils/themeConfigOptions.ts
@@ -87,3 +87,29 @@ export const backgroundColors: Record<string, BackgroundOption> = {
     },
   },
 };
+
+// Tailwind Theme Extensions (https://v3.tailwindcss.com/docs/theme#extending-the-default-theme)
+// to use in the tailwind.config.ts in conjunction with themeResolver and the theme.config
+export const defaultThemeTailwindExtensions = {
+  colors: {
+    "palette-primary-light": "hsl(from var(--colors-palette-primary) h s 98)",
+    "palette-secondary-light":
+      "hsl(from var(--colors-palette-secondary) h s 98)",
+    "palette-tertiary-light": "hsl(from var(--colors-palette-tertiary) h s 98)",
+    "palette-quaternary-light":
+      "hsl(from var(--colors-palette-quaternary) h s 98)",
+    "palette-primary-dark": "hsl(from var(--colors-palette-primary) h s 20)",
+    "palette-secondary-dark":
+      "hsl(from var(--colors-palette-secondary) h s 20)",
+    gray: {
+      100: "#F9F9F9",
+      200: "#EDEDED",
+      300: "#D4D4D4",
+      400: "#BABABA",
+      500: "#7A7A7A",
+      600: "#2B2B2B",
+      800: "#1F1F1F",
+      900: "#121212",
+    },
+  },
+};

--- a/starter/tailwind.config.ts
+++ b/starter/tailwind.config.ts
@@ -25,7 +25,7 @@ export default {
             "hsl(from var(--colors-palette-secondary) h s 20)",
           gray: {
             100: "#F9F9F9",
-            200: "EDEDED",
+            200: "#EDEDED",
             300: "#D4D4D4",
             400: "#BABABA",
             500: "#7A7A7A",

--- a/starter/tailwind.config.ts
+++ b/starter/tailwind.config.ts
@@ -23,6 +23,16 @@ export default {
             "hsl(from var(--colors-palette-primary) h s 20)",
           "palette-secondary-dark":
             "hsl(from var(--colors-palette-secondary) h s 20)",
+          gray: {
+            100: "#F9F9F9",
+            200: "EDEDED",
+            300: "#D4D4D4",
+            400: "#BABABA",
+            500: "#7A7A7A",
+            600: "#2B2B2B",
+            800: "#1F1F1F",
+            900: "#121212",
+          },
         },
       },
       themeConfig,

--- a/starter/tailwind.config.ts
+++ b/starter/tailwind.config.ts
@@ -1,6 +1,9 @@
 import type { Config } from "tailwindcss";
 import { themeConfig } from "./theme.config";
-import { themeResolver } from "@yext/visual-editor";
+import {
+  themeResolver,
+  defaultThemeTailwindExtensions,
+} from "@yext/visual-editor";
 
 export default {
   content: [
@@ -8,35 +11,7 @@ export default {
     "./node_modules/@yext/visual-editor/dist/**/*.js",
   ],
   theme: {
-    extend: themeResolver(
-      {
-        colors: {
-          "palette-primary-light":
-            "hsl(from var(--colors-palette-primary) h s 98)",
-          "palette-secondary-light":
-            "hsl(from var(--colors-palette-secondary) h s 98)",
-          "palette-tertiary-light":
-            "hsl(from var(--colors-palette-tertiary) h s 98)",
-          "palette-quaternary-light":
-            "hsl(from var(--colors-palette-quaternary) h s 98)",
-          "palette-primary-dark":
-            "hsl(from var(--colors-palette-primary) h s 20)",
-          "palette-secondary-dark":
-            "hsl(from var(--colors-palette-secondary) h s 20)",
-          gray: {
-            100: "#F9F9F9",
-            200: "#EDEDED",
-            300: "#D4D4D4",
-            400: "#BABABA",
-            500: "#7A7A7A",
-            600: "#2B2B2B",
-            800: "#1F1F1F",
-            900: "#121212",
-          },
-        },
-      },
-      themeConfig,
-    ),
+    extend: themeResolver(defaultThemeTailwindExtensions, themeConfig),
   },
   plugins: [],
 } satisfies Config;

--- a/starter/tailwind.config.ts
+++ b/starter/tailwind.config.ts
@@ -8,7 +8,25 @@ export default {
     "./node_modules/@yext/visual-editor/dist/**/*.js",
   ],
   theme: {
-    extend: themeResolver({}, themeConfig),
+    extend: themeResolver(
+      {
+        colors: {
+          "palette-primary-light":
+            "hsl(from var(--colors-palette-primary) h s 98)",
+          "palette-secondary-light":
+            "hsl(from var(--colors-palette-secondary) h s 98)",
+          "palette-tertiary-light":
+            "hsl(from var(--colors-palette-tertiary) h s 98)",
+          "palette-quaternary-light":
+            "hsl(from var(--colors-palette-quaternary) h s 98)",
+          "palette-primary-dark":
+            "hsl(from var(--colors-palette-primary) h s 20)",
+          "palette-secondary-dark":
+            "hsl(from var(--colors-palette-secondary) h s 20)",
+        },
+      },
+      themeConfig,
+    ),
   },
   plugins: [],
 } satisfies Config;


### PR DESCRIPTION
- Creates the tailwind colors based on the theme editor colors
  - palette-primary-light
  - palette-secondary-light
  - palette-tertiary-light
  - palette-quaternary-light
  - palette-primary-dark
  - palette-secondary-dark 
- Overrides tailwind's grays with the 9 grays from the Figma 
- Creates a helper to provide the 7 background options
- Updates header to always use the white background and footer to have the 7 background options

<img width="1840" alt="Screenshot 2025-03-24 at 5 02 24 PM" src="https://github.com/user-attachments/assets/a8e008ad-5e1f-453d-af36-32a030400f47" />