### PR TITLE
fix: handle non-string values correctly in BasicSelector

### DIFF
--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -50,7 +50,7 @@
     "@radix-ui/react-tooltip": "^1.1.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
-    "cmdk": "^1.0.4",
+    "cmdk": "^1.1.1",
     "dompurify": "^3.2.3",
     "eslint": "^9.8.0",
     "eslint-plugin-react": "^7.35.0",

--- a/packages/visual-editor/src/components/editor/BasicSelector.tsx
+++ b/packages/visual-editor/src/components/editor/BasicSelector.tsx
@@ -9,22 +9,20 @@ export const BasicSelector = (
 ): Field => {
   return {
     type: "custom",
-    render: ({ value, onChange }) => {
+    render: ({
+      value,
+      onChange,
+    }: {
+      value: any;
+      onChange: (selectedOption: any) => void;
+    }) => {
       return (
         <FieldLabel label={label} icon={<ChevronDown size={16} />}>
           <Combobox
             defaultValue={
               options.find((option) => option.value === value) ?? options[0]
             }
-            // option from onChange is the stringified value of the selected option
-            onChange={(option: any) => {
-              onChange(
-                (
-                  options.find((o) => o.value.toString() === option) ??
-                  options[0]
-                )?.value
-              );
-            }}
+            onChange={onChange}
             options={options}
           />
         </FieldLabel>

--- a/packages/visual-editor/src/components/editor/BasicSelector.tsx
+++ b/packages/visual-editor/src/components/editor/BasicSelector.tsx
@@ -16,12 +16,15 @@ export const BasicSelector = (
             defaultValue={
               options.find((option) => option.value === value) ?? options[0]
             }
-            // option from onChange is the label of the selected option, but Puck's onChange expects the value
-            onChange={(option: any) =>
+            // option from onChange is the stringified value of the selected option
+            onChange={(option: any) => {
               onChange(
-                (options.find((o) => o.label === option) ?? options[0])?.value
-              )
-            }
+                (
+                  options.find((o) => o.value.toString() === option) ??
+                  options[0]
+                )?.value
+              );
+            }}
             options={options}
           />
         </FieldLabel>

--- a/packages/visual-editor/src/components/puck/TextList.tsx
+++ b/packages/visual-editor/src/components/puck/TextList.tsx
@@ -1,65 +1,15 @@
 import * as React from "react";
 import { ComponentConfig, Fields } from "@measured/puck";
-import { cva, type VariantProps } from "class-variance-authority";
 import {
   useDocument,
   resolveYextEntityField,
   EntityField,
   YextEntityField,
   YextEntityFieldSelector,
-  getFontWeightOverrideOptions,
-  BasicSelector,
 } from "../../index.js";
 
-const textListVariants = cva(
-  "list-disc components list-inside text-body-fontSize font-body-fontFamily",
-  {
-    variants: {
-      fontWeight: {
-        default: "font-body-fontWeight",
-        "100": "font-thin",
-        "200": "font-extralight",
-        "300": "font-light",
-        "400": "font-normal",
-        "500": "font-medium",
-        "600": "font-semibold",
-        "700": "font-bold",
-        "800": "font-extrabold",
-        "900": "font-black",
-      },
-      color: {
-        default: "text-palette-body-color",
-        primary: "text-palette-primary",
-        secondary: "text-palette-secondary",
-        accent: "text-palette-accent",
-        text: "text-palette-text",
-        background: "text-palette-background",
-      },
-      textTransform: {
-        none: "",
-        uppercase: "uppercase",
-        lowercase: "lowercase",
-        capitalize: "capitalize",
-      },
-      padding: {
-        default: "px-4 py-16 md:px-8",
-        none: "p-0",
-        small: "px-4 py-8 md:px-8",
-        large: "px-[200px] py-24 md:px-8",
-      },
-    },
-    defaultVariants: {
-      padding: "none",
-      fontWeight: "default",
-      color: "default",
-      textTransform: "none",
-    },
-  }
-);
-
-interface TextListProps extends VariantProps<typeof textListVariants> {
+interface TextListProps {
   list: YextEntityField<string[]>;
-  textSize?: number;
 }
 
 const textListFields: Fields<TextListProps> = {
@@ -70,39 +20,9 @@ const textListFields: Fields<TextListProps> = {
       includeListsOnly: true,
     },
   }),
-  padding: {
-    label: "Padding",
-    type: "radio",
-    options: [
-      { label: "None", value: "none" },
-      { label: "Small", value: "small" },
-      { label: "Medium", value: "default" },
-      { label: "Large", value: "large" },
-    ],
-  },
-  color: BasicSelector("Color", [
-    { label: "Default", value: "default" },
-    { label: "Primary", value: "primary" },
-    { label: "Secondary", value: "secondary" },
-    { label: "Accent", value: "accent" },
-    { label: "Text", value: "text" },
-    { label: "Background", value: "background" },
-  ]),
-  textTransform: BasicSelector("Text Transform", [
-    { label: "None", value: "none" },
-    { label: "Uppercase", value: "uppercase" },
-    { label: "Lowercase", value: "lowercase" },
-    { label: "Capitalize", value: "capitalize" },
-  ]),
 };
 
-const TextList: React.FC<TextListProps> = ({
-  list: textListField,
-  padding,
-  fontWeight,
-  color,
-  textTransform,
-}) => {
+const TextList: React.FC<TextListProps> = ({ list: textListField }) => {
   const document = useDocument();
   let resolvedTextList: any = resolveYextEntityField(document, textListField);
   if (!resolvedTextList) {
@@ -117,14 +37,7 @@ const TextList: React.FC<TextListProps> = ({
       fieldId={textListField.field}
       constantValueEnabled={textListField.constantValueEnabled}
     >
-      <ul
-        className={textListVariants({
-          padding,
-          fontWeight,
-          color,
-          textTransform,
-        })}
-      >
+      <ul className="components list-disc list-inside text-body-fontSize font-body-fontFamily font-body-fontWeight text-body-color">
         {resolvedTextList.map((text: any, index: any) => (
           <li key={index} className="mb-2">
             {text}
@@ -139,20 +52,10 @@ const TextListComponent: ComponentConfig<TextListProps> = {
   label: "Text List",
   fields: textListFields,
   defaultProps: {
-    padding: "none",
     list: {
       field: "",
       constantValue: [],
     },
-  },
-  resolveFields: async () => {
-    const fontWeightOptions = await getFontWeightOverrideOptions({
-      fontCssVariable: `--fontFamily-body-fontFamily`,
-    });
-    return {
-      ...textListFields,
-      fontWeight: BasicSelector("Font Weight", fontWeightOptions),
-    };
   },
   render: (props) => <TextList {...props} />,
 };

--- a/packages/visual-editor/src/internal/puck/ui/Combobox.tsx
+++ b/packages/visual-editor/src/internal/puck/ui/Combobox.tsx
@@ -21,7 +21,7 @@ type ComboboxOption = {
 type ComboboxProps = {
   defaultValue: ComboboxOption;
   onChange: (value: any) => void;
-  options: Array<any>;
+  options: Array<ComboboxOption>;
 };
 
 export const Combobox = ({
@@ -55,10 +55,13 @@ export const Combobox = ({
             <CommandGroup>
               {options.map((option) => (
                 <CommandItem
-                  key={option.key}
+                  key={option.label}
                   value={option.value.toString()}
                   onSelect={(currentValue) => {
-                    onChange(currentValue);
+                    onChange(
+                      options.find((o) => o.value.toString() === currentValue)
+                        ?.value ?? options[0]?.value
+                    );
                     setOpen(false);
                   }}
                 >

--- a/packages/visual-editor/src/internal/puck/ui/Combobox.tsx
+++ b/packages/visual-editor/src/internal/puck/ui/Combobox.tsx
@@ -56,7 +56,7 @@ export const Combobox = ({
               {options.map((option) => (
                 <CommandItem
                   key={option.key}
-                  value={option.value}
+                  value={option.value.toString()}
                   onSelect={(currentValue) => {
                     onChange(currentValue);
                     setOpen(false);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,8 +134,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       cmdk:
-        specifier: ^1.0.4
-        version: 1.0.4(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       dompurify:
         specifier: ^3.2.3
         version: 3.2.4
@@ -2232,6 +2232,22 @@ packages:
     resolution:
       {
         integrity: sha512-Yj4dZtqa2o+kG61fzB0H2qUvmwBA2oyQroGLyNtBj1beo1khoQ3q1a2AO8rrQYjd8256CO9+N8L9tvsS+bnIyA==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      "@types/react-dom": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      "@types/react-dom":
+        optional: true
+
+  "@radix-ui/react-dialog@1.1.6":
+    resolution:
+      {
+        integrity: sha512-/IVhJV5AceX620DUJ4uYVMymzsipdKBzo3edo+omeskCKGm9FRHM0ebIdbPnlQVJqyuHbuBltQUOG2mOTq2IYw==,
       }
     peerDependencies:
       "@types/react": "*"
@@ -4574,10 +4590,10 @@ packages:
       }
     engines: { node: ^18.17.0 || >=20.5.0 }
 
-  cmdk@1.0.4:
+  cmdk@1.1.1:
     resolution:
       {
-        integrity: sha512-AnsjfHyHpQ/EFeAnG216WY7A5LiYCoZzCSygiLvfXC3H3LFGCprErteUcszaVluGOhuOTbJS3jWHrSDYPBBygg==,
+        integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==,
       }
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
@@ -11612,6 +11628,28 @@ snapshots:
       "@types/react": 18.3.12
       "@types/react-dom": 18.3.1
 
+  "@radix-ui/react-dialog@1.1.6(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
+    dependencies:
+      "@radix-ui/primitive": 1.1.1
+      "@radix-ui/react-compose-refs": 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      "@radix-ui/react-context": 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      "@radix-ui/react-dismissable-layer": 1.1.5(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-focus-guards": 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      "@radix-ui/react-focus-scope": 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-id": 1.1.0(@types/react@18.3.12)(react@18.3.1)
+      "@radix-ui/react-portal": 1.1.4(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-presence": 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-primitive": 2.0.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-slot": 1.1.2(@types/react@18.3.12)(react@18.3.1)
+      "@radix-ui/react-use-controllable-state": 1.1.0(@types/react@18.3.12)(react@18.3.1)
+      aria-hidden: 1.2.4
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.6.3(@types/react@18.3.12)(react@18.3.1)
+    optionalDependencies:
+      "@types/react": 18.3.12
+      "@types/react-dom": 18.3.1
+
   "@radix-ui/react-direction@1.1.0(@types/react@18.3.12)(react@18.3.1)":
     dependencies:
       react: 18.3.1
@@ -13271,14 +13309,14 @@ snapshots:
 
   cmd-shim@7.0.0: {}
 
-  cmdk@1.0.4(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  cmdk@1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      "@radix-ui/react-dialog": 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-compose-refs": 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      "@radix-ui/react-dialog": 1.1.6(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       "@radix-ui/react-id": 1.1.0(@types/react@18.3.12)(react@18.3.1)
       "@radix-ui/react-primitive": 2.0.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      use-sync-external-store: 1.4.0(react@18.3.1)
     transitivePeerDependencies:
       - "@types/react"
       - "@types/react-dom"
@@ -16834,6 +16872,7 @@ snapshots:
   use-sync-external-store@1.4.0(react@18.3.1):
     dependencies:
       react: 18.3.1
+    optional: true
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
cmdk's CommandItem component expects all values to be strings, and produces inconsistent results when non-string values are provided. We want our BasicSelector to work for non-string values like numbers (such as in the HeadingText component's level field), so this change stringifies the values that are passed in, and updates BasicComponent to select the option with the value that, when stringified, matches the value that was clicked. This also updates the cmdk package to ensure we get other bug fixes that have been released (although the newest version still does not handle non-string values).

Tested manually and confirmed that BasicSelector works as expected for both string and non-string values.