### PR TITLE
refactor: body theme updates

### DIFF
--- a/packages/visual-editor/src/components/puck/Address.tsx
+++ b/packages/visual-editor/src/components/puck/Address.tsx
@@ -60,7 +60,7 @@ const Address = ({
           fieldId={addressField.field}
           constantValueEnabled={addressField.constantValueEnabled}
         >
-          <Body fontSize="base">
+          <Body variant="base">
             <RenderAddress
               address={address as AddressType}
               lines={[["line1"], ["line2", "city", "region", "postalCode"]]}
@@ -74,7 +74,7 @@ const Address = ({
                 linkType: "DRIVING_DIRECTIONS",
               }}
               target="_blank"
-              className="font-bold text-link-color text-link-fontSize underline hover:no-underline mt-2 block"
+              className="font-bold text-link-color text-body-fontSize underline hover:no-underline mt-2 block"
             />
           )}
         </EntityField>

--- a/packages/visual-editor/src/components/puck/BodyText.tsx
+++ b/packages/visual-editor/src/components/puck/BodyText.tsx
@@ -40,7 +40,7 @@ const bodyTextFields: Fields<BodyTextProps> = {
       types: ["type.string"],
     },
   }),
-  fontSize: {
+  variant: {
     label: "Variant",
     type: "radio",
     options: [
@@ -60,7 +60,7 @@ const BodyTextComponent: ComponentConfig<BodyTextProps> = {
       constantValue: "Text",
       constantValueEnabled: true,
     },
-    fontSize: "base",
+    variant: "base",
   },
   render: (props) => <BodyText {...props} />,
 };

--- a/packages/visual-editor/src/components/puck/Breadcrumbs.tsx
+++ b/packages/visual-editor/src/components/puck/Breadcrumbs.tsx
@@ -51,7 +51,7 @@ export const BreadcrumbsComponent = (props: BreadcrumbsProps) => {
     <div>
       {breadcrumbs?.length > 0 && (
         <nav className="my-4" aria-label="Breadcrumb">
-          <ol className="components flex flex-wrap text-link-fontSize">
+          <ol className="components flex flex-wrap text-body-sm-fontSize">
             {breadcrumbs.map(({ name, slug }, idx) => {
               const isLast = idx === breadcrumbs.length - 1;
               const href = relativePrefixToRoot
@@ -61,7 +61,7 @@ export const BreadcrumbsComponent = (props: BreadcrumbsProps) => {
                 <li key={idx}>
                   <MaybeLink
                     href={isLast ? "" : href}
-                    className="text-link-color underline hover:no-underline"
+                    className={"text-link-color underline hover:no-underline"}
                   >
                     {name}
                   </MaybeLink>

--- a/packages/visual-editor/src/components/puck/Card.tsx
+++ b/packages/visual-editor/src/components/puck/Card.tsx
@@ -48,9 +48,7 @@ interface CardProps {
   };
   body: {
     text: YextEntityField<string>;
-    fontSize: BodyProps["fontSize"];
-    weight: BodyProps["fontWeight"];
-    transform: BodyProps["textTransform"];
+    variant: BodyProps["variant"];
   };
   image: {
     image: YextEntityField<ImageType>;
@@ -124,14 +122,15 @@ const cardFields: Fields<CardProps> = {
           types: ["type.string"],
         },
       }),
-      fontSize: FontSizeSelector(),
-      weight: BasicSelector("Font Weight", []),
-      transform: BasicSelector("Text Transform", [
-        { value: "none", label: "None" },
-        { value: "lowercase", label: "Lowercase" },
-        { value: "uppercase", label: "Uppercase" },
-        { value: "capitalize", label: "Capitalize" },
-      ]),
+      variant: {
+        type: "radio",
+        label: "Variant",
+        options: [
+          { label: "Small", value: "sm" },
+          { label: "Base", value: "base" },
+          { label: "Large", value: "lg" },
+        ],
+      },
     },
   },
   image: {
@@ -265,11 +264,7 @@ const CardWrapper = ({
           )}
           {body?.text && (
             <EntityField displayName="Description" fieldId={body.text.field}>
-              <Body
-                fontSize={body.fontSize}
-                textTransform={body.transform}
-                fontWeight={body.weight}
-              >
+              <Body variant={body.variant}>
                 {resolveYextEntityField(document, body.text)}
               </Body>
             </EntityField>
@@ -322,9 +317,7 @@ export const CardComponent: ComponentConfig<CardProps> = {
         constantValue: "Body",
         constantValueEnabled: true,
       },
-      fontSize: "base",
-      weight: "default",
-      transform: "none",
+      variant: "base",
     },
     image: {
       image: {

--- a/packages/visual-editor/src/components/puck/Directory.tsx
+++ b/packages/visual-editor/src/components/puck/Directory.tsx
@@ -127,7 +127,7 @@ const DirectoryList = ({
         {sortedDirectoryChildren.map((child, idx) => (
           <li className="p-3" key={idx}>
             <MaybeLink
-              className="inline-block after:content-[attr(data-count)] after:ml-2 hover:underline text-link-fontSize text-link-color"
+              className="inline-block after:content-[attr(data-count)] after:ml-2 hover:underline text-body-fontSize text-link-color"
               href={
                 relativePrefixToRoot
                   ? relativePrefixToRoot + child.slug

--- a/packages/visual-editor/src/components/puck/Emails.tsx
+++ b/packages/visual-editor/src/components/puck/Emails.tsx
@@ -12,17 +12,20 @@ import {
 } from "../../index.js";
 import { Link } from "@yext/pages-components";
 
-const emailsVariants = cva("components list-inside font-body-fontFamily", {
-  variants: {
-    includeHyperlink: {
-      true: "underline hover:no-underline text-link-fontSize text-link-color",
-      false: "text-body-fontSize",
+const emailsVariants = cva(
+  "components list-inside font-body-fontFamily text-body-fontSize",
+  {
+    variants: {
+      includeHyperlink: {
+        true: "underline hover:no-underline text-link-color",
+        false: "",
+      },
     },
-  },
-  defaultVariants: {
-    includeHyperlink: true,
-  },
-});
+    defaultVariants: {
+      includeHyperlink: true,
+    },
+  }
+);
 
 interface EmailsProps extends VariantProps<typeof emailsVariants> {
   list: YextEntityField<string[]>;

--- a/packages/visual-editor/src/components/puck/Footer.tsx
+++ b/packages/visual-editor/src/components/puck/Footer.tsx
@@ -123,7 +123,7 @@ const FooterComponent: React.FC<FooterProps> = (props) => {
         </div>
         {copyrightMessage && (
           <div
-            className={`text-body-fontSize text-center sm:text-left ${backgroundColor?.textColor}`}
+            className={`text-body-sm-fontSize text-center sm:text-left ${backgroundColor?.textColor}`}
           >
             <EntityField
               displayName="Copyright Text"

--- a/packages/visual-editor/src/components/puck/HoursStatus.tsx
+++ b/packages/visual-editor/src/components/puck/HoursStatus.tsx
@@ -81,7 +81,7 @@ const HoursStatusWrapper: React.FC<HoursStatusProps> = ({
       <HoursStatus
         hours={hours}
         className={themeManagerCn(
-          "components mb-2 font-h5-fontWeight font-h5-fontFamily",
+          "components mb-2 font-body-fontWeight text-body-lg-fontSize",
           className
         )}
         currentTemplate={showCurrentStatus ? undefined : () => <></>}

--- a/packages/visual-editor/src/components/puck/HoursTable.tsx
+++ b/packages/visual-editor/src/components/puck/HoursTable.tsx
@@ -114,7 +114,9 @@ const VisualEditorHoursTable = ({
         )}
         {additionalHoursText && showAdditionalHoursText && (
           <EntityField displayName="Hours Text" fieldId="additionalHoursText">
-            <div className="mt-4">{additionalHoursText}</div>
+            <div className="mt-4 text-body-sm-fontSize">
+              {additionalHoursText}
+            </div>
           </EntityField>
         )}
       </div>

--- a/packages/visual-editor/src/components/puck/Promo.tsx
+++ b/packages/visual-editor/src/components/puck/Promo.tsx
@@ -87,7 +87,7 @@ const promoFields: Fields<PromoProps> = {
           types: ["type.string"],
         },
       }),
-     variant: {
+      variant: {
         label: "Variant",
         type: "radio",
         options: [

--- a/packages/visual-editor/src/components/puck/Promo.tsx
+++ b/packages/visual-editor/src/components/puck/Promo.tsx
@@ -13,6 +13,7 @@ import {
   ImageWrapperProps,
   BackgroundStyle,
   backgroundColors,
+  BodyProps,
 } from "../../index.js";
 import { CTA, CTAProps } from "./atoms/cta.js";
 import { Heading, HeadingProps, headingOptions } from "./atoms/heading.js";

--- a/packages/visual-editor/src/components/puck/Promo.tsx
+++ b/packages/visual-editor/src/components/puck/Promo.tsx
@@ -28,8 +28,7 @@ interface PromoProps {
   };
   description: {
     text: YextEntityField<string>;
-    fontSize: BodyProps["fontSize"];
-    transform: BodyProps["textTransform"];
+    variant: BodyProps["variant"];
   };
   image: {
     image: YextEntityField<ImageType>;
@@ -79,13 +78,15 @@ const promoFields: Fields<PromoProps> = {
           types: ["type.string"],
         },
       }),
-      fontSize: FontSizeSelector(),
-      transform: BasicSelector("Text Transform", [
-        { value: "none", label: "None" },
-        { value: "lowercase", label: "Lowercase" },
-        { value: "uppercase", label: "Uppercase" },
-        { value: "capitalize", label: "Capitalize" },
-      ]),
+      variant: {
+        label: "Variant",
+        type: "radio",
+        options: [
+          { label: "Small", value: "sm" },
+          { label: "Base", value: "base" },
+          { label: "Large", value: "lg" },
+        ],
+      },
     },
   },
   image: {
@@ -195,10 +196,7 @@ const PromoWrapper: React.FC<PromoProps> = ({
             </Heading>
           )}
           {description?.text && (
-            <Body
-              fontSize={description.fontSize}
-              textTransform={description.transform}
-            >
+            <Body variant={description.variant}>
               {resolveYextEntityField(document, description.text)}
             </Body>
           )}
@@ -237,8 +235,7 @@ export const PromoComponent: ComponentConfig<PromoProps> = {
         constantValue: "Description",
         constantValueEnabled: true,
       },
-      fontSize: "base",
-      transform: "none",
+      variant: "base",
     },
     image: {
       image: {

--- a/packages/visual-editor/src/components/puck/atoms/body.tsx
+++ b/packages/visual-editor/src/components/puck/atoms/body.tsx
@@ -3,38 +3,21 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { themeManagerCn } from "../../../index.ts";
 
 // Define the variants for the body component
-const bodyVariants = cva("components font-body-fontFamily", {
-  variants: {
-    fontSize: {
-      sm: "text-sm",
-      base: "text-base",
-      lg: "text-lg",
+const bodyVariants = cva(
+  "components font-body-fontFamily font-body-fontWeight",
+  {
+    variants: {
+      variant: {
+        sm: "text-body-sm-fontSize",
+        base: "text-body-fontSize",
+        lg: "text-body-lg-fontSize",
+      },
     },
-    fontWeight: {
-      default: "font-body-fontWeight",
-      "100": "font-thin",
-      "200": "font-extralight",
-      "300": "font-light",
-      "400": "font-normal",
-      "500": "font-medium",
-      "600": "font-semibold",
-      "700": "font-bold",
-      "800": "font-extrabold",
-      "900": "font-black",
+    defaultVariants: {
+      variant: "base",
     },
-    textTransform: {
-      none: "",
-      uppercase: "uppercase",
-      lowercase: "lowercase",
-      capitalize: "capitalize",
-    },
-  },
-  defaultVariants: {
-    fontSize: "base",
-    fontWeight: "default",
-    textTransform: "none",
-  },
-});
+  }
+);
 
 // Omit 'color' from HTMLAttributes<HTMLParagraphElement> to avoid conflict
 export interface BodyProps
@@ -42,14 +25,12 @@ export interface BodyProps
     VariantProps<typeof bodyVariants> {}
 
 const Body = React.forwardRef<HTMLParagraphElement, BodyProps>(
-  ({ className, fontSize, fontWeight, textTransform, ...props }, ref) => {
+  ({ className, variant, ...props }, ref) => {
     return (
       <p
         className={themeManagerCn(
           bodyVariants({
-            fontSize,
-            fontWeight,
-            textTransform,
+            variant,
             className,
           }),
           className

--- a/packages/visual-editor/src/components/puck/atoms/button.tsx
+++ b/packages/visual-editor/src/components/puck/atoms/button.tsx
@@ -14,10 +14,10 @@ const buttonVariants = cva(
           "bg-button-backgroundColor text-button-textColor border-2 border-button-backgroundColor hover:border-button-textColor " +
           "focus:border-button-textColor active:bg-button-textColor active:text-button-backgroundColor active:border-button-backgroundColor text-button-fontSize",
         // TODO: Update to use styles set in the theme
-        seconday:
+        secondary:
           "bg-button-backgroundColor text-button-textColor border-2 border-button-backgroundColor hover:border-button-textColor " +
           "focus:border-button-textColor active:bg-button-textColor active:text-button-backgroundColor active:border-button-backgroundColor text-button-fontSize",
-        link: "text-link-color text-link-fontSize underline-offset-4 underline hover:no-underline",
+        link: "text-link-color text-body-fontSize underline-offset-4 underline hover:no-underline",
       },
       size: {
         small: "h-9 px-3",

--- a/packages/visual-editor/src/utils/themeConfigOptions.ts
+++ b/packages/visual-editor/src/utils/themeConfigOptions.ts
@@ -112,4 +112,8 @@ export const defaultThemeTailwindExtensions = {
       900: "#121212",
     },
   },
+  fontSize: {
+    "body-sm-fontSize": "calc(var(--fontSize-body-fontSize) - 2px)",
+    "body-lg-fontSize": "calc(var(--fontSize-body-fontSize) + 2px)",
+  },
 };

--- a/starter/theme.config.ts
+++ b/starter/theme.config.ts
@@ -338,13 +338,6 @@ export const themeConfig: ThemeConfig = {
         options: getColorOptions(),
         default: "var(--colors-palette-primary)",
       },
-      fontSize: {
-        label: "Font Size",
-        type: "select",
-        plugin: "fontSize",
-        options: getFontSizeOptions(false),
-        default: "12px",
-      },
     },
   },
   button: {


### PR DESCRIPTION
- Creates `text-body-sm-fontSize` and `text-body-lg-fontSize` classes based on the body font size set in theme editor.
- Updates the Body atom to use the Variant option (small, base, large)
- Updates components that use body text to use the variant in the Figma
- Drops link fontSize