### PR TITLE
fix: export heading options

### DIFF
--- a/packages/visual-editor/src/components/puck/Card.tsx
+++ b/packages/visual-editor/src/components/puck/Card.tsx
@@ -12,21 +12,15 @@ import {
   BasicSelector,
   BodyProps,
   getFontWeightOverrideOptions,
+  backgroundColors,
+  BackgroundStyle,
+  headingLevelOptions,
 } from "../../index.js";
 import { Body } from "./atoms/body.js";
 import { CTA, CTAProps, linkTypeFields } from "./atoms/cta.js";
-import {
-  Heading,
-  HeadingProps,
-  HeadingLevel,
-  headingOptions,
-} from "./atoms/heading.js";
+import { Heading, HeadingProps, HeadingLevel } from "./atoms/heading.js";
 import { Section } from "./atoms/section.js";
 import { imageWrapperVariants, ImageWrapperProps } from "./Image.js";
-import {
-  backgroundColors,
-  BackgroundStyle,
-} from "../../utils/themeConfigOptions.js";
 
 const PLACEHOLDER_IMAGE_URL = "https://placehold.co/640x360";
 
@@ -90,7 +84,7 @@ const cardFields: Fields<CardProps> = {
         { value: "uppercase", label: "Uppercase" },
         { value: "capitalize", label: "Capitalize" },
       ]),
-      level: BasicSelector("Level", headingOptions),
+      level: BasicSelector("Level", headingLevelOptions),
     },
   },
   subheading: {
@@ -111,7 +105,7 @@ const cardFields: Fields<CardProps> = {
         { value: "uppercase", label: "Uppercase" },
         { value: "capitalize", label: "Capitalize" },
       ]),
