### PR TITLE
feat: add additional result card data, and basic styling

### DIFF
--- a/starter/src/components/Locator.tsx
+++ b/starter/src/components/Locator.tsx
@@ -18,7 +18,7 @@ import { cva, VariantProps } from "class-variance-authority";
 import { BasicSelector, Button, themeManagerCn } from "@yext/visual-editor";
 import { normalizeSlug } from "@yext/visual-editor";
 import { useEffect, useState } from "react";
-import { HoursStatus } from "@yext/pages-components";
+import { HoursStatus, Link } from "@yext/pages-components";
 import { Address, Hours } from "../types/autogen.ts";
 
 const DEFAULT_FIELD = "builtin.location";
@@ -155,17 +155,17 @@ const LocationCard: CardComponent<Location> = ({
               hours={location.hours}
               timezone={location.timezone}
               className="text-sm"
-            ></HoursStatus>
+            />
           )}
           <div>
-            <a
+            <Link
               target={"_blank"}
               href={getPath(location)}
               className="text-sm py-1000 text-blue-700 cursor-pointer"
               rel="noreferrer"
             >
               <input type="submit" value="View More Information" />
-            </a>
+            </Link>
           </div>
           <div>
             {location.yextDisplayCoordinate && (

--- a/starter/src/components/Locator.tsx
+++ b/starter/src/components/Locator.tsx
@@ -12,34 +12,49 @@ import {
   useSearchState,
 } from "@yext/search-headless-react";
 import * as React from "react";
+import { cva, VariantProps } from "class-variance-authority";
+import { BasicSelector, themeManagerCn } from "@yext/visual-editor";
 
-type LocatorProps = {
-  fieldApiName: string;
-  entityType: string;
-};
+const DEFAULT_FIELD = "builtin.location";
+const DEFAULT_ENTITY_TYPE = "location";
 
-const fields: Fields<LocatorProps> = {
-  fieldApiName: {
-    label: "Field Name",
-    type: "text",
+const locatorVariants = cva("", {
+  variants: {
+    backgroundColor: {
+      default: "bg-locator-backgroundColor",
+      primary: "bg-palette-primary",
+      secondary: "bg-palette-secondary",
+      accent: "bg-palette-accent",
+      text: "bg-palette-text",
+      background: "bg-palette-background",
+    },
   },
-  entityType: {
-    label: "Entity Type",
-    type: "text",
+  defaultVariants: {
+    backgroundColor: "default",
   },
+});
+
+type LocatorProps = VariantProps<typeof locatorVariants>;
+
+const locatorFields: Fields<LocatorProps> = {
+  backgroundColor: BasicSelector("Background Color", [
+    { label: "Default", value: "default" },
+    { label: "Primary", value: "primary" },
+    { label: "Secondary", value: "secondary" },
+    { label: "Accent", value: "accent" },
+    { label: "Text", value: "text" },
+    { label: "Background", value: "background" },
+  ]),
 };
 
 const LocatorComponent: ComponentConfig<LocatorProps> = {
-  fields,
-  defaultProps: {
-    fieldApiName: "builtin.location",
-    entityType: "location",
-  },
+  fields: locatorFields,
   label: "Locator",
   render: (props) => <Locator {...props} />,
 };
 
-const Locator: React.FC<LocatorProps> = ({ fieldApiName, entityType }) => {
+const Locator: React.FC<LocatorProps> = (props) => {
+  const { backgroundColor } = props;
   const resultCount = useSearchState(
     (state) => state.vertical.resultsCount || 0,
   );
@@ -53,7 +68,7 @@ const Locator: React.FC<LocatorProps> = ({ fieldApiName, entityType }) => {
         kind: "fieldValue",
         fieldId: params.newFilter.fieldId,
         value: params.newFilter.value,
-        matcher: Matcher.Equals,
+        matcher: Matcher.Near,
       },
     };
     searchActions.setStaticFilters([locationFilter]);
@@ -65,13 +80,20 @@ const Locator: React.FC<LocatorProps> = ({ fieldApiName, entityType }) => {
   return (
     <>
       <FilterSearch
-        searchFields={[{ fieldApiName: fieldApiName, entityType: entityType }]}
+        searchFields={[
+          { fieldApiName: DEFAULT_FIELD, entityType: DEFAULT_ENTITY_TYPE },
+        ]}
         onSelect={(params) => handleFilterSelect(params)}
       />
       <div>
         {resultCount > 0 && <VerticalResults CardComponent={StandardCard} />}
         {resultCount === 0 && !searchLoading && (
-          <div className="flex items-center justify-center">
+          <div
+            className={themeManagerCn(
+              "flex items-center justify-center",
+              locatorVariants({ backgroundColor }),
+            )}
+          >
             <p className="pt-4 text-2xl">No results found for this area</p>
           </div>
         )}

--- a/starter/src/components/Locator.tsx
+++ b/starter/src/components/Locator.tsx
@@ -1,8 +1,10 @@
 import { ComponentConfig, Fields } from "@measured/puck";
 import {
+  CardComponent,
+  CardProps,
+  Coordinate,
   FilterSearch,
   OnSelectParams,
-  StandardCard,
   VerticalResults,
 } from "@yext/search-ui-react";
 import {
@@ -14,6 +16,8 @@ import {
 import * as React from "react";
 import { cva, VariantProps } from "class-variance-authority";
 import { BasicSelector, themeManagerCn } from "@yext/visual-editor";
+import { normalizeSlug } from "@yext/visual-editor";
+import { useEffect, useState } from "react";
 
 const DEFAULT_FIELD = "builtin.location";
 const DEFAULT_ENTITY_TYPE = "location";
@@ -53,6 +57,8 @@ const LocatorComponent: ComponentConfig<LocatorProps> = {
   render: (props) => <Locator {...props} />,
 };
 
+type SearchState = "not started" | "loading" | "complete";
+
 const Locator: React.FC<LocatorProps> = (props) => {
   const { backgroundColor } = props;
   const resultCount = useSearchState(
@@ -73,9 +79,17 @@ const Locator: React.FC<LocatorProps> = (props) => {
     };
     searchActions.setStaticFilters([locationFilter]);
     searchActions.executeVerticalQuery();
+    setSearchState("loading");
   };
 
   const searchLoading = useSearchState((state) => state.searchStatus.isLoading);
+  const [searchState, setSearchState] = useState<SearchState>("not started");
+
+  useEffect(() => {
+    if (!searchLoading && searchState === "loading") {
+      setSearchState("complete");
+    }
+  }, [searchLoading]);
 
   return (
     <>
@@ -86,8 +100,8 @@ const Locator: React.FC<LocatorProps> = (props) => {
         onSelect={(params) => handleFilterSelect(params)}
       />
       <div>
-        {resultCount > 0 && <VerticalResults CardComponent={StandardCard} />}
-        {resultCount === 0 && !searchLoading && (
+        {resultCount > 0 && <VerticalResults CardComponent={LocationCard} />}
+        {resultCount === 0 && searchState === "complete" && (
           <div
             className={themeManagerCn(
               "flex items-center justify-center",
@@ -101,5 +115,208 @@ const Locator: React.FC<LocatorProps> = (props) => {
     </>
   );
 };
+
+const LocationCard: CardComponent<Location> = ({
+  result,
+}: CardProps<Location>): React.JSX.Element => {
+  const location = result.rawData;
+  const distance = result.distance;
+
+  // function that takes coordinates and returns a google maps link for directions
+  const getGoogleMapsLink = (coordinate: Coordinate): string => {
+    return `https://www.google.com/maps/dir/?api=1&destination=${coordinate.latitude},${coordinate.longitude}`;
+  };
+
+  const distanceInMiles = distance
+    ? (distance / 1609.344).toFixed(1)
+    : undefined;
+
+  return (
+    <div className="flex justify left border-y p-50">
+      <div className="flex p-2.5">
+        <div>
+          <p className="text-lg py-2 text-rose-500">{location.name}</p>
+          <p className="text-sm">{location.address.line1}</p>
+          <p className="text-sm">{`${location.address.city}, ${location.address.region} ${location.address.postalCode}`}</p>
+          {location.mainPhone && (
+            <a
+              target={"_blank"}
+              href={`tel:${location.mainPhone}`}
+              className="text-sm py-5"
+              rel="noreferrer"
+            >
+              {formatPhoneNumber(location.mainPhone)}
+            </a>
+          )}
+          {location.hours && <p className="text-lg">Hours:</p>}
+          {location.hours && (
+            <ul>
+              {location.hours.monday && (
+                <li className="text-xs" key="monday">
+                  {HoursText("Monday", location.hours.monday)}
+                </li>
+              )}
+              {location.hours.tuesday && (
+                <li className="text-xs" key="tuesday">
+                  {HoursText("Tuesday", location.hours.tuesday)}
+                </li>
+              )}
+              {location.hours.wednesday && (
+                <li className="text-xs" key="wednesday">
+                  {HoursText("Wednesday", location.hours.wednesday)}
+                </li>
+              )}
+              {location.hours.thursday && (
+                <li className="text-xs" key="thursday">
+                  {HoursText("Thursday", location.hours.thursday)}
+                </li>
+              )}
+              {location.hours.friday && (
+                <li className="text-xs" key="friday">
+                  {HoursText("Friday", location.hours.friday)}
+                </li>
+              )}
+              {location.hours.saturday && (
+                <li className="text-xs" key="saturday">
+                  {HoursText("Saturday", location.hours.saturday)}
+                </li>
+              )}
+              {location.hours.sunday && (
+                <li className="text-xs" key="sunday">
+                  {HoursText("Sunday", location.hours.sunday)}
+                </li>
+              )}
+            </ul>
+          )}
+          <div>
+            <a
+              target={"_blank"}
+              href={getPath(location)}
+              className="text-sm py-1000 text-blue-700 cursor-pointer"
+              rel="noreferrer"
+            >
+              <input type="submit" value="View More Information" />
+            </a>
+          </div>
+          <div>
+            {location.yextDisplayCoordinate && (
+              <button
+                onClick={() =>
+                  window.open(
+                    getGoogleMapsLink(
+                      location.yextDisplayCoordinate
+                        ? location.yextDisplayCoordinate
+                        : {
+                            latitude: 0,
+                            longitude: 0,
+                          },
+                    ),
+                    "_blank",
+                  )
+                }
+                className="flex flex-col text-sm py-3 bg-rose-500 text-stone-50 rounded-lg drop-shadow-md"
+              >
+                Get Directions
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+      {distanceInMiles && (
+        <div className="flex items-start p-5 italic">
+          {distanceInMiles + " mi"}
+        </div>
+      )}
+    </div>
+  );
+};
+
+//reformats a phone number in the familiar (123)-456-7890 style
+function formatPhoneNumber(phoneNumber: string) {
+  const cleaned = ("" + phoneNumber).replace(/\D/g, "");
+  const match = cleaned.match(/^(1|)?(\d{3})(\d{3})(\d{4})$/);
+  if (match) {
+    const intlCode = match[1] ? "+1 " : "";
+    return [intlCode, "(", match[2], ") ", match[3], "-", match[4]].join("");
+  }
+  return null;
+}
+
+const HoursText = (dayOfWeek: string, hours: DayHour) => {
+  return hours.isClosed ? (
+    <p>{dayOfWeek}: Closed</p>
+  ) : (
+    dayOfWeek +
+      ": " +
+      hours.openIntervals?.map((i) => i.start + "-" + i.end).join(", ")
+  );
+};
+
+const getPath = (location: Location) => {
+  if (location.slug) {
+    return location.slug;
+  }
+
+  // TODO: in the same way that locale is hardcoded to 'en' in dev.tsx we may need to eventually have the
+  // right language populated here.
+  const localePath = "en";
+  const path = location.address
+    ? `${localePath}${location.address.region}/${location.address.city}/${location.address.line1}`
+    : `${localePath}${location.id}`;
+
+  return normalizeSlug(path);
+};
+
+export interface Interval {
+  start?: any;
+  end?: any;
+}
+
+export interface DayHour {
+  openIntervals?: Interval[];
+  isClosed?: boolean;
+}
+
+export interface HolidayHours {
+  date: string;
+  openIntervals?: Interval[];
+  isClosed?: boolean;
+  isRegularHours?: boolean;
+}
+
+export interface Hours {
+  monday?: DayHour;
+  tuesday?: DayHour;
+  wednesday?: DayHour;
+  thursday?: DayHour;
+  friday?: DayHour;
+  saturday?: DayHour;
+  sunday?: DayHour;
+  holidayHours?: HolidayHours[];
+  reopenDate?: string;
+}
+
+interface Address {
+  line1?: string;
+  line2?: string;
+  line3?: string;
+  sublocality?: string;
+  city?: string;
+  region?: string;
+  postalCode?: string;
+  extraDescription?: string;
+  countryCode?: string;
+}
+
+interface Location {
+  address: Address;
+  hours?: Hours;
+  id: string;
+  mainPhone?: string;
+  name: string;
+  neighborhood?: string;
+  slug?: string;
+  yextDisplayCoordinate?: Coordinate;
+}
 
 export { type LocatorProps, LocatorComponent as Locator };

--- a/starter/src/components/Locator.tsx
+++ b/starter/src/components/Locator.tsx
@@ -15,9 +15,11 @@ import {
 } from "@yext/search-headless-react";
 import * as React from "react";
 import { cva, VariantProps } from "class-variance-authority";
-import { BasicSelector, themeManagerCn } from "@yext/visual-editor";
+import { BasicSelector, Button, themeManagerCn } from "@yext/visual-editor";
 import { normalizeSlug } from "@yext/visual-editor";
 import { useEffect, useState } from "react";
+import { HoursStatus } from "@yext/pages-components";
+import { Address, Hours } from "../types/autogen.ts";
 
 const DEFAULT_FIELD = "builtin.location";
 const DEFAULT_ENTITY_TYPE = "location";
@@ -148,45 +150,12 @@ const LocationCard: CardComponent<Location> = ({
               {formatPhoneNumber(location.mainPhone)}
             </a>
           )}
-          {location.hours && <p className="text-lg">Hours:</p>}
           {location.hours && (
-            <ul>
-              {location.hours.monday && (
-                <li className="text-xs" key="monday">
-                  {HoursText("Monday", location.hours.monday)}
-                </li>
-              )}
-              {location.hours.tuesday && (
-                <li className="text-xs" key="tuesday">
-                  {HoursText("Tuesday", location.hours.tuesday)}
-                </li>
-              )}
-              {location.hours.wednesday && (
-                <li className="text-xs" key="wednesday">
-                  {HoursText("Wednesday", location.hours.wednesday)}
-                </li>
-              )}
-              {location.hours.thursday && (
-                <li className="text-xs" key="thursday">
-                  {HoursText("Thursday", location.hours.thursday)}
-                </li>
-              )}
-              {location.hours.friday && (
-                <li className="text-xs" key="friday">
-                  {HoursText("Friday", location.hours.friday)}
-                </li>
-              )}
-              {location.hours.saturday && (
-                <li className="text-xs" key="saturday">
-                  {HoursText("Saturday", location.hours.saturday)}
-                </li>
-              )}
-              {location.hours.sunday && (
-                <li className="text-xs" key="sunday">
-                  {HoursText("Sunday", location.hours.sunday)}
-                </li>
-              )}
-            </ul>
+            <HoursStatus
+              hours={location.hours}
+              timezone={location.timezone}
+              className="text-sm"
+            ></HoursStatus>
           )}
           <div>
             <a
@@ -200,7 +169,7 @@ const LocationCard: CardComponent<Location> = ({
           </div>
           <div>
             {location.yextDisplayCoordinate && (
-              <button
+              <Button
                 onClick={() =>
                   window.open(
                     getGoogleMapsLink(
@@ -217,7 +186,7 @@ const LocationCard: CardComponent<Location> = ({
                 className="flex flex-col text-sm py-3 bg-rose-500 text-stone-50 rounded-lg drop-shadow-md"
               >
                 Get Directions
-              </button>
+              </Button>
             )}
           </div>
         </div>
@@ -242,16 +211,6 @@ function formatPhoneNumber(phoneNumber: string) {
   return null;
 }
 
-const HoursText = (dayOfWeek: string, hours: DayHour) => {
-  return hours.isClosed ? (
-    <p>{dayOfWeek}: Closed</p>
-  ) : (
-    dayOfWeek +
-      ": " +
-      hours.openIntervals?.map((i) => i.start + "-" + i.end).join(", ")
-  );
-};
-
 const getPath = (location: Location) => {
   if (location.slug) {
     return location.slug;
@@ -267,47 +226,6 @@ const getPath = (location: Location) => {
   return normalizeSlug(path);
 };
 
-export interface Interval {
-  start?: any;
-  end?: any;
-}
-
-export interface DayHour {
-  openIntervals?: Interval[];
-  isClosed?: boolean;
-}
-
-export interface HolidayHours {
-  date: string;
-  openIntervals?: Interval[];
-  isClosed?: boolean;
-  isRegularHours?: boolean;
-}
-
-export interface Hours {
-  monday?: DayHour;
-  tuesday?: DayHour;
-  wednesday?: DayHour;
-  thursday?: DayHour;
-  friday?: DayHour;
-  saturday?: DayHour;
-  sunday?: DayHour;
-  holidayHours?: HolidayHours[];
-  reopenDate?: string;
-}
-
-interface Address {
-  line1?: string;
-  line2?: string;
-  line3?: string;
-  sublocality?: string;
-  city?: string;
-  region?: string;
-  postalCode?: string;
-  extraDescription?: string;
-  countryCode?: string;
-}
-
 interface Location {
   address: Address;
   hours?: Hours;
@@ -316,6 +234,7 @@ interface Location {
   name: string;
   neighborhood?: string;
   slug?: string;
+  timezone: string;
   yextDisplayCoordinate?: Coordinate;
 }
 

--- a/starter/src/components/Locator.tsx
+++ b/starter/src/components/Locator.tsx
@@ -141,14 +141,14 @@ const LocationCard: CardComponent<Location> = ({
           <p className="text-sm">{location.address.line1}</p>
           <p className="text-sm">{`${location.address.city}, ${location.address.region} ${location.address.postalCode}`}</p>
           {location.mainPhone && (
-            <a
+            <Link
               target={"_blank"}
               href={`tel:${location.mainPhone}`}
               className="text-sm py-5"
               rel="noreferrer"
             >
               {formatPhoneNumber(location.mainPhone)}
-            </a>
+            </Link>
           )}
           {location.hours && (
             <HoursStatus
@@ -218,10 +218,9 @@ const getPath = (location: Location) => {
 
   // TODO: in the same way that locale is hardcoded to 'en' in dev.tsx we may need to eventually have the
   // right language populated here.
-  const localePath = "en";
   const path = location.address
-    ? `${localePath}${location.address.region}/${location.address.city}/${location.address.line1}`
-    : `${localePath}${location.id}`;
+    ? `${location.address.region}/${location.address.city}/${location.address.line1}`
+    : `${location.id}`;
 
   return normalizeSlug(path);
 };

--- a/starter/src/components/Locator.tsx
+++ b/starter/src/components/Locator.tsx
@@ -1,22 +1,30 @@
 import { ComponentConfig, Fields } from "@measured/puck";
-import { FilterSearch } from "@yext/search-ui-react";
 import {
-  CloudChoice,
-  CloudRegion,
-  Environment,
-  provideHeadless,
-  SearchHeadlessProvider,
+  FilterSearch,
+  OnSelectParams,
+  StandardCard,
+  VerticalResults,
+} from "@yext/search-ui-react";
+import {
+  Matcher,
+  SelectableStaticFilter,
+  useSearchActions,
+  useSearchState,
 } from "@yext/search-headless-react";
 import * as React from "react";
-import { useDocument } from "@yext/visual-editor";
 
 type LocatorProps = {
-  apiKey: string;
+  fieldApiName: string;
+  entityType: string;
 };
 
 const fields: Fields<LocatorProps> = {
-  apiKey: {
-    label: "API Key",
+  fieldApiName: {
+    label: "Field Name",
+    type: "text",
+  },
+  entityType: {
+    label: "Entity Type",
     type: "text",
   },
 };
@@ -24,36 +32,51 @@ const fields: Fields<LocatorProps> = {
 const LocatorComponent: ComponentConfig<LocatorProps> = {
   fields,
   defaultProps: {
-    apiKey: "Fake Key",
+    fieldApiName: "builtin.location",
+    entityType: "location",
   },
   label: "Locator",
   render: (props) => <Locator {...props} />,
 };
 
-const Locator: React.FC<LocatorProps> = ({ apiKey }) => {
-  const document: {
-    businessId: number;
-  } = useDocument();
-  const config = {
-    apiKey,
-    experienceKey: "jacob-test",
-    locale: "en",
-    experienceVersion: "STAGING",
-    businessId: document.businessId,
-    cloudRegion: CloudRegion.US,
-    cloudChoice: CloudChoice.GLOBAL_MULTI,
-    environment: Environment.PROD,
+const Locator: React.FC<LocatorProps> = ({ fieldApiName, entityType }) => {
+  const resultCount = useSearchState(
+    (state) => state.vertical.resultsCount || 0,
+  );
+
+  const searchActions = useSearchActions();
+  const handleFilterSelect = (params: OnSelectParams) => {
+    const locationFilter: SelectableStaticFilter = {
+      displayName: params.newDisplayName,
+      selected: true,
+      filter: {
+        kind: "fieldValue",
+        fieldId: params.newFilter.fieldId,
+        value: params.newFilter.value,
+        matcher: Matcher.Equals,
+      },
+    };
+    searchActions.setStaticFilters([locationFilter]);
+    searchActions.executeVerticalQuery();
   };
-  const searcher = provideHeadless(config);
-  searcher.setVertical("locations");
+
+  const searchLoading = useSearchState((state) => state.searchStatus.isLoading);
+
   return (
-    <SearchHeadlessProvider searcher={searcher}>
+    <>
       <FilterSearch
-        searchFields={[
-          { fieldApiName: "builtin.location", entityType: "location" },
-        ]}
-      ></FilterSearch>
-    </SearchHeadlessProvider>
+        searchFields={[{ fieldApiName: fieldApiName, entityType: entityType }]}
+        onSelect={(params) => handleFilterSelect(params)}
+      />
+      <div>
+        {resultCount > 0 && <VerticalResults CardComponent={StandardCard} />}
+        {resultCount === 0 && !searchLoading && (
+          <div className="flex items-center justify-center">
+            <p className="pt-4 text-2xl">No results found for this area</p>
+          </div>
+        )}
+      </div>
+    </>
   );
 };
 

--- a/starter/src/templates/dev.tsx
+++ b/starter/src/templates/dev.tsx
@@ -114,7 +114,7 @@ const Dev: Template<TemplateRenderProps> = (props) => {
   const entityFields = devTemplateStream.stream.schema
     .fields as unknown as YextSchemaField[];
   const config = {
-    apiKey: "722d20ad53157666ea2df0d3831433c2",
+    apiKey: "",
     experienceKey: "jacob-test",
     locale: "en",
     experienceVersion: "STAGING",

--- a/starter/src/templates/dev.tsx
+++ b/starter/src/templates/dev.tsx
@@ -125,6 +125,7 @@ const Dev: Template<TemplateRenderProps> = (props) => {
     environment: Environment.PROD,
   };
   const searcher = provideHeadless(config);
+
   return (
     <div>
       <div className={"flex-container"}>

--- a/starter/src/templates/dev.tsx
+++ b/starter/src/templates/dev.tsx
@@ -20,6 +20,13 @@ import { buildSchema } from "../utils/buildSchema.ts";
 import tailwindConfig from "../../tailwind.config";
 import { devTemplateStream } from "../dev.config";
 import React from "react";
+import {
+  CloudChoice,
+  CloudRegion,
+  Environment,
+  provideHeadless,
+  SearchHeadlessProvider,
+} from "@yext/search-headless-react";
 
 export const config = {
   name: "dev-location",
@@ -106,7 +113,18 @@ const Dev: Template<TemplateRenderProps> = (props) => {
   const { document } = props;
   const entityFields = devTemplateStream.stream.schema
     .fields as unknown as YextSchemaField[];
-
+  const config = {
+    apiKey: "722d20ad53157666ea2df0d3831433c2",
+    experienceKey: "jacob-test",
+    locale: "en",
+    experienceVersion: "STAGING",
+    verticalKey: "locations",
+    businessId: document.businessId,
+    cloudRegion: CloudRegion.US,
+    cloudChoice: CloudChoice.GLOBAL_MULTI,
+    environment: Environment.PROD,
+  };
+  const searcher = provideHeadless(config);
   return (
     <div>
       <div className={"flex-container"}>
@@ -120,19 +138,21 @@ const Dev: Template<TemplateRenderProps> = (props) => {
         </button>
       </div>
       <div>
-        <VisualEditorProvider
-          templateProps={props}
-          entityFields={entityFields}
-          tailwindConfig={tailwindConfig}
-        >
-          <Editor
-            document={document}
-            componentRegistry={componentRegistry}
-            themeConfig={themeConfig}
-            localDev={true}
-            forceThemeMode={themeMode}
-          />
-        </VisualEditorProvider>
+        <SearchHeadlessProvider searcher={searcher}>
+          <VisualEditorProvider
+            templateProps={props}
+            entityFields={entityFields}
+            tailwindConfig={tailwindConfig}
+          >
+            <Editor
+              document={document}
+              componentRegistry={componentRegistry}
+              themeConfig={themeConfig}
+              localDev={true}
+              forceThemeMode={themeMode}
+            />
+          </VisualEditorProvider>
+        </SearchHeadlessProvider>
       </div>
     </div>
   );


### PR DESCRIPTION
This PR adds a little more styling to the result cards.
It also builds out a variety of information, including:
- name
- address
- basic hours
- distance
- phone number
- slug link
- map link

Some changes will follow - the hours display will use a
forthcoming display util to be added to search-ui-react, and
a later change will pass down styling from the VLE in general
J=WAT-4699
TEST=manual

![Screenshot 2025-03-27 at 4 34 25 PM](https://github.com/user-attachments/assets/ba81bcb3-2c3e-4b4d-a2dd-013a4385bfee)
