### PR TITLE
refactor: update text and background color for components

### DIFF
--- a/packages/visual-editor/src/components/editor/BorderRadiusSelector.tsx
+++ b/packages/visual-editor/src/components/editor/BorderRadiusSelector.tsx
@@ -71,10 +71,10 @@ type BorderRadiusOption = {
 };
 
 export const convertDefaultBorderRadiusToOptions = (
-  borderRadiuss: BorderRadiusOption[],
+  borderRadius: BorderRadiusOption[],
   tailwindConfig: TailwindConfig
 ) => {
-  return borderRadiuss.map((option) => {
+  return borderRadius.map((option) => {
     const customBorderRadius = getCustomBorderRadius(
       tailwindConfig,
       option.value

--- a/packages/visual-editor/src/components/puck/Banner.tsx
+++ b/packages/visual-editor/src/components/puck/Banner.tsx
@@ -8,11 +8,15 @@ import {
 } from "../../index.js";
 import { Body } from "./atoms/body.js";
 import { ComponentConfig, Fields } from "@measured/puck";
+import {
+  backgroundColors,
+  BackgroundStyle,
+} from "../../utils/themeConfigOptions.js";
 
 export type BannerProps = {
   text: YextEntityField<string>;
   textAlignment: "left" | "right" | "center";
-  backgroundColor: "bg-palette-primary" | "bg-palette-secondary";
+  backgroundColor?: BackgroundStyle;
 };
 
 const bannerFields: Fields<BannerProps> = {
@@ -31,10 +35,14 @@ const bannerFields: Fields<BannerProps> = {
       { label: "Right", value: "right" },
     ],
   },
-  backgroundColor: BasicSelector("Background Color", [
-    { label: "Dark Primary", value: "bg-palette-primary" },
-    { label: "Dark Secondary", value: "bg-palette-secondary" },
-  ]),
+  backgroundColor: BasicSelector(
+    "Background Color",
+    // only allow the dark backgrounds
+    Object.values({
+      dark1: backgroundColors.background6,
+      dark2: backgroundColors.background7,
+    })
+  ),
 };
 
 const BannerComponent = ({
@@ -51,13 +59,14 @@ const BannerComponent = ({
     right: "justify-end",
   }[textAlignment];
 
-  const textColor =
-    backgroundColor === "bg-palette-primary" ? "secondary" : "primary";
-
   return (
-    <div className={`Banner ${backgroundColor} components px-4 md:px-20 py-6`}>
-      <div className={`flex ${justifyClass} items-center`}>
-        <Body color={textColor}>{resolvedText}</Body>
+    <div
+      className={`Banner ${backgroundColor?.bgColor} components px-4 md:px-20 py-6`}
+    >
+      <div
+        className={`flex ${justifyClass} items-center ${backgroundColor?.textColor}`}
+      >
+        <Body>{resolvedText}</Body>
       </div>
     </div>
   );
@@ -72,7 +81,7 @@ export const Banner: ComponentConfig<BannerProps> = {
       constantValueEnabled: true,
     },
     textAlignment: "center",
-    backgroundColor: "bg-palette-primary",
+    backgroundColor: backgroundColors.background6.value,
   },
   render: (props) => <BannerComponent {...props} />,
 };

--- a/packages/visual-editor/src/components/puck/Breadcrumbs.tsx
+++ b/packages/visual-editor/src/components/puck/Breadcrumbs.tsx
@@ -51,7 +51,7 @@ export const BreadcrumbsComponent = (props: BreadcrumbsProps) => {
     <div>
       {breadcrumbs?.length > 0 && (
         <nav className="my-4" aria-label="Breadcrumb">
-          <ol className="components flex flex-wrap text-link-fontSize text-body-color">
+          <ol className="components flex flex-wrap text-link-fontSize">
             {breadcrumbs.map(({ name, slug }, idx) => {
               const isLast = idx === breadcrumbs.length - 1;
               const href = relativePrefixToRoot

--- a/packages/visual-editor/src/components/puck/Card.tsx
+++ b/packages/visual-editor/src/components/puck/Card.tsx
@@ -23,6 +23,10 @@ import {
 } from "./atoms/heading.js";
 import { Section } from "./atoms/section.js";
 import { imageWrapperVariants, ImageWrapperProps } from "./Image.js";
+import {
+  backgroundColors,
+  BackgroundStyle,
+} from "../../utils/themeConfigOptions.js";
 
 const PLACEHOLDER_IMAGE_URL = "https://placehold.co/640x360";
 
@@ -31,7 +35,6 @@ interface CardProps {
   heading: {
     text: YextEntityField<string>;
     fontSize: HeadingProps["fontSize"];
-    color: HeadingProps["color"];
     weight: HeadingProps["weight"];
     transform: HeadingProps["transform"];
     level: HeadingLevel;
@@ -39,7 +42,6 @@ interface CardProps {
   subheading: {
     text: YextEntityField<string>;
     fontSize: HeadingProps["fontSize"];
-    color: HeadingProps["color"];
     weight: HeadingProps["weight"];
     transform: HeadingProps["transform"];
     level: HeadingLevel;
@@ -47,7 +49,6 @@ interface CardProps {
   body: {
     text: YextEntityField<string>;
     fontSize: BodyProps["fontSize"];
-    color: BodyProps["color"];
     weight: BodyProps["fontWeight"];
     transform: BodyProps["textTransform"];
   };
@@ -63,13 +64,7 @@ interface CardProps {
     variant: CTAProps["variant"];
     fontSize: CTAProps["fontSize"];
   };
-  backgroundColor:
-    | "bg-card-backgroundColor"
-    | "bg-palette-primary"
-    | "bg-palette-secondary"
-    | "bg-palette-accent"
-    | "bg-palette-text"
-    | "bg-palette-background";
+  backgroundColor?: BackgroundStyle;
 }
 
 const cardFields: Fields<CardProps> = {
@@ -88,14 +83,6 @@ const cardFields: Fields<CardProps> = {
         },
       }),
       fontSize: FontSizeSelector(),
-      color: BasicSelector("Font Color", [
-        { label: "Default", value: "default" },
-        { label: "Primary", value: "primary" },
-        { label: "Secondary", value: "secondary" },
-        { label: "Accent", value: "accent" },
-        { label: "Text", value: "text" },
-        { label: "Background", value: "background" },
-      ]),
       weight: BasicSelector("Font Weight", []),
       transform: BasicSelector("Text Transform", [
         { value: "none", label: "None" },
@@ -117,14 +104,6 @@ const cardFields: Fields<CardProps> = {
         },
       }),
       fontSize: FontSizeSelector(),
-      color: BasicSelector("Font Color", [
-        { label: "Default", value: "default" },
-        { label: "Primary", value: "primary" },
-        { label: "Secondary", value: "secondary" },
-        { label: "Accent", value: "accent" },
-        { label: "Text", value: "text" },
-        { label: "Background", value: "background" },
-      ]),
       weight: BasicSelector("Font Weight", []),
       transform: BasicSelector("Text Transform", [
         { value: "none", label: "None" },
@@ -146,14 +125,6 @@ const cardFields: Fields<CardProps> = {
         },
       }),
       fontSize: FontSizeSelector(),
-      color: BasicSelector("Font Color", [
-        { label: "Default", value: "default" },
-        { label: "Primary", value: "primary" },
-        { label: "Secondary", value: "secondary" },
-        { label: "Accent", value: "accent" },
-        { label: "Text", value: "text" },
-        { label: "Background", value: "background" },
-      ]),
       weight: BasicSelector("Font Weight", []),
       transform: BasicSelector("Text Transform", [
         { value: "none", label: "None" },
@@ -212,14 +183,10 @@ const cardFields: Fields<CardProps> = {
       linkType: linkTypeFields,
     },
   },
-  backgroundColor: BasicSelector("Background Color", [
-    { label: "Default", value: "bg-card-backgroundColor" },
-    { label: "Primary", value: "bg-palette-primary" },
-    { label: "Secondary", value: "bg-palette-secondary" },
-    { label: "Accent", value: "bg-palette-accent" },
-    { label: "Text", value: "bg-palette-text" },
-    { label: "Background", value: "bg-palette-background" },
-  ]),
+  backgroundColor: BasicSelector(
+    "Background Color",
+    Object.values(backgroundColors)
+  ),
 };
 
 const CardWrapper = ({
@@ -239,12 +206,11 @@ const CardWrapper = ({
   const resolvedCTA = resolveYextEntityField(document, cta.entityField);
 
   return (
-    <Section className="components">
+    <Section background={backgroundColor} className={`components`}>
       <div
         className={themeManagerCn(
-          "flex flex-col md:flex-row bg-white overflow-hidden md:gap-8",
-          orientation === "right" && "md:flex-row-reverse",
-          backgroundColor
+          "flex flex-col md:flex-row overflow-hidden md:gap-8",
+          orientation === "right" && "md:flex-row-reverse"
         )}
       >
         {resolvedImage && (
@@ -277,7 +243,6 @@ const CardWrapper = ({
             <EntityField displayName="Heading" fieldId={heading.text.field}>
               <Heading
                 fontSize={heading.fontSize}
-                color={heading.color}
                 transform={heading.transform}
                 level={heading.level}
                 weight={heading.weight}
@@ -290,7 +255,6 @@ const CardWrapper = ({
             <EntityField displayName="Subtitle" fieldId={subheading.text.field}>
               <Heading
                 fontSize={subheading.fontSize}
-                color={subheading.color}
                 transform={subheading.transform}
                 level={subheading.level}
                 weight={subheading.weight}
@@ -304,7 +268,6 @@ const CardWrapper = ({
               <Body
                 fontSize={body.fontSize}
                 textTransform={body.transform}
-                color={body.color}
                 fontWeight={body.weight}
               >
                 {resolveYextEntityField(document, body.text)}
@@ -339,7 +302,6 @@ export const CardComponent: ComponentConfig<CardProps> = {
       },
       fontSize: "default",
       weight: "default",
-      color: "default",
       transform: "none",
       level: 1,
     },
@@ -351,7 +313,6 @@ export const CardComponent: ComponentConfig<CardProps> = {
       },
       fontSize: "default",
       weight: "default",
-      color: "default",
       transform: "none",
       level: 2,
     },
@@ -363,7 +324,6 @@ export const CardComponent: ComponentConfig<CardProps> = {
       },
       fontSize: "base",
       weight: "default",
-      color: "default",
       transform: "none",
     },
     image: {
@@ -392,7 +352,7 @@ export const CardComponent: ComponentConfig<CardProps> = {
       variant: "primary",
       linkType: "URL",
     },
-    backgroundColor: "bg-card-backgroundColor",
+    backgroundColor: backgroundColors.background1.value,
   },
   resolveFields: async (data): Promise<Fields<CardProps>> => {
     const headingFontWeightOptions = await getFontWeightOverrideOptions({

--- a/packages/visual-editor/src/components/puck/Directory.tsx
+++ b/packages/visual-editor/src/components/puck/Directory.tsx
@@ -5,6 +5,7 @@ import { MaybeLink } from "./atoms/maybeLink.tsx";
 import { Address, HoursStatus } from "@yext/pages-components";
 import { innerLayoutVariants, layoutVariants } from "./Layout.tsx";
 import { Section } from "./atoms/section.tsx";
+import { backgroundColors } from "../../utils/themeConfigOptions.ts";
 
 // isDirectoryGrid indicates whether the children should appear in
 // DirectoryGrid or DirectoryList dependent on the dm_directoryChildren type.
@@ -37,7 +38,7 @@ const DirectoryCard = ({
   relativePrefixToRoot: string;
 }) => {
   return (
-    <div className="bg-card-backgroundColor px-6 py-8 border h-full">
+    <div className="px-6 py-8 border h-full">
       <MaybeLink
         className="hover:underline text-h1-fontSize text-link-color mb-4"
         href={
@@ -49,7 +50,7 @@ const DirectoryCard = ({
         {profile.name}
       </MaybeLink>
       {profile.hours && (
-        <div className="mb-2 font-semibold font-body-fontFamily text-body-color">
+        <div className="mb-2 font-semibold font-body-fontFamily">
           <HoursStatus
             hours={profile.hours}
             timezone={profile.timezone}
@@ -58,7 +59,7 @@ const DirectoryCard = ({
         </div>
       )}
       {profile.address && (
-        <div className="font-body-fontFamily text-body-color">
+        <div className="font-body-fontFamily">
           <Address address={profile.address} lines={[["line1"]]} />
         </div>
       )}
@@ -80,11 +81,11 @@ const DirectoryGrid = ({
     <Section
       className={themeManagerCn(
         layoutVariants({
-          backgroundColor: "none",
           verticalPadding: "default",
           horizontalPadding: "default",
         })
       )}
+      background={backgroundColors.background1.value}
       maxWidth="full"
       padding="none"
     >

--- a/packages/visual-editor/src/components/puck/Emails.tsx
+++ b/packages/visual-editor/src/components/puck/Emails.tsx
@@ -16,7 +16,7 @@ const emailsVariants = cva("components list-inside font-body-fontFamily", {
   variants: {
     includeHyperlink: {
       true: "underline hover:no-underline text-link-fontSize text-link-color",
-      false: "text-body-fontSize text-body-color",
+      false: "text-body-fontSize",
     },
   },
   defaultVariants: {

--- a/packages/visual-editor/src/components/puck/Flex.tsx
+++ b/packages/visual-editor/src/components/puck/Flex.tsx
@@ -1,19 +1,17 @@
 import * as React from "react";
 import { ComponentConfig, DropZone, Fields } from "@measured/puck";
-import { VariantProps } from "class-variance-authority";
 import { Section } from "./atoms/section.js";
 import { themeManagerCn } from "../../utils/cn.js";
 import {
   innerLayoutVariants,
   layoutFields,
+  layoutProps,
   layoutVariants,
 } from "./Layout.tsx";
 import { BasicSelector } from "../../index.js";
+import { backgroundColors } from "../../utils/themeConfigOptions.ts";
 
-interface FlexProps
-  extends React.HTMLAttributes<HTMLDivElement>,
-    VariantProps<typeof layoutVariants>,
-    VariantProps<typeof innerLayoutVariants> {
+interface FlexProps extends layoutProps {
   justifyContent: "start" | "center" | "end";
   direction: "row" | "column";
   wrap: "wrap" | "nowrap";
@@ -36,9 +34,9 @@ const FlexContainer = React.forwardRef<HTMLDivElement, FlexProps>(
   ) => {
     return (
       <Section
+        background={backgroundColor}
         className={themeManagerCn(
           layoutVariants({
-            backgroundColor,
             verticalPadding,
             horizontalPadding,
             gap,
@@ -99,7 +97,7 @@ const FlexContainerComponent: ComponentConfig<FlexProps> = {
     gap: "0",
     verticalPadding: "default",
     horizontalPadding: "default",
-    backgroundColor: "none",
+    backgroundColor: backgroundColors.background1.value,
   },
   resolveFields: (data, params) => {
     // If the Flex has a parent component, the defaultProps should
@@ -110,7 +108,6 @@ const FlexContainerComponent: ComponentConfig<FlexProps> = {
         data.props.verticalPadding = "0";
         data.props.horizontalPadding = "0";
         data.props.gap = "0";
-        data.props.backgroundColor = "inherit";
         data.props.maxContentWidth = "none";
       }
       return flexContainerFields;

--- a/packages/visual-editor/src/components/puck/Footer.tsx
+++ b/packages/visual-editor/src/components/puck/Footer.tsx
@@ -89,7 +89,7 @@ const FooterComponent: React.FC<FooterProps> = (props) => {
       label: <FaPinterest className="w-5 h-5 mr-4" />,
     },
     {
-      name: "titok",
+      name: "tiktok",
       link: document?._site?.tikTokUrl,
       label: <FaTiktok className="w-5 h-5 mr-4" />,
     },

--- a/packages/visual-editor/src/components/puck/Grid.tsx
+++ b/packages/visual-editor/src/components/puck/Grid.tsx
@@ -1,20 +1,17 @@
 import * as React from "react";
-import { type VariantProps } from "class-variance-authority";
 import { ComponentConfig, DropZone, Fields } from "@measured/puck";
 import { Section } from "./atoms/section.js";
 import { themeManagerCn, BasicSelector } from "../../index.js";
 import { innerLayoutVariants, layoutVariants } from "./Layout.tsx";
-import { layoutFields } from "./Layout.tsx";
+import { layoutFields, layoutProps } from "./Layout.tsx";
+import { backgroundColors } from "../../utils/themeConfigOptions.ts";
 
 interface ColumnProps {
   justifyContent: "center" | "start" | "end" | "spaceBetween";
   span?: number;
 }
 
-interface GridProps
-  extends React.HTMLAttributes<HTMLDivElement>,
-    VariantProps<typeof layoutVariants>,
-    VariantProps<typeof innerLayoutVariants> {
+interface GridProps extends layoutProps {
   columns: ColumnProps[];
 }
 
@@ -34,9 +31,9 @@ const GridSection = React.forwardRef<HTMLDivElement, GridProps>(
   ) => {
     return (
       <Section
+        background={backgroundColor}
         className={themeManagerCn(
           layoutVariants({
-            backgroundColor,
             verticalPadding,
             horizontalPadding,
           })
@@ -123,7 +120,7 @@ const GridSectionComponent: ComponentConfig<GridProps> = {
     gap: "0",
     verticalPadding: "default",
     horizontalPadding: "default",
-    backgroundColor: "none",
+    backgroundColor: backgroundColors.background1.value,
   },
   resolveFields: (data, params) => {
     // If the Grid has a parent component, the defaultProps should
@@ -134,7 +131,6 @@ const GridSectionComponent: ComponentConfig<GridProps> = {
         data.props.verticalPadding = "0";
         data.props.horizontalPadding = "0";
         data.props.gap = "0";
-        data.props.backgroundColor = "inherit";
         data.props.maxContentWidth = "none";
       }
       return gridSectionFields;

--- a/packages/visual-editor/src/components/puck/HoursTable.tsx
+++ b/packages/visual-editor/src/components/puck/HoursTable.tsx
@@ -95,7 +95,7 @@ const VisualEditorHoursTable = ({
 
   return (
     <Section
-      className={`flex flex-col justify-center components ${alignment} font-body-fontFamily font-body-fontWeight text-body-fontSize text-body-color`}
+      className={`flex flex-col justify-center components ${alignment} font-body-fontFamily font-body-fontWeight text-body-fontSize`}
       padding={padding}
     >
       <div>

--- a/packages/visual-editor/src/components/puck/Layout.tsx
+++ b/packages/visual-editor/src/components/puck/Layout.tsx
@@ -1,6 +1,10 @@
 import { cva, VariantProps } from "class-variance-authority";
 import { Fields } from "@measured/puck";
 import { SpacingSelector, BasicSelector } from "../../index.js";
+import {
+  backgroundColors,
+  BackgroundStyle,
+} from "../../utils/themeConfigOptions.js";
 
 export const layoutVariants = cva("components w-full", {
   variants: {
@@ -78,21 +82,11 @@ export const layoutVariants = cva("components w-full", {
       "20": "px-20",
       "24": "px-24",
     },
-    backgroundColor: {
-      none: "",
-      primary: "bg-palette-primary",
-      secondary: "bg-palette-secondary",
-      accent: "bg-palette-accent",
-      text: "bg-palette-text",
-      background: "bg-palette-background",
-      inherit: "bg-inherit",
-    },
   },
   defaultVariants: {
     gap: "none",
     verticalPadding: "none",
     horizontalPadding: "none",
-    backgroundColor: "none",
   },
 });
 
@@ -114,20 +108,18 @@ export const innerLayoutVariants = cva(
   }
 );
 
-interface layoutProps
+export interface layoutProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof layoutVariants>,
-    VariantProps<typeof innerLayoutVariants> {}
+    VariantProps<typeof innerLayoutVariants> {
+  backgroundColor?: BackgroundStyle;
+}
 
 export const layoutFields: Fields<layoutProps> = {
-  backgroundColor: BasicSelector("Background Color", [
-    { label: "Default", value: "default" },
-    { label: "Primary", value: "primary" },
-    { label: "Secondary", value: "secondary" },
-    { label: "Accent", value: "accent" },
-    { label: "Text", value: "text" },
-    { label: "Background", value: "background" },
-  ]),
+  backgroundColor: BasicSelector(
+    "Background Color",
+    Object.values(backgroundColors)
+  ),
   gap: SpacingSelector("gap", "Gap"),
   verticalPadding: SpacingSelector("padding", "Vertical Padding"),
   horizontalPadding: SpacingSelector("padding", "Horizontal Padding"),

--- a/packages/visual-editor/src/components/puck/Phone.tsx
+++ b/packages/visual-editor/src/components/puck/Phone.tsx
@@ -30,14 +30,6 @@ const phoneVariants = cva(
         "800": "font-extrabold",
         "900": "font-black",
       },
-      color: {
-        default: "text-body-color",
-        primary: "text-palette-primary",
-        secondary: "text-palette-secondary",
-        accent: "text-palette-accent",
-        text: "text-palette-text",
-        background: "text-palette-background",
-      },
       includeHyperlink: {
         true: "underline hover:no-underline",
         false: "",
@@ -45,7 +37,6 @@ const phoneVariants = cva(
     },
     defaultVariants: {
       fontWeight: "default",
-      color: "default",
       includeHyperlink: true,
     },
   }
@@ -92,14 +83,6 @@ const PhoneFields: Fields<PhoneProps> = {
       { label: "International", value: "international" },
     ],
   },
-  color: BasicSelector("Color", [
-    { label: "Default", value: "default" },
-    { label: "Primary", value: "primary" },
-    { label: "Secondary", value: "secondary" },
-    { label: "Accent", value: "accent" },
-    { label: "Text", value: "text" },
-    { label: "Background", value: "background" },
-  ]),
   includeHyperlink: {
     label: "Include Hyperlink",
     type: "radio",
@@ -114,7 +97,6 @@ const Phone: React.FC<PhoneProps> = ({
   phone,
   format,
   fontWeight,
-  color,
   includeHyperlink,
 }) => {
   const document = useDocument();
@@ -125,7 +107,7 @@ const Phone: React.FC<PhoneProps> = ({
   }
 
   const formattedPhoneNumber: string = formatPhoneNumber(resolvedPhone, format);
-  const classNameCn = phoneVariants({ fontWeight, color, includeHyperlink });
+  const classNameCn = phoneVariants({ fontWeight, includeHyperlink });
 
   return (
     <EntityField

--- a/packages/visual-editor/src/components/puck/Promo.tsx
+++ b/packages/visual-editor/src/components/puck/Promo.tsx
@@ -24,13 +24,11 @@ interface PromoProps {
   title: {
     text: YextEntityField<string>;
     fontSize: HeadingProps["fontSize"];
-    color: HeadingProps["color"];
     transform: HeadingProps["transform"];
   };
   description: {
     text: YextEntityField<string>;
     fontSize: BodyProps["fontSize"];
-    color: BodyProps["color"];
     transform: BodyProps["textTransform"];
   };
   image: {
@@ -63,14 +61,6 @@ const promoFields: Fields<PromoProps> = {
         },
       }),
       fontSize: FontSizeSelector(),
-      color: BasicSelector("Font Color", [
-        { label: "Default", value: "default" },
-        { label: "Primary", value: "primary" },
-        { label: "Secondary", value: "secondary" },
-        { label: "Accent", value: "accent" },
-        { label: "Text", value: "text" },
-        { label: "Background", value: "background" },
-      ]),
       transform: BasicSelector("Text Transform", [
         { value: "none", label: "None" },
         { value: "lowercase", label: "Lowercase" },
@@ -90,14 +80,6 @@ const promoFields: Fields<PromoProps> = {
         },
       }),
       fontSize: FontSizeSelector(),
-      color: BasicSelector("Font Color", [
-        { label: "Default", value: "default" },
-        { label: "Primary", value: "primary" },
-        { label: "Secondary", value: "secondary" },
-        { label: "Accent", value: "accent" },
-        { label: "Text", value: "text" },
-        { label: "Background", value: "background" },
-      ]),
       transform: BasicSelector("Text Transform", [
         { value: "none", label: "None" },
         { value: "lowercase", label: "Lowercase" },
@@ -208,11 +190,7 @@ const PromoWrapper: React.FC<PromoProps> = ({
         )}
         <div className="flex flex-col justify-center gap-y-4 md:gap-y-8 p-4 md:px-16 md:py-0 w-full break-all">
           {title?.text && (
-            <Heading
-              fontSize={title.fontSize}
-              color={title.color}
-              transform={title.transform}
-            >
+            <Heading fontSize={title.fontSize} transform={title.transform}>
               {resolveYextEntityField(document, title.text)}
             </Heading>
           )}
@@ -220,7 +198,6 @@ const PromoWrapper: React.FC<PromoProps> = ({
             <Body
               fontSize={description.fontSize}
               textTransform={description.transform}
-              color={description.color}
             >
               {resolveYextEntityField(document, description.text)}
             </Body>
@@ -252,7 +229,6 @@ export const PromoComponent: ComponentConfig<PromoProps> = {
         constantValueEnabled: true,
       },
       fontSize: "default",
-      color: "default",
       transform: "none",
     },
     description: {
@@ -262,7 +238,6 @@ export const PromoComponent: ComponentConfig<PromoProps> = {
         constantValueEnabled: true,
       },
       fontSize: "base",
-      color: "default",
       transform: "none",
     },
     image: {

--- a/packages/visual-editor/src/components/puck/TextList.tsx
+++ b/packages/visual-editor/src/components/puck/TextList.tsx
@@ -37,7 +37,7 @@ const TextList: React.FC<TextListProps> = ({ list: textListField }) => {
       fieldId={textListField.field}
       constantValueEnabled={textListField.constantValueEnabled}
     >
-      <ul className="components list-disc list-inside text-body-fontSize font-body-fontFamily font-body-fontWeight text-body-color">
+      <ul className="components list-disc list-inside text-body-fontSize font-body-fontFamily font-body-fontWeight">
         {resolvedTextList.map((text: any, index: any) => (
           <li key={index} className="mb-2">
             {text}

--- a/packages/visual-editor/src/components/puck/atoms/body.tsx
+++ b/packages/visual-editor/src/components/puck/atoms/body.tsx
@@ -22,14 +22,6 @@ const bodyVariants = cva("components font-body-fontFamily", {
       "800": "font-extrabold",
       "900": "font-black",
     },
-    color: {
-      default: "text-body-color",
-      primary: "text-palette-primary",
-      secondary: "text-palette-secondary",
-      accent: "text-palette-accent",
-      text: "text-palette-text",
-      background: "text-palette-background",
-    },
     textTransform: {
       none: "",
       uppercase: "uppercase",
@@ -40,7 +32,6 @@ const bodyVariants = cva("components font-body-fontFamily", {
   defaultVariants: {
     fontSize: "base",
     fontWeight: "default",
-    color: "default",
     textTransform: "none",
   },
 });
@@ -51,17 +42,13 @@ export interface BodyProps
     VariantProps<typeof bodyVariants> {}
 
 const Body = React.forwardRef<HTMLParagraphElement, BodyProps>(
-  (
-    { className, fontSize, fontWeight, color, textTransform, ...props },
-    ref
-  ) => {
+  ({ className, fontSize, fontWeight, textTransform, ...props }, ref) => {
     return (
       <p
         className={themeManagerCn(
           bodyVariants({
             fontSize,
             fontWeight,
-            color,
             textTransform,
             className,
           }),

--- a/packages/visual-editor/src/components/puck/atoms/heading.tsx
+++ b/packages/visual-editor/src/components/puck/atoms/heading.tsx
@@ -51,14 +51,6 @@ const headingVariants = cva("components", {
       "800": "font-extrabold",
       "900": "font-black",
     },
-    color: {
-      default: "",
-      primary: "text-palette-primary",
-      secondary: "text-palette-secondary",
-      accent: "text-palette-accent",
-      text: "text-palette-text",
-      background: "text-palette-background",
-    },
     transform: {
       none: "",
       uppercase: "uppercase",
@@ -68,7 +60,6 @@ const headingVariants = cva("components", {
   },
   defaultVariants: {
     fontSize: "default",
-    color: "primary",
     weight: "default",
     transform: "none",
   },
@@ -85,10 +76,7 @@ export interface HeadingProps
 }
 
 const Heading = React.forwardRef<HTMLHeadingElement, HeadingProps>(
-  (
-    { className, level = 1, color, weight, transform, fontSize, ...props },
-    ref
-  ) => {
+  ({ className, level = 1, weight, transform, fontSize, ...props }, ref) => {
     const Tag = `h${level}` as keyof Pick<
       JSX.IntrinsicElements,
       "h1" | "h2" | "h3" | "h4" | "h5" | "h6"
@@ -100,7 +88,6 @@ const Heading = React.forwardRef<HTMLHeadingElement, HeadingProps>(
         className={themeManagerCn(
           headingVariants({
             fontSize,
-            color,
             weight,
             transform,
             level,

--- a/packages/visual-editor/src/components/puck/atoms/section.tsx
+++ b/packages/visual-editor/src/components/puck/atoms/section.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { themeManagerCn } from "../../../index.ts";
+import { BackgroundStyle } from "../../../utils/themeConfigOptions.ts";
 
 const sectionVariants = cva("mx-auto", {
   variants: {
@@ -24,12 +25,16 @@ const sectionVariants = cva("mx-auto", {
 
 export interface SectionProps
   extends React.HTMLAttributes<HTMLDivElement>,
-    VariantProps<typeof sectionVariants> {}
+    VariantProps<typeof sectionVariants> {
+  background?: BackgroundStyle;
+}
 
 const Section = React.forwardRef<HTMLDivElement, SectionProps>(
-  ({ className, padding, maxWidth, ...props }, ref) => {
+  ({ className, padding, maxWidth, background, ...props }, ref) => {
     return (
-      <div className="components bg-main">
+      <div
+        className={`components ${background?.bgColor} ${background?.textColor}`}
+      >
         <div
           className={themeManagerCn(
             sectionVariants({ padding, maxWidth }),


### PR DESCRIPTION
Uses the new background styles for all background and text color

In general, removes text color as a class that is set in individual components, so that the text color set by the Grid/Flex/Section is inherited.

CTAs still need to be updated to the new styles, so they are a little off.


https://github.com/user-attachments/assets/f3b2b655-1927-47b1-95c1-bb828b9f0661

