### PR TITLE
feat: integrate mapbox map component within locator component

### DIFF
--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -59,7 +59,8 @@
     "react-error-boundary": "^5.0.0",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.4.0",
-    "tsx": "^4.16.3"
+    "tsx": "^4.16.3",
+    "mapbox-gl": "^2.9.2"
   },
   "engines": {
     "node": "^17 || ^18 || ^20"
@@ -106,7 +107,8 @@
     "uuid": "11.0.3",
     "vite": "^5.3.5",
     "vitest": "^3.0.5",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "@types/mapbox-gl": "^2.7.5"
   },
   "peerDependencies": {
     "@yext/pages-components": "^1.1.0",

--- a/packages/visual-editor/src/internal/components/InternalLayoutEditor.tsx
+++ b/packages/visual-editor/src/internal/components/InternalLayoutEditor.tsx
@@ -7,7 +7,7 @@ import {
   AppState,
 } from "@measured/puck";
 import React from "react";
-import { useState, useRef, useCallback } from "react";
+import { useState, useRef, useCallback, useEffect } from "react";
 import { TemplateMetadata } from "../types/templateMetadata.ts";
 import { EntityFieldProvider } from "../../components/editor/EntityField.tsx";
 import { LayoutSaveState } from "../types/saveState.ts";
@@ -175,7 +175,33 @@ export const InternalLayoutEditor = ({
               isDevMode={templateMetadata.isDevMode}
             />
           ),
+          iframe: ({ children, document }) => {
+            useEffect(() => {
+              if (!document) return;
+
+              // Ensure Mapbox script is loaded in the iframe
+              if (!document.getElementById("mapbox-script")) {
+                const script = document.createElement("script");
+                script.id = "mapbox-script";
+                script.src =
+                  "https://api.mapbox.com/mapbox-gl-js/v2.9.2/mapbox-gl.js";
+                document.body.appendChild(script);
+              }
+
+              // Ensure Mapbox stylesheet is loaded in the iframe
+              if (!document.getElementById("mapbox-stylesheet")) {
+                const link = document.createElement("link");
+                link.id = "mapbox-stylesheet";
+                link.href =
+                  "https://api.mapbox.com/mapbox-gl-js/v2.9.2/mapbox-gl.css";
+                link.rel = "stylesheet";
+                document.body.appendChild(link);
+              }
+            }, [document]);
+            return <>{children}</>;
+          },
         }}
+        // iframe={{enabled:false}}
       />
     </EntityFieldProvider>
   );

--- a/packages/visual-editor/src/internal/components/InternalThemeEditor.tsx
+++ b/packages/visual-editor/src/internal/components/InternalThemeEditor.tsx
@@ -182,6 +182,31 @@ export const InternalThemeEditor = ({
           actionBar: () => <></>,
           components: () => <></>,
           fields: fieldsOverride,
+          iframe: ({ children, document }) => {
+            useEffect(() => {
+              if (!document) return;
+
+              // Ensure Mapbox script is loaded in the iframe
+              if (!document.getElementById("mapbox-script")) {
+                const script = document.createElement("script");
+                script.id = "mapbox-script";
+                script.src =
+                  "https://api.mapbox.com/mapbox-gl-js/v2.9.2/mapbox-gl.js";
+                document.body.appendChild(script);
+              }
+
+              // Ensure Mapbox stylesheet is loaded in the iframe
+              if (!document.getElementById("mapbox-stylesheet")) {
+                const link = document.createElement("link");
+                link.id = "mapbox-stylesheet";
+                link.href =
+                  "https://api.mapbox.com/mapbox-gl-js/v2.9.2/mapbox-gl.css";
+                link.rel = "stylesheet";
+                document.body.appendChild(link);
+              }
+            }, [document]);
+            return <>{children}</>;
+          },
         }}
       />
     </EntityFieldProvider>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,9 @@ importers:
       lz-string:
         specifier: 1.5.0
         version: 1.5.0
+      mapbox-gl:
+        specifier: ^2.9.2
+        version: 2.15.0
       next-themes:
         specifier: ^0.3.0
         version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -206,6 +209,9 @@ importers:
       "@types/fs-extra":
         specifier: ^11.0.4
         version: 11.0.4
