### PR TITLE
feat: update grid component

### DIFF
--- a/packages/visual-editor/src/components/editor/SpacingSelector.tsx
+++ b/packages/visual-editor/src/components/editor/SpacingSelector.tsx
@@ -71,7 +71,7 @@ const convertDefaultSpacingsToOptions = (
     );
     const spacingPx = customSpacing ? customSpacing.toString() : option.px;
     return {
-      label: option.label + (option.px ? ` (${spacingPx}px)` : ""),
+      label: option.px ? `${spacingPx}px` : option.label,
       value: option.value,
     };
   });

--- a/packages/visual-editor/src/components/puck/Directory.tsx
+++ b/packages/visual-editor/src/components/puck/Directory.tsx
@@ -82,7 +82,7 @@ const DirectoryGrid = ({
       className={themeManagerCn(
         layoutVariants({
           verticalPadding: "default",
-          horizontalPadding: "default",
+          horizontalPadding: "0",
         })
       )}
       background={backgroundColors.background1.value}

--- a/packages/visual-editor/src/components/puck/Flex.tsx
+++ b/packages/visual-editor/src/components/puck/Flex.tsx
@@ -96,7 +96,7 @@ const FlexContainerComponent: ComponentConfig<FlexProps> = {
     wrap: "nowrap",
     gap: "0",
     verticalPadding: "default",
-    horizontalPadding: "default",
+    horizontalPadding: "0",
     backgroundColor: backgroundColors.background1.value,
   },
   resolveFields: (data, params) => {
@@ -106,7 +106,6 @@ const FlexContainerComponent: ComponentConfig<FlexProps> = {
       // the props values should only be changed initially
       if (!data.props.maxContentWidth) {
         data.props.verticalPadding = "0";
-        data.props.horizontalPadding = "0";
         data.props.gap = "0";
         data.props.maxContentWidth = "none";
       }

--- a/packages/visual-editor/src/components/puck/Grid.tsx
+++ b/packages/visual-editor/src/components/puck/Grid.tsx
@@ -82,7 +82,7 @@ const GridSectionComponent: ComponentConfig<GridProps> = {
     columns: 2,
     gap: "0",
     verticalPadding: "default",
-    horizontalPadding: "default",
+    horizontalPadding: "0",
     backgroundColor: backgroundColors.background1.value,
     columnFormatting: "default",
   },
@@ -92,7 +92,6 @@ const GridSectionComponent: ComponentConfig<GridProps> = {
     if (params.parent) {
       // the props values should only be changed initially
       data.props.verticalPadding = "0";
-      data.props.horizontalPadding = "0";
       data.props.gap = "0";
       data.props.columnFormatting = "forceHorizontal";
       return gridSectionFields;

--- a/packages/visual-editor/src/components/puck/Grid.tsx
+++ b/packages/visual-editor/src/components/puck/Grid.tsx
@@ -2,20 +2,15 @@ import * as React from "react";
 import { type VariantProps } from "class-variance-authority";
 import { ComponentConfig, DropZone, Fields } from "@measured/puck";
 import { Section } from "./atoms/section.js";
-import { themeManagerCn, BasicSelector } from "../../index.js";
+import { themeManagerCn } from "../../index.js";
 import { innerLayoutVariants, layoutVariants } from "./Layout.tsx";
 import { layoutFields } from "./Layout.tsx";
-
-interface ColumnProps {
-  justifyContent: "center" | "start" | "end" | "spaceBetween";
-  span?: number;
-}
 
 interface GridProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof layoutVariants>,
     VariantProps<typeof innerLayoutVariants> {
-  columns: ColumnProps[];
+  columns: number;
 }
 
 const GridSection = React.forwardRef<HTMLDivElement, GridProps>(
@@ -26,8 +21,8 @@ const GridSection = React.forwardRef<HTMLDivElement, GridProps>(
       gap,
       verticalPadding,
       horizontalPadding,
-      maxContentWidth,
       backgroundColor,
+      columnFormatting,
       ...props
     },
     ref
@@ -46,30 +41,20 @@ const GridSection = React.forwardRef<HTMLDivElement, GridProps>(
       >
         <div
           className={themeManagerCn(
-            layoutVariants({ gap }),
-            innerLayoutVariants({ maxContentWidth }),
-            "flex flex-col md:grid md:grid-cols-12",
+            layoutVariants({ gap, columnFormatting }),
+            "flex flex-col min-h-0 min-w-0 mx-auto max-w-pageSection-contentWidth",
             className
           )}
           ref={ref}
           style={{
-            gridTemplateColumns: `repeat(${columns.length}, 1fr)`,
+            gridTemplateColumns: `repeat(${columns}, 1fr)`,
           }}
           {...props}
         >
-          {columns.map(({ span, justifyContent }, idx) => (
-            <div
-              className="w-full"
-              key={idx}
-              style={{
-                gridColumn: span,
-              }}
-            >
+          {Array.from({ length: columns }).map((_, idx) => (
+            <div className="w-full" key={idx}>
               <DropZone
                 className="flex flex-col w-full"
-                style={{
-                  justifyContent,
-                }}
                 zone={`column-${idx}`}
                 disallow={["Banner"]}
               />
@@ -85,25 +70,10 @@ GridSection.displayName = "GridSection";
 
 const gridSectionFields: Fields<GridProps> = {
   columns: {
-    type: "array",
-    getItemSummary: (col, id) =>
-      `Column ${(id ?? 0) + 1}, span ${
-        col.span ? Math.max(Math.min(col.span, 12), 1) : "auto"
-      }`,
-    arrayFields: {
-      span: {
-        label: "Span (1-12)",
-        type: "number",
-        min: 0,
-        max: 12,
-      },
-      justifyContent: BasicSelector("Vertical Alignment", [
-        { value: "start", label: "Start" },
-        { value: "center", label: "Center" },
-        { value: "end", label: "End" },
-        { value: "spaceBetween", label: "Space Between" },
-      ]),
-    },
+    type: "number",
+    label: "Columns",
+    min: 1,
+    max: 12,
   },
   ...layoutFields,
 };
@@ -112,62 +82,45 @@ const GridSectionComponent: ComponentConfig<GridProps> = {
   label: "Grid",
   fields: gridSectionFields,
   defaultProps: {
-    columns: [
-      {
-        justifyContent: "start",
-      },
-      {
-        justifyContent: "start",
-      },
-    ],
+    columns: 2,
     gap: "0",
     verticalPadding: "default",
     horizontalPadding: "default",
     backgroundColor: "none",
+    columnFormatting: "default",
   },
-  resolveFields: (data, params) => {
+  resolveFields: (data: { props: GridProps }, params: { parent: any }) => {
     // If the Grid has a parent component, the defaultProps should
-    // be adjusted and maxContentWidth should not be a field.
+    // be adjusted.
     if (params.parent) {
       // the props values should only be changed initially
-      if (!data.props.maxContentWidth) {
-        data.props.verticalPadding = "0";
-        data.props.horizontalPadding = "0";
-        data.props.gap = "0";
-        data.props.backgroundColor = "inherit";
-        data.props.maxContentWidth = "none";
-      }
+      data.props.verticalPadding = "0";
+      data.props.horizontalPadding = "0";
+      data.props.gap = "0";
+      data.props.backgroundColor = "inherit";
+      data.props.columnFormatting = "forceHorizontal";
       return gridSectionFields;
     }
 
-    if (!data.props.maxContentWidth) {
-      data.props.maxContentWidth = "default";
-    }
     return {
       ...gridSectionFields,
-      maxContentWidth: BasicSelector("Maximum Content Width", [
-        { value: "default", label: "Default" },
-        { value: "lg", label: "LG (1024px)" },
-        { value: "xl", label: "XL (1280px)" },
-        { value: "xxl", label: "2XL (1536px)" },
-      ]),
     };
   },
   render: ({
     columns,
     backgroundColor,
-    maxContentWidth,
     gap,
     verticalPadding,
     horizontalPadding,
-  }) => (
+    columnFormatting,
+  }: GridProps) => (
     <GridSection
       columns={columns}
       backgroundColor={backgroundColor}
-      maxContentWidth={maxContentWidth}
       gap={gap}
       verticalPadding={verticalPadding}
       horizontalPadding={horizontalPadding}
+      columnFormatting={columnFormatting}
     />
   ),
 };

--- a/packages/visual-editor/src/components/puck/Grid.tsx
+++ b/packages/visual-editor/src/components/puck/Grid.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { ComponentConfig, DropZone, Fields } from "@measured/puck";
 import { Section } from "./atoms/section.js";
 import { themeManagerCn } from "../../index.js";
-import { innerLayoutVariants, layoutVariants } from "./Layout.tsx";
+import { layoutVariants } from "./Layout.tsx";
 import { layoutFields, layoutProps } from "./Layout.tsx";
 import { backgroundColors } from "../../utils/themeConfigOptions.ts";
 

--- a/packages/visual-editor/src/components/puck/Layout.tsx
+++ b/packages/visual-editor/src/components/puck/Layout.tsx
@@ -59,7 +59,6 @@ export const layoutVariants = cva("components w-full", {
     },
     horizontalPadding: {
       none: "",
-      default: "px-pageSection-horizontalPadding",
       "0": "px-0",
       "0.5": "px-0.5",
       "1": "px-1",

--- a/packages/visual-editor/src/components/puck/Layout.tsx
+++ b/packages/visual-editor/src/components/puck/Layout.tsx
@@ -87,12 +87,18 @@ export const layoutVariants = cva("components w-full", {
       background: "bg-palette-background",
       inherit: "bg-inherit",
     },
+    columnFormatting: {
+      none: "",
+      default: "md:grid md:grid-cols-12",
+      forceHorizontal: "!grid grid-cols-12",
+    },
   },
   defaultVariants: {
     gap: "none",
     verticalPadding: "none",
     horizontalPadding: "none",
     backgroundColor: "none",
+    columnFormatting: "none",
   },
 });
 
@@ -121,6 +127,7 @@ interface layoutProps
 
 export const layoutFields: Fields<layoutProps> = {
   backgroundColor: BasicSelector("Background Color", [
+    // TODO: Replace with new color selector dropdown
     { label: "Default", value: "default" },
     { label: "Primary", value: "primary" },
     { label: "Secondary", value: "secondary" },
@@ -129,6 +136,6 @@ export const layoutFields: Fields<layoutProps> = {
     { label: "Background", value: "background" },
   ]),
   gap: SpacingSelector("gap", "Gap"),
-  verticalPadding: SpacingSelector("padding", "Vertical Padding"),
-  horizontalPadding: SpacingSelector("padding", "Horizontal Padding"),
+  verticalPadding: SpacingSelector("padding", "Top/Bottom Padding"),
+  horizontalPadding: SpacingSelector("padding", "Left/Right Padding"),
 };

--- a/starter/theme.config.ts
+++ b/starter/theme.config.ts
@@ -260,15 +260,8 @@ export const themeConfig: ThemeConfig = {
         ],
         default: "1024px",
       },
-      topPadding: {
-        label: "Top Padding",
-        type: "select",
-        plugin: "padding",
-        options: getSpacingOptions(),
-        default: "0px",
-      },
-      bottomPadding: {
-        label: "Bottom Padding",
+      verticalPadding: {
+        label: "Top/Bottom Padding",
         type: "select",
         plugin: "padding",
         options: getSpacingOptions(),


### PR DESCRIPTION
This removes the Maximum Content Width option from the Grid component, and simplifies the behavior of columns. The column field is now a basic number field, and columns wrap to rows on small screen sizes if the Grid is at the top level of the layout, but are fixed to a horizontal alignment at all times if the Grid is at a lower level. This also renames the padding fields and shows the raw px values for spacing rather than the more complicated "[number] ([pixel_value]px)" format.

This screenshot shows two Grids containing CTA buttons on a small mobile screen. The top grid is at the top level of the layout, so it wraps into one column with multiple rows. The bottom grid is within another grid, so the buttons are always horizontally aligned into columns.

<img width="994" alt="Screenshot 2025-03-26 at 11 51 35 AM" src="https://github.com/user-attachments/assets/dd5f4570-2bb4-4c9e-9f72-58e1094e4d6a" />