-      level: BasicSelector("Level", headingOptions),
+      level: BasicSelector("Level", headingLevelOptions),
     },
   },
   body: {

--- a/packages/visual-editor/src/components/puck/Card.tsx
+++ b/packages/visual-editor/src/components/puck/Card.tsx
@@ -15,10 +15,11 @@ import {
   backgroundColors,
   BackgroundStyle,
   headingLevelOptions,
+  HeadingLevel,
 } from "../../index.js";
 import { Body } from "./atoms/body.js";
 import { CTA, CTAProps, linkTypeFields } from "./atoms/cta.js";
-import { Heading, HeadingProps, HeadingLevel } from "./atoms/heading.js";
+import { Heading, HeadingProps } from "./atoms/heading.js";
 import { Section } from "./atoms/section.js";
 import { imageWrapperVariants, ImageWrapperProps } from "./Image.js";
 

--- a/packages/visual-editor/src/components/puck/Directory.tsx
+++ b/packages/visual-editor/src/components/puck/Directory.tsx
@@ -1,11 +1,14 @@
-import { useTemplateProps, themeManagerCn } from "../../index.js";
+import {
+  useTemplateProps,
+  themeManagerCn,
+  backgroundColors,
+} from "../../index.js";
 import { BreadcrumbsComponent } from "./Breadcrumbs.tsx";
 import { ComponentConfig } from "@measured/puck";
 import { MaybeLink } from "./atoms/maybeLink.tsx";
 import { Address, HoursStatus } from "@yext/pages-components";
 import { innerLayoutVariants, layoutVariants } from "./Layout.tsx";
 import { Section } from "./atoms/section.tsx";
-import { backgroundColors } from "../../utils/themeConfigOptions.ts";
 
 // isDirectoryGrid indicates whether the children should appear in
 // DirectoryGrid or DirectoryList dependent on the dm_directoryChildren type.

--- a/packages/visual-editor/src/components/puck/Flex.tsx
+++ b/packages/visual-editor/src/components/puck/Flex.tsx
@@ -1,15 +1,17 @@
 import * as React from "react";
 import { ComponentConfig, DropZone, Fields } from "@measured/puck";
 import { Section } from "./atoms/section.js";
-import { themeManagerCn } from "../../utils/cn.js";
 import {
   innerLayoutVariants,
   layoutFields,
   layoutProps,
   layoutVariants,
 } from "./Layout.tsx";
-import { BasicSelector } from "../../index.js";
-import { backgroundColors } from "../../utils/themeConfigOptions.ts";
+import {
+  BasicSelector,
+  backgroundColors,
+  themeManagerCn,
+} from "../../index.js";
 
 interface FlexProps extends layoutProps {
   justifyContent: "start" | "center" | "end";

--- a/packages/visual-editor/src/components/puck/Footer.tsx
+++ b/packages/visual-editor/src/components/puck/Footer.tsx
@@ -7,6 +7,8 @@ import {
   themeManagerCn,
   useDocument,
   BasicSelector,
+  type BackgroundStyle,
+  backgroundColors,
 } from "../../index.ts";
 import {
   FaFacebook,
@@ -17,10 +19,6 @@ import {
   FaTwitter,
   FaYoutube,
 } from "react-icons/fa";
-import {
-  type BackgroundStyle,
-  backgroundColors,
-} from "../../utils/themeConfigOptions.ts";
 
 type socialLink = {
   name: string;

--- a/packages/visual-editor/src/components/puck/Grid.tsx
+++ b/packages/visual-editor/src/components/puck/Grid.tsx
@@ -1,10 +1,13 @@
 import * as React from "react";
 import { ComponentConfig, DropZone, Fields } from "@measured/puck";
 import { Section } from "./atoms/section.js";
-import { themeManagerCn, BasicSelector } from "../../index.js";
+import {
+  themeManagerCn,
+  BasicSelector,
+  backgroundColors,
+} from "../../index.js";
 import { innerLayoutVariants, layoutVariants } from "./Layout.tsx";
 import { layoutFields, layoutProps } from "./Layout.tsx";
-import { backgroundColors } from "../../utils/themeConfigOptions.ts";
 
 interface ColumnProps {
   justifyContent: "center" | "start" | "end" | "spaceBetween";

--- a/packages/visual-editor/src/components/puck/Grid.tsx
+++ b/packages/visual-editor/src/components/puck/Grid.tsx
@@ -1,12 +1,8 @@
 import * as React from "react";
 import { ComponentConfig, DropZone, Fields } from "@measured/puck";
 import { Section } from "./atoms/section.js";
-import {
-  themeManagerCn,
-  BasicSelector,
-  backgroundColors,
-} from "../../index.js";
-import { innerLayoutVariants, layoutVariants } from "./Layout.tsx";
+import { themeManagerCn, backgroundColors } from "../../index.js";
+import { layoutVariants } from "./Layout.tsx";
 import { layoutFields, layoutProps } from "./Layout.tsx";
 
 interface GridProps extends layoutProps {

--- a/packages/visual-editor/src/components/puck/HeadingText.tsx
+++ b/packages/visual-editor/src/components/puck/HeadingText.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { ComponentConfig, Fields } from "@measured/puck";
-import { Heading, headingOptions, HeadingProps } from "./atoms/heading.js";
+import { Heading, HeadingProps } from "./atoms/heading.js";
 import {
   useDocument,
   resolveYextEntityField,
@@ -8,6 +8,7 @@ import {
   YextEntityField,
   YextEntityFieldSelector,
   BasicSelector,
+  headingLevelOptions,
 } from "../../index.js";
 
 interface HeadingTextProps extends HeadingProps {
@@ -41,7 +42,7 @@ const headingTextFields: Fields<HeadingTextProps> = {
       types: ["type.string"],
     },
   }),
-  level: BasicSelector("Heading Level", headingOptions),
+  level: BasicSelector("Heading Level", headingLevelOptions),
 };
 
 const HeadingTextComponent: ComponentConfig<HeadingTextProps> = {

--- a/packages/visual-editor/src/components/puck/Promo.tsx
+++ b/packages/visual-editor/src/components/puck/Promo.tsx
@@ -14,9 +14,10 @@ import {
   BackgroundStyle,
   backgroundColors,
   BodyProps,
+  headingLevelOptions,
 } from "../../index.js";
 import { CTA, CTAProps } from "./atoms/cta.js";
-import { Heading, HeadingProps, headingOptions } from "./atoms/heading.js";
+import { Heading, HeadingProps } from "./atoms/heading.js";
 import { Section } from "./atoms/section.js";
 import { imageWrapperVariants } from "./Image.js";
 
@@ -75,7 +76,7 @@ const promoFields: Fields<PromoProps> = {
           types: ["type.string"],
         },
       }),
-      level: BasicSelector("Business Name Heading", headingOptions),
+      level: BasicSelector("Business Name Heading Level", headingLevelOptions),
     },
   },
   description: {

--- a/packages/visual-editor/src/components/puck/atoms/heading.tsx
+++ b/packages/visual-editor/src/components/puck/atoms/heading.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
-import { themeManagerCn } from "../../../index.ts";
+import { themeManagerCn, HeadingLevel } from "../../../index.ts";
 
 // Define the variants for the heading component
 const headingVariants = cva("components", {
@@ -64,9 +64,6 @@ const headingVariants = cva("components", {
     transform: "none",
   },
 });
-
-// Define the valid levels for the heading element
-export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
 
 // Omit 'color' from HTMLAttributes<HTMLHeadingElement> to avoid conflict
 export interface HeadingProps

--- a/packages/visual-editor/src/components/puck/atoms/heading.tsx
+++ b/packages/visual-editor/src/components/puck/atoms/heading.tsx
@@ -104,13 +104,4 @@ const Heading = React.forwardRef<HTMLHeadingElement, HeadingProps>(
 );
 Heading.displayName = "Heading";
 
-const headingOptions = [
-  { label: "H1", value: 1 },
-  { label: "H2", value: 2 },
-  { label: "H3", value: 3 },
-  { label: "H4", value: 4 },
-  { label: "H5", value: 5 },
-  { label: "H6", value: 6 },
-];
-
-export { Heading, headingVariants, headingOptions };
+export { Heading, headingVariants };

--- a/packages/visual-editor/src/components/puck/atoms/section.tsx
+++ b/packages/visual-editor/src/components/puck/atoms/section.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
-import { themeManagerCn } from "../../../index.ts";
-import { BackgroundStyle } from "../../../utils/themeConfigOptions.ts";
+import { themeManagerCn, BackgroundStyle } from "../../../index.ts";
 
 const sectionVariants = cva("mx-auto", {
   variants: {

--- a/packages/visual-editor/src/utils/README.md
+++ b/packages/visual-editor/src/utils/README.md
@@ -544,6 +544,23 @@ theme: {
 },
 ```
 
+## headingLevelOptions
+
+The set of heading levels (H1 through H6) for use with BasicSelector.
+
+#### Usage
+
+```tsx
+const myComponentFields: Fields<MyComponentProps> = {
+  heading: {
+    type: "object",
+    label: "Heading",
+    objectFields: {
+      level: BasicSelector("Level", headingLevelOptions),
+    },
+  },
+```
+
 ## backgroundColors
 
 An object of the following shape containing the seven auto-generated background styles.

--- a/packages/visual-editor/src/utils/index.ts
+++ b/packages/visual-editor/src/utils/index.ts
@@ -18,6 +18,7 @@ export {
   backgroundColors,
   defaultThemeTailwindExtensions,
   type BackgroundStyle,
+  headingLevelOptions,
 } from "./themeConfigOptions.ts";
 export { applyAnalytics } from "./applyAnalytics.ts";
 export { getPageMetadata } from "./getPageMetadata.ts";

--- a/packages/visual-editor/src/utils/index.ts
+++ b/packages/visual-editor/src/utils/index.ts
@@ -19,6 +19,7 @@ export {
   defaultThemeTailwindExtensions,
   type BackgroundStyle,
   headingLevelOptions,
+  type HeadingLevel,
 } from "./themeConfigOptions.ts";
 export { applyAnalytics } from "./applyAnalytics.ts";
 export { getPageMetadata } from "./getPageMetadata.ts";

--- a/packages/visual-editor/src/utils/themeConfigOptions.ts
+++ b/packages/visual-editor/src/utils/themeConfigOptions.ts
@@ -88,6 +88,15 @@ export const backgroundColors: Record<string, BackgroundOption> = {
   },
 };
 
+export const headingLevelOptions = [
+  { label: "H1", value: 1 },
+  { label: "H2", value: 2 },
+  { label: "H3", value: 3 },
+  { label: "H4", value: 4 },
+  { label: "H5", value: 5 },
+  { label: "H6", value: 6 },
+];
+
 // Tailwind Theme Extensions (https://v3.tailwindcss.com/docs/theme#extending-the-default-theme)
 // to use in the tailwind.config.ts in conjunction with themeResolver and the theme.config
 export const defaultThemeTailwindExtensions = {

--- a/packages/visual-editor/src/utils/themeConfigOptions.ts
+++ b/packages/visual-editor/src/utils/themeConfigOptions.ts
@@ -88,6 +88,10 @@ export const backgroundColors: Record<string, BackgroundOption> = {
   },
 };
 
+// Defines the valid levels for the heading element
+export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
+
+// Provides a mapping of label to value for BasicSelector
 export const headingLevelOptions = [
   { label: "H1", value: 1 },
   { label: "H2", value: 2 },


### PR DESCRIPTION
Moves `headingLevelOptions` to themeConfigOptions.tsx for export from the package
Also updates a number of imports that should have been importing through the package alias rather than specific files