+      "@types/mapbox-gl":
+        specifier: ^2.7.5
+        version: 2.7.21
       "@types/minimist":
         specifier: ^1.2.5
         version: 1.2.5
@@ -332,15 +338,21 @@ importers:
       "@radix-ui/react-tooltip":
         specifier: ^1.1.2
         version: 1.1.3(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@types/mapbox-gl":
+        specifier: ^2.7.5
+        version: 2.7.21
       "@types/node":
         specifier: ^20.12.3
         version: 20.17.6
+      "@yext/components-maps":
+        specifier: ^2.2.7
+        version: 2.2.7(@yext/components-geo@1.1.4)(@yext/components-performance@1.1.4)(@yext/components-util@1.1.7(@yext/components-spinner-modal@1.1.4))
       "@yext/search-headless-react":
         specifier: ^2.5.0
         version: 2.5.0(encoding@0.1.13)(react@18.3.1)
       "@yext/search-ui-react":
-        specifier: ^1.8.0
-        version: 1.8.0(@types/react@18.3.12)(@yext/search-headless-react@2.5.0(encoding@0.1.13)(react@18.3.1))(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.14(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)))
+        specifier: ^1.8.2
+        version: 1.8.2(@types/react@18.3.12)(@yext/search-headless-react@2.5.0(encoding@0.1.13)(react@18.3.1))(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.14(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)))
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
@@ -353,6 +365,9 @@ importers:
       lucide-react:
         specifier: ^0.378.0
         version: 0.378.0(react@18.3.1)
+      mapbox-gl:
+        specifier: ^2.9.2
+        version: 2.15.0
       next-themes:
         specifier: ^0.3.0
         version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3453,6 +3468,12 @@ packages:
         integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==,
       }
 
+  "@types/geojson@7946.0.16":
+    resolution:
+      {
+        integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==,
+      }
+
   "@types/hast@2.3.10":
     resolution:
       {
@@ -3493,6 +3514,12 @@ packages:
     resolution:
       {
         integrity: sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==,
+      }
+
+  "@types/mapbox-gl@2.7.21":
+    resolution:
+      {
+        integrity: sha512-Dx9MuF2kKgT/N22LsMUB4b3acFZh9clVqz9zv1fomoiPoBrJolwYxpWA/9LPO/2N0xWbKi4V+pkjTaFkkx/4wA==,
       }
 
   "@types/markdown-it@14.1.2":
@@ -3997,6 +4024,47 @@ packages:
         integrity: sha512-D8ahIRIVtdvV7Ycup13OY930waOzi50gzwXO7Cpa4SK0+eREg3YMxsNxbXpgXVoEdwKaMw/xhsKy3Cy0fTcQZA==,
       }
 
+  "@yext/components-geo@1.1.4":
+    resolution:
+      {
+        integrity: sha512-bTrtT5MZ2es0NGWSFccVUGscG1+Z0LWiEywjkZ/vKuGenMFYwUiiapyEgLx6cjMqj6YUZMOzDe6SZAfveKh6iw==,
+      }
+    engines: { node: ">=12.16.x" }
+
+  "@yext/components-maps@2.2.7":
+    resolution:
+      {
+        integrity: sha512-3T2FagidNTPnpDI5FDay9Rq4pJYXZbO5DtVImhFbVytdH4vRPZq06gh+7SRiJHF4z8viKxyqu99phYdHsBHQAg==,
+      }
+    engines: { node: ">=12.16.x" }
+    peerDependencies:
+      "@yext/components-geo": 1.1.4
+      "@yext/components-performance": 1.1.4
+      "@yext/components-util": 1.1.7
+
+  "@yext/components-performance@1.1.4":
+    resolution:
+      {
+        integrity: sha512-m27zdDmg8r+uXHi3f3FRZt0a5+DhZ/GSSvRq9+nk0H8S+GCSY5y66hyVVNa5mJeOjQOdBwZYbMuFVQdRRgNAjA==,
+      }
+    engines: { node: ">=12.16.x" }
+
+  "@yext/components-spinner-modal@1.1.4":
+    resolution:
+      {
+        integrity: sha512-Xv6IpKuoUpim8PzCAVdcMGn4LExqCY0lJYfQgxm70WUYkrSsLQbowMfrbEZYcVB74Bj0oDcT5EACw4JT+4eqzQ==,
+      }
+    engines: { node: ">=12.16.x" }
+
+  "@yext/components-util@1.1.7":
+    resolution:
+      {
+        integrity: sha512-qb8KJDUmkp2Tt8KWo53WxdwypST1yBRSucMdCUYeA6xVDfiqvXYylmuqpi+me0phjpHlDteX9KBRNwzjZE3KBw==,
+      }
+    engines: { node: ">=12.16.x" }
+    peerDependencies:
+      "@yext/components-spinner-modal": 1.1.4
+
   "@yext/pages-components@1.1.1":
     resolution:
       {
@@ -4040,10 +4108,10 @@ packages:
         integrity: sha512-IIc4YaRhmZvyQg6Iq6d5ZKhBbRA4BKLytdngTer3nZ47WzWHLxwAsrg0aIgUHFbJhKbuU+bKBVg8N9cTYrzTDQ==,
       }
 
-  "@yext/search-ui-react@1.8.0":
+  "@yext/search-ui-react@1.8.2":
     resolution:
       {
-        integrity: sha512-y03R6fPNtTSGht9Jgd0/VBVa6FhVUPu3kownlf8Mlm/eMPUMVcmVIGa9GXW8IkA5WwKmQEX/ArBjjNx66qwxjg==,
+        integrity: sha512-6QTQfWdplxzOcmqJXaOmLf6O4yyaqvxNZd2t+MBpKmpNk4GaqRsE9dtkmZ1uPDCnkVclp7PTpkggm1R3tOIcGg==,
       }
     peerDependencies:
       "@yext/search-headless-react": ^2.5.0
@@ -13153,6 +13221,8 @@ snapshots:
       "@types/jsonfile": 6.1.4
       "@types/node": 20.17.6
 
+  "@types/geojson@7946.0.16": {}
+
   "@types/hast@2.3.10":
     dependencies:
       "@types/unist": 2.0.11
@@ -13172,6 +13242,10 @@ snapshots:
   "@types/linkify-it@5.0.0": {}
 
   "@types/lodash@4.17.16": {}
+
+  "@types/mapbox-gl@2.7.21":
+    dependencies:
+      "@types/geojson": 7946.0.16
 
   "@types/markdown-it@14.1.2":
     dependencies:
@@ -13572,6 +13646,22 @@ snapshots:
     dependencies:
       ulidx: 2.4.1
 
+  "@yext/components-geo@1.1.4": {}
+
+  "@yext/components-maps@2.2.7(@yext/components-geo@1.1.4)(@yext/components-performance@1.1.4)(@yext/components-util@1.1.7(@yext/components-spinner-modal@1.1.4))":
+    dependencies:
+      "@yext/components-geo": 1.1.4
+      "@yext/components-performance": 1.1.4
+      "@yext/components-util": 1.1.7(@yext/components-spinner-modal@1.1.4)
+
+  "@yext/components-performance@1.1.4": {}
+
+  "@yext/components-spinner-modal@1.1.4": {}
+
+  "@yext/components-util@1.1.7(@yext/components-spinner-modal@1.1.4)":
+    dependencies:
+      "@yext/components-spinner-modal": 1.1.4
+
   "@yext/pages-components@1.1.1(@lexical/clipboard@0.12.6(lexical@0.12.6))(@lexical/selection@0.12.6(lexical@0.12.6))(@types/react@18.3.12)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(yjs@13.6.20)":
     dependencies:
       "@lexical/code": 0.12.6(lexical@0.12.6)
@@ -13695,7 +13785,7 @@ snapshots:
       - react
       - react-redux
 
-  "@yext/search-ui-react@1.8.0(@types/react@18.3.12)(@yext/search-headless-react@2.5.0(encoding@0.1.13)(react@18.3.1))(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.14(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)))":
+  "@yext/search-ui-react@1.8.2(@types/react@18.3.12)(@yext/search-headless-react@2.5.0(encoding@0.1.13)(react@18.3.1))(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.14(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)))":
     dependencies:
       "@restart/ui": 1.9.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       "@tailwindcss/forms": 0.5.10(tailwindcss@3.4.14(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)))
@@ -17933,7 +18023,7 @@ snapshots:
   tuf-js@3.0.1:
     dependencies:
       "@tufjs/models": 3.0.1
-      debug: 4.3.7
+      debug: 4.4.0
       make-fetch-happen: 14.0.3
     transitivePeerDependencies:
       - supports-color

--- a/starter/package.json
+++ b/starter/package.json
@@ -38,8 +38,11 @@
     "sonner": "^1.4.41",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",
-    "@yext/search-ui-react": "^1.8.0",
-    "@yext/search-headless-react": "^2.5.0"
+    "@yext/search-ui-react": "^1.8.2",
+    "@yext/search-headless-react": "^2.5.0",
+    "@types/mapbox-gl": "^2.7.5",
+    "@yext/components-maps": "^2.2.7",
+    "mapbox-gl": "^2.9.2"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.13",

--- a/starter/src/components/Locator.tsx
+++ b/starter/src/components/Locator.tsx
@@ -188,16 +188,16 @@ const Locator: React.FC<LocatorProps> = (props) => {
 
   return (
     <>
-      <div className="flex w-full h-full aspect-[3/2]">
+      <div className="flex w-full h-full aspect-[1/2] md:aspect-[3/2]">
         {/* Left Section: FilterSearch + Results. Full width for small screens */}
-        <div className="w-full md:w-1/3 p-4">
+        <div className="w-full md:w-1/3 p-4 h-full flex flex-col">
           <FilterSearch
             searchFields={[
               { fieldApiName: DEFAULT_FIELD, entityType: DEFAULT_ENTITY_TYPE },
             ]}
             onSelect={(params) => handleFilterSelect(params)}
           />
-          <div>
+          <div id="innerDiv" className="flex-grow overflow-y-auto">
             {resultCount > 0 && (
               <VerticalResults CardComponent={StandardCard} />
             )}

--- a/starter/src/components/Locator.tsx
+++ b/starter/src/components/Locator.tsx
@@ -1,6 +1,9 @@
 import { ComponentConfig, Fields } from "@measured/puck";
 import {
   FilterSearch,
+  getUserLocation,
+  MapboxMap,
+  OnDragHandler,
   OnSelectParams,
   StandardCard,
   VerticalResults,
@@ -14,9 +17,13 @@ import {
 import * as React from "react";
 import { cva, VariantProps } from "class-variance-authority";
 import { BasicSelector, themeManagerCn } from "@yext/visual-editor";
+// import { MapboxMap } from "./MapboxMap2";
+import { LngLat, LngLatBounds } from "mapbox-gl";
 
 const DEFAULT_FIELD = "builtin.location";
 const DEFAULT_ENTITY_TYPE = "location";
+const DEFAULT_MAP_CENTER = [-74.005371, 40.741611]; // New York City
+const DEFAULT_RADIUS_METERS = 40233.6; // 25 miles
 
 const locatorVariants = cva("", {
   variants: {
@@ -34,7 +41,9 @@ const locatorVariants = cva("", {
   },
 });
 
-type LocatorProps = VariantProps<typeof locatorVariants>;
+interface LocatorProps extends VariantProps<typeof locatorVariants> {
+  mapStyle?: string;
+}
 
 const locatorFields: Fields<LocatorProps> = {
   backgroundColor: BasicSelector("Background Color", [
@@ -45,6 +54,23 @@ const locatorFields: Fields<LocatorProps> = {
     { label: "Text", value: "text" },
     { label: "Background", value: "background" },
   ]),
+  mapStyle: BasicSelector("Map Style", [
+    { label: "Default", value: "mapbox://styles/mapbox/streets-v12" },
+    {
+      label: "Satellite",
+      value: "mapbox://styles/mapbox/satellite-streets-v12",
+    },
+    { label: "Light", value: "mapbox://styles/mapbox/light-v11" },
+    { label: "Dark", value: "mapbox://styles/mapbox/dark-v11" },
+    {
+      label: "Navigation (Day)",
+      value: "mapbox://styles/mapbox/navigation-day-v1",
+    },
+    {
+      label: "Navigation (Night)",
+      value: "mapbox://styles/mapbox/navigation-night-v1",
+    },
+  ]),
 };
 
 const LocatorComponent: ComponentConfig<LocatorProps> = {
@@ -54,10 +80,42 @@ const LocatorComponent: ComponentConfig<LocatorProps> = {
 };
 
 const Locator: React.FC<LocatorProps> = (props) => {
-  const { backgroundColor } = props;
+  const { backgroundColor, mapStyle } = props;
   const resultCount = useSearchState(
     (state) => state.vertical.resultsCount || 0,
   );
+
+  const [showSearchAreaButton, setShowSearchAreaButton] = React.useState(false);
+  const [mapCenter, setMapCenter] = React.useState<LngLat | undefined>();
+  const [mapBounds, setMapBounds] = React.useState<LngLatBounds | undefined>();
+
+  const handleDrag: OnDragHandler = (center: LngLat, bounds: LngLatBounds) => {
+    setMapCenter(center);
+    setMapBounds(bounds);
+    setShowSearchAreaButton(true);
+  };
+
+  const handleSearchAreaClick = () => {
+    if (mapCenter && mapBounds) {
+      const locationFilter: SelectableStaticFilter = {
+        selected: true,
+        displayName: "Current map area",
+        filter: {
+          kind: "fieldValue",
+          fieldId: "builtin.location",
+          value: {
+            lat: mapCenter.lat,
+            lng: mapCenter.lng,
+            radius: mapBounds.getNorthEast().distanceTo(mapCenter),
+          },
+          matcher: Matcher.Near,
+        },
+      };
+      searchActions.setStaticFilters([locationFilter]);
+      searchActions.executeVerticalQuery();
+      setShowSearchAreaButton(false);
+    }
+  };
 
   const searchActions = useSearchActions();
   const handleFilterSelect = (params: OnSelectParams) => {
@@ -75,30 +133,140 @@ const Locator: React.FC<LocatorProps> = (props) => {
     searchActions.executeVerticalQuery();
   };
 
+  const [userLocation, setUserLocation] =
+    React.useState<number[]>(DEFAULT_MAP_CENTER);
+  React.useEffect(() => {
+    getUserLocation()
+      .then((location) => {
+        setUserLocation([location.coords.longitude, location.coords.latitude]);
+        searchActions.setStaticFilters([
+          {
+            selected: true,
+            displayName: "Current Location",
+            filter: {
+              kind: "fieldValue",
+              fieldId: "builtin.location",
+              value: {
+                lat: location.coords.latitude,
+                lng: location.coords.longitude,
+                radius: DEFAULT_RADIUS_METERS,
+              },
+              matcher: Matcher.Near,
+            },
+          },
+        ]);
+      })
+      .catch(() => {
+        searchActions.setStaticFilters([
+          {
+            selected: true,
+            displayName: "New York City, New York, NY",
+            filter: {
+              kind: "fieldValue",
+              fieldId: "builtin.location",
+              value: {
+                lat: DEFAULT_MAP_CENTER[1],
+                lng: DEFAULT_MAP_CENTER[0],
+                radius: DEFAULT_RADIUS_METERS,
+              },
+              matcher: Matcher.Near,
+            },
+          },
+        ]);
+      })
+      .then(() => {
+        searchActions.executeVerticalQuery();
+      });
+  }, []);
+
   const searchLoading = useSearchState((state) => state.searchStatus.isLoading);
+  const mapProps: MapProps = {
+    ...(userLocation && { centerCoords: userLocation }),
+    ...(mapStyle && { mapStyle }),
+    onDragHandler: handleDrag,
+  };
 
   return (
     <>
-      <FilterSearch
-        searchFields={[
-          { fieldApiName: DEFAULT_FIELD, entityType: DEFAULT_ENTITY_TYPE },
-        ]}
-        onSelect={(params) => handleFilterSelect(params)}
-      />
-      <div>
-        {resultCount > 0 && <VerticalResults CardComponent={StandardCard} />}
-        {resultCount === 0 && !searchLoading && (
-          <div
-            className={themeManagerCn(
-              "flex items-center justify-center",
-              locatorVariants({ backgroundColor }),
+      <div className="flex w-full h-full aspect-[3/2]">
+        {/* Left Section: FilterSearch + Results. Full width for small screens */}
+        <div className="w-full md:w-1/3 p-4">
+          <FilterSearch
+            searchFields={[
+              { fieldApiName: DEFAULT_FIELD, entityType: DEFAULT_ENTITY_TYPE },
+            ]}
+            onSelect={(params) => handleFilterSelect(params)}
+          />
+          <div>
+            {resultCount > 0 && (
+              <VerticalResults CardComponent={StandardCard} />
             )}
-          >
-            <p className="pt-4 text-2xl">No results found for this area</p>
+            {resultCount === 0 && !searchLoading && (
+              <div
+                className={themeManagerCn(
+                  "flex items-center justify-center",
+                  locatorVariants({ backgroundColor }),
+                )}
+              >
+                <p className="pt-4 text-2xl">No results found for this area</p>
+              </div>
+            )}
           </div>
-        )}
+        </div>
+
+        {/* Right Section: Map. Hidden for small screens */}
+        <div className="w-2/3 md:flex hidden">
+          <div className="relative w-full h-full">
+            <Map {...mapProps} />
+            {showSearchAreaButton && (
+              <div className="absolute bottom-10 left-0 right-0 flex justify-center">
+                <button
+                  onClick={handleSearchAreaClick}
+                  className="rounded-2xl border bg-white py-2 px-4 shadow-xl"
+                >
+                  <p>Search This Area</p>
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
       </div>
     </>
+  );
+};
+
+interface MapProps {
+  mapStyle?: string;
+  centerCoords?: number[];
+  onDragHandler?: OnDragHandler;
+}
+
+const Map: React.FC<MapProps> = ({ mapStyle, centerCoords, onDragHandler }) => {
+  const iframe = document.getElementById("preview-frame") as HTMLIFrameElement;
+  const mapboxApiKey = "";
+  if (iframe?.contentDocument && !iframe.contentWindow?.mapboxgl) {
+    // We are in an iframe, and mapboxgl is not loaded in yet
+    return (
+      <div className="flex items-center justify-center w-full h-full">
+        <div className="border border-gray-300 rounded-lg p-6 bg-white shadow-md">
+          <span className="text-gray-700 text-lg font-medium">
+            Loading Map...
+          </span>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <MapboxMap
+      mapboxAccessToken={mapboxApiKey || ""}
+      mapboxOptions={{
+        center: centerCoords ?? DEFAULT_MAP_CENTER,
+        ...(mapStyle ? { style: mapStyle } : {}),
+      }}
+      onDrag={onDragHandler}
+      iframeWindow={iframe?.contentWindow ?? undefined}
+      allowUpdates={!!iframe?.contentDocument}
+    />
   );
 };
 


### PR DESCRIPTION
I have added the `MapboxMap` from `search-ui-react` to the Locator component.
Currently, the only property of the map that is configurable is the "style"
of the map (e.g. street, dark mode, day navigation, etc).
The map will attempt to find the user's location, and use that as the
first search. The user can either drag/zoom around the map and click
"Search this area" to run a search, or they can use the filter search bar.

The display will be the following:
- for small screen sizes, the map component will be hidden
- for medium and larger screen sizes, the filter search + results will
occupy the left 1/3 of the screen, while the map will occupy the remaining
right 2/3.

To see it in action, see this video:
https://drive.google.com/file/d/1hvAdD6mtwnOLRXfU_0cN0jokzBqnBfOx/view?usp=drive_link

J=[WAT-4700](https://yexttest.atlassian.net/browse/WAT-4700?atlOrigin=eyJpIjoiYTIzY2NjNDllYTdhNDE4MWJlNzU3ZjZlZGFmZmIzYTciLCJwIjoiaiJ9)