### PR TITLE
refactor: theme and utility updates to support updated link and button styles

### DIFF
--- a/packages/visual-editor/src/utils/applyTheme.test.ts
+++ b/packages/visual-editor/src/utils/applyTheme.test.ts
@@ -91,6 +91,35 @@ describe("buildCssOverridesStyle", () => {
         "}</style>"
     );
   });
+
+  it("should generate contrasting palette colors", () => {
+    const document: Document = {
+      __: {
+        theme: JSON.stringify({ "--colors-palette-primary": "#7ED321" }),
+      },
+    };
+    const result = applyTheme(document, {
+      palette: {
+        label: "Colors",
+        styles: {
+          primary: {
+            label: "Primary",
+            plugin: "colors",
+            type: "color",
+            default: "#000000",
+          },
+        },
+      },
+    });
+
+    expect(result).toBe(
+      defaultGoogleFontsLinkTags +
+        '<style id="visual-editor-theme" type="text/css">.components{' +
+        "--colors-palette-primary:#7ED321 !important;" +
+        "--colors-palette-primary-contrast:#FFFFFF !important" +
+        "}</style>"
+    );
+  });
 });
 
 const themeConfig: ThemeConfig = {

--- a/packages/visual-editor/src/utils/applyTheme.ts
+++ b/packages/visual-editor/src/utils/applyTheme.ts
@@ -66,9 +66,11 @@ const internalApplyTheme = (
   );
 };
 
-// generateContrastingColors computes whether each color is
-// light or dark and adds a corresponding -contrast value that
-// is either black (for light colors) or white (for dark colors)
+/**
+ * generateContrastingColors computes whether each color is
+ * light or dark and adds a corresponding -contrast value that
+ * is either black (for light colors) or white (for dark colors)
+ */
 const generateContrastingColors = (themeData: ThemeData) => {
   const contrastingColors: Record<string, string> = {};
   Object.entries(themeData).forEach(([cssVariableName, value]) => {

--- a/packages/visual-editor/src/utils/applyTheme.ts
+++ b/packages/visual-editor/src/utils/applyTheme.ts
@@ -3,6 +3,7 @@ import { internalThemeResolver } from "../internal/utils/internalThemeResolver.t
 import { DevLogger } from "./devLogger.ts";
 import { googleFontLinkTags } from "./visualEditorFonts.ts";
 import { ThemeConfig } from "./themeResolver.ts";
+import { hexToHSL } from "./colors.ts";
 
 export type Document = {
   [key: string]: any;
@@ -40,14 +41,20 @@ const internalApplyTheme = (
 ): string => {
   devLogger.logFunc("internalApplyTheme");
 
-  const themeValuesToApply = internalThemeResolver(
+  const mergedThemeValues = internalThemeResolver(
     themeConfig,
     savedThemeValues
   );
 
-  if (!themeValuesToApply || Object.keys(themeValuesToApply).length === 0) {
+  if (!mergedThemeValues || Object.keys(mergedThemeValues).length === 0) {
     return "";
   }
+
+  const themeValuesToApply = {
+    ...mergedThemeValues,
+    ...generateContrastingColors(mergedThemeValues),
+  };
+
   devLogger.logData("THEME_VALUES_TO_APPLY", themeValuesToApply);
 
   return (
@@ -57,6 +64,24 @@ const internalApplyTheme = (
       .join(";") +
     "}"
   );
+};
+
+// generateContrastingColors computes whether each color is
+// light or dark and adds a corresponding -contrast value that
+// is either black (for light colors) or white (for dark colors)
+const generateContrastingColors = (themeData: ThemeData) => {
+  const contrastingColors: Record<string, string> = {};
+  Object.entries(themeData).forEach(([cssVariableName, value]) => {
+    if (cssVariableName.includes("--colors")) {
+      const hsl = hexToHSL(value);
+      if (hsl && hsl[2] >= 50) {
+        contrastingColors[cssVariableName + "-contrast"] = "#000000";
+      } else if (hsl) {
+        contrastingColors[cssVariableName + "-contrast"] = "#FFFFFF";
+      }
+    }
+  });
+  return contrastingColors;
 };
 
 export const updateThemeInEditor = async (

--- a/packages/visual-editor/src/utils/colors.test.ts
+++ b/packages/visual-editor/src/utils/colors.test.ts
@@ -5,6 +5,7 @@ import {
   hexToHSL,
   luminanceFromRGB,
   passesWcagAAColorContrast,
+  srgbToHSL,
 } from "./colors.ts";
 
 describe("getContrastingColor", () => {
@@ -62,6 +63,22 @@ describe("hexToHSL", () => {
     expect(hexToHSL("123456")).toBeUndefined();
     expect(hexToHSL("#123456789")).toBeUndefined();
     expect(hexToHSL("#16")).toBeUndefined();
+  });
+});
+
+describe("srgbToHSL", () => {
+  it("should correctly calculate RGB", () => {
+    expect(srgbToHSL([0, 0, 0])).toStrictEqual([0, 0, 0]);
+    expect(srgbToHSL([1, 1, 1])).toStrictEqual([0, 0, 100]);
+    expect(srgbToHSL([0.23, 0.5, 0.1])).toStrictEqual([100.5, 66.6, 30]);
+    expect(srgbToHSL([0.88, 0.1, 0.9])).toStrictEqual([298.5, 80, 50]);
+  });
+
+  it("should return undefined if hex argument is invalid", () => {
+    expect(srgbToHSL([])).toBeUndefined();
+    expect(srgbToHSL([1, 2, 3, 4])).toBeUndefined();
+    expect(srgbToHSL([2000, 0.4, 0.2])).toBeUndefined();
+    expect(srgbToHSL([0.2, -0.4, 0.2])).toBeUndefined();
   });
 });
 

--- a/packages/visual-editor/src/utils/colors.test.ts
+++ b/packages/visual-editor/src/utils/colors.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import {
+  getContrastingColor,
+  hexToRGB,
+  hexToHSL,
+  luminanceFromRGB,
+  passesWcagAAColorContrast,
+} from "./colors.ts";
+
+describe("getContrastingColor", () => {
+  it("should return black given a light color", () => {
+    expect(getContrastingColor("#bad5ff", 12, 400)).toBe("#000000");
+  });
+  it("should return white given a dark color", () => {
+    expect(getContrastingColor("#0d2140", 12, 400)).toBe("#FFFFFF");
+  });
+  it("should return black given an invalid color", () => {
+    expect(getContrastingColor("###0d2140", 12, 400)).toBe("#000000");
+  });
+});
+
+describe("getLuminanceFromRgb", () => {
+  it("should correctly calculate luminance", () => {
+    expect(luminanceFromRGB([255, 255, 255])).toBe(1);
+    expect(luminanceFromRGB([0, 0, 0])).toBe(0);
+    expect(luminanceFromRGB([192, 62, 62])).toBe(0.14999517012130859);
+    expect(luminanceFromRGB([52, 69, 67])).toBe(0.05391555744327111);
+  });
+
+  it("should return undefined if rgb argument is invalid", () => {
+    expect(luminanceFromRGB([0])).toBeUndefined();
+    expect(luminanceFromRGB([0, 1, 3, 4, 5])).toBeUndefined();
+    expect(luminanceFromRGB([-2, 4, 5])).toBeUndefined();
+    expect(luminanceFromRGB([2555, 2, 2])).toBeUndefined();
+  });
+});
+
+describe("hexToRGB", () => {
+  it("should correctly calculate RGB", () => {
+    expect(hexToRGB("#000000")).toStrictEqual([0, 0, 0]);
+    expect(hexToRGB("#FFF")).toStrictEqual([255, 255, 255]);
+    expect(hexToRGB("#11544d")).toStrictEqual([17, 84, 77]);
+    expect(hexToRGB("#777")).toStrictEqual([119, 119, 119]);
+  });
+
+  it("should return undefined if hex argument is invalid", () => {
+    expect(hexToRGB("123456")).toBeUndefined();
+    expect(hexToRGB("#123456789")).toBeUndefined();
+    expect(hexToRGB("#16")).toBeUndefined();
+  });
+});
+
+describe("hexToHSL", () => {
+  it("should correctly calculate HSL", () => {
+    expect(hexToHSL("#000000")).toStrictEqual([0, 0, 0]);
+    expect(hexToHSL("#FFF")).toStrictEqual([0, 0, 100]);
+    expect(hexToHSL("#11544d")).toStrictEqual([174, 66.3, 19.8]);
+    expect(hexToHSL("#777")).toStrictEqual([0, 0, 46.7]);
+  });
+
+  it("should return undefined if hex argument is invalid", () => {
+    expect(hexToHSL("123456")).toBeUndefined();
+    expect(hexToHSL("#123456789")).toBeUndefined();
+    expect(hexToHSL("#16")).toBeUndefined();
+  });
+});
+
+describe("passesWcagAAColorContrast", () => {
+  it("should return false for values that always fail", () => {
+    expect(
+      passesWcagAAColorContrast([67, 67, 112], [182, 47, 47], 12, 400)
+    ).toBe(false);
+    expect(
+      passesWcagAAColorContrast([67, 67, 112], [182, 47, 47], 12, 900)
+    ).toBe(false);
+    expect(
+      passesWcagAAColorContrast([67, 67, 112], [182, 47, 47], 20, 400)
+    ).toBe(false);
+  });
+
+  it("should return true for values that always pass", () => {
+    expect(passesWcagAAColorContrast([0, 0, 0], [255, 255, 255], 12, 400)).toBe(
+      true
+    );
+    expect(passesWcagAAColorContrast([0, 0, 0], [255, 255, 255], 12, 900)).toBe(
+      true
+    );
+    expect(passesWcagAAColorContrast([0, 0, 0], [255, 255, 255], 20, 400)).toBe(
+      true
+    );
+  });
+
+  it("should return true or false for values that depend on font size and weight", () => {
+    expect(
+      passesWcagAAColorContrast([67, 67, 112], [229, 154, 154], 12, 400)
+    ).toBe(false);
+    expect(
+      passesWcagAAColorContrast([67, 67, 112], [229, 154, 154], 12, 900)
+    ).toBe(false);
+    expect(
+      passesWcagAAColorContrast([67, 67, 112], [229, 154, 154], 14, 900)
+    ).toBe(true);
+    expect(
+      passesWcagAAColorContrast([67, 67, 112], [229, 154, 154], 20, 400)
+    ).toBe(true);
+  });
+
+  it("should return false for invalid values", () => {
+    expect(
+      passesWcagAAColorContrast([10000, 67, 112], [229, 154, 154], 12, 400)
+    ).toBe(false);
+    expect(passesWcagAAColorContrast([], [], 12, 400)).toBe(false);
+  });
+});

--- a/packages/visual-editor/src/utils/colors.test.ts
+++ b/packages/visual-editor/src/utils/colors.test.ts
@@ -4,7 +4,7 @@ import {
   hexToRGB,
   hexToHSL,
   luminanceFromRGB,
-  passesWcagAAColorContrast,
+  isColorContrastWcagCompliant,
   srgbToHSL,
 } from "./colors.ts";
 
@@ -82,50 +82,50 @@ describe("srgbToHSL", () => {
   });
 });
 
-describe("passesWcagAAColorContrast", () => {
+describe("isColorContrastWcagCompliant", () => {
   it("should return false for values that always fail", () => {
     expect(
-      passesWcagAAColorContrast([67, 67, 112], [182, 47, 47], 12, 400)
+      isColorContrastWcagCompliant([67, 67, 112], [182, 47, 47], 12, 400)
     ).toBe(false);
     expect(
-      passesWcagAAColorContrast([67, 67, 112], [182, 47, 47], 12, 900)
+      isColorContrastWcagCompliant([67, 67, 112], [182, 47, 47], 12, 900)
     ).toBe(false);
     expect(
-      passesWcagAAColorContrast([67, 67, 112], [182, 47, 47], 20, 400)
+      isColorContrastWcagCompliant([67, 67, 112], [182, 47, 47], 20, 400)
     ).toBe(false);
   });
 
   it("should return true for values that always pass", () => {
-    expect(passesWcagAAColorContrast([0, 0, 0], [255, 255, 255], 12, 400)).toBe(
-      true
-    );
-    expect(passesWcagAAColorContrast([0, 0, 0], [255, 255, 255], 12, 900)).toBe(
-      true
-    );
-    expect(passesWcagAAColorContrast([0, 0, 0], [255, 255, 255], 20, 400)).toBe(
-      true
-    );
+    expect(
+      isColorContrastWcagCompliant([0, 0, 0], [255, 255, 255], 12, 400)
+    ).toBe(true);
+    expect(
+      isColorContrastWcagCompliant([0, 0, 0], [255, 255, 255], 12, 900)
+    ).toBe(true);
+    expect(
+      isColorContrastWcagCompliant([0, 0, 0], [255, 255, 255], 20, 400)
+    ).toBe(true);
   });
 
   it("should return true or false for values that depend on font size and weight", () => {
     expect(
-      passesWcagAAColorContrast([67, 67, 112], [229, 154, 154], 12, 400)
+      isColorContrastWcagCompliant([67, 67, 112], [229, 154, 154], 12, 400)
     ).toBe(false);
     expect(
-      passesWcagAAColorContrast([67, 67, 112], [229, 154, 154], 12, 900)
+      isColorContrastWcagCompliant([67, 67, 112], [229, 154, 154], 12, 900)
     ).toBe(false);
     expect(
-      passesWcagAAColorContrast([67, 67, 112], [229, 154, 154], 14, 900)
+      isColorContrastWcagCompliant([67, 67, 112], [229, 154, 154], 14, 900)
     ).toBe(true);
     expect(
-      passesWcagAAColorContrast([67, 67, 112], [229, 154, 154], 20, 400)
+      isColorContrastWcagCompliant([67, 67, 112], [229, 154, 154], 20, 400)
     ).toBe(true);
   });
 
   it("should return false for invalid values", () => {
     expect(
-      passesWcagAAColorContrast([10000, 67, 112], [229, 154, 154], 12, 400)
+      isColorContrastWcagCompliant([10000, 67, 112], [229, 154, 154], 12, 400)
     ).toBe(false);
-    expect(passesWcagAAColorContrast([], [], 12, 400)).toBe(false);
+    expect(isColorContrastWcagCompliant([], [], 12, 400)).toBe(false);
   });
 });

--- a/packages/visual-editor/src/utils/colors.ts
+++ b/packages/visual-editor/src/utils/colors.ts
@@ -1,0 +1,172 @@
+// Based on https://css-tricks.com/converting-color-spaces-in-javascript/
+export const hexToRGB = (h: string) => {
+  let r: string, g: string, b: string;
+
+  if (h.length == 4) {
+    // 3 character hex
+    r = "0x" + h[1] + h[1];
+    g = "0x" + h[2] + h[2];
+    b = "0x" + h[3] + h[3];
+  } else if (h.length == 7) {
+    // 6 character hex
+    r = "0x" + h[1] + h[2];
+    g = "0x" + h[3] + h[4];
+    b = "0x" + h[5] + h[6];
+  } else {
+    return;
+  }
+
+  return [+r, +g, +b];
+};
+
+// Based on https://css-tricks.com/converting-color-spaces-in-javascript/
+export const hexToHSL = (H: string) => {
+  // Convert hex to RGB first
+  const rgb = hexToRGB(H);
+  if (!rgb || rgb.length !== 3) {
+    return;
+  }
+
+  const r = rgb[0] / 255;
+  const g = rgb[1] / 255;
+  const b = rgb[2] / 255;
+  const cmin = Math.min(r, g, b),
+    cmax = Math.max(r, g, b),
+    delta = cmax - cmin;
+
+  let h = 0,
+    s = 0,
+    l = 0;
+
+  if (delta == 0) h = 0;
+  else if (cmax == r) h = ((g - b) / delta) % 6;
+  else if (cmax == g) h = (b - r) / delta + 2;
+  else h = (r - g) / delta + 4;
+
+  h = Math.round(h * 60);
+
+  if (h < 0) h += 360;
+
+  l = (cmax + cmin) / 2;
+  s = delta == 0 ? 0 : delta / (1 - Math.abs(2 * l - 1));
+  s = +(s * 100).toFixed(1);
+  l = +(l * 100).toFixed(1);
+
+  return [h, s, l];
+};
+
+export const luminanceFromRGB = (rgb: number[]) => {
+  if (rgb.length !== 3 || rgb.some((v) => v > 255 || v < 0)) {
+    return;
+  }
+
+  const a = rgb.map((v) => {
+    v /= 255;
+    return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+  });
+  return a[0] * 0.2126 + a[1] * 0.7152 + a[2] * 0.0722;
+};
+
+// WCAG 2.1 SC 1.4.3 (Level AA)
+// The visual presentation of text and images of text has a contrast ratio of at least 4.5:1, except for
+// large-scale text and images of large-scale text have a contrast ratio of at least 3:1.
+// Large-scale text means with at least 18 point or 14 point bold.
+// Based on https://dev.to/alvaromontoro/building-your-own-color-contrast-checker-4j7o
+export const passesWcagAAColorContrast = (
+  rgb1: number[],
+  rgb2: number[],
+  fontSizePt: number,
+  fontWeight: number
+) => {
+  if (rgb1.length !== 3 || rgb2.length !== 3) {
+    return false;
+  }
+
+  const l1 = luminanceFromRGB(rgb1),
+    l2 = luminanceFromRGB(rgb2);
+
+  if (l1 === undefined || l2 === undefined) {
+    return false;
+  }
+
+  const contrast =
+    l1 > l2 ? (l2 + 0.05) / (l1 + 0.05) : (l1 + 0.05) / (l2 + 0.05);
+
+  if (fontSizePt >= 18 || (fontSizePt >= 14 && fontWeight >= 700)) {
+    return contrast < 1 / 3;
+  } else {
+    return contrast < 1 / 4.5;
+  }
+};
+
+// getContrastingColor returns the hex code for white or black
+// depending on which meets WCAG color contrast standards
+export const getContrastingColor = (
+  hexColor: string,
+  fontSizePx: number,
+  fontWeight: number
+) => {
+  const rgb = hexToRGB(hexColor);
+  const fontSizePt = fontSizePx * 0.75;
+
+  if (!rgb) {
+    return "#000000"; // error, fall back to black
+  }
+
+  // Compare with black
+  if (passesWcagAAColorContrast(rgb, [0, 0, 0], fontSizePt, fontWeight)) {
+    return "#000000";
+  }
+
+  // Compare with white
+  if (passesWcagAAColorContrast(rgb, [255, 255, 255], fontSizePt, fontWeight)) {
+    return "#FFFFFF";
+  }
+
+  // If neither is sufficiently contrasting, or there was an error, fallback to black
+  return `#000000`;
+};
+
+export const srgbToHsl = (r: number, g: number, b: number) => {
+  // based on https://codepen.io/himonoye/pen/ByaraoG?editors=1111
+  // and https://www.rapidtables.com/convert/color/rgb-to-hsl.html
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const sum = min + max;
+  const diff = max - min;
+
+  let sat = 0,
+    hue = 0,
+    light = 0;
+
+  // Calculate Luminance
+  light = sum / 2;
+
+  // Calculate Saturation
+  switch (diff) {
+    case 0:
+      break;
+    default:
+      sat = diff / (1 - Math.abs(2 * light - 1));
+  }
+
+  // Calculate Hue
+  switch (max) {
+    case min:
+      break;
+    case r:
+      hue = (g - b) / diff + (g < b ? 6 : 0);
+      break;
+    case g:
+      hue = (b - r) / diff + 2;
+      break;
+    case b:
+      hue = (r - g) / diff + 4;
+  }
+
+  hue = Math.floor(hue * 60 * 10) / 10;
+  sat = Math.floor(sat * 100 * 10) / 10;
+  light = Math.floor(light * 100 * 10) / 10;
+
+  return [hue, sat, light];
+};

--- a/packages/visual-editor/src/utils/colors.ts
+++ b/packages/visual-editor/src/utils/colors.ts
@@ -66,7 +66,7 @@ export const hexToHSL = (H: string): number[] | undefined => {
 };
 
 /**
- * luminanceFromRGB converts a rgb color string to
+ * luminanceFromRGB returns the luminance value from an rgb color
  * @param H [r, g, b]
  * @returns {number | undefined} luminance if conversion succeeds
  */
@@ -83,7 +83,7 @@ export const luminanceFromRGB = (rgb: number[]): number | undefined => {
 };
 
 /**
- * passesWcagAAColorContrast checks color contrast based on WCAG 2.1 SC 1.4.3 (Level AA)
+ * isColorContrastWcagCompliant checks color contrast based on WCAG 2.1 SC 1.4.3 (Level AA)
  * The visual presentation of text and images of text has a contrast ratio of at least 4.5:1, except for
  * large-scale text and images of large-scale text have a contrast ratio of at least 3:1.
  * Large-scale text means with at least 18 point or 14 point bold.
@@ -93,7 +93,7 @@ export const luminanceFromRGB = (rgb: number[]): number | undefined => {
  * @param fontWeight the numerical font weight (100-900)
  * @returns {boolean} Whether the colors pass the contrast check. False if color conversion fails
  */
-export const passesWcagAAColorContrast = (
+export const isColorContrastWcagCompliant = (
   rgb1: number[],
   rgb2: number[],
   fontSizePt: number,
@@ -143,12 +143,14 @@ export const getContrastingColor = (
   }
 
   // Compare with black
-  if (passesWcagAAColorContrast(rgb, [0, 0, 0], fontSizePt, fontWeight)) {
+  if (isColorContrastWcagCompliant(rgb, [0, 0, 0], fontSizePt, fontWeight)) {
     return "#000000";
   }
 
   // Compare with white
-  if (passesWcagAAColorContrast(rgb, [255, 255, 255], fontSizePt, fontWeight)) {
+  if (
+    isColorContrastWcagCompliant(rgb, [255, 255, 255], fontSizePt, fontWeight)
+  ) {
     return "#FFFFFF";
   }
 

--- a/packages/visual-editor/src/utils/colors.ts
+++ b/packages/visual-editor/src/utils/colors.ts
@@ -1,17 +1,22 @@
-// Based on https://css-tricks.com/converting-color-spaces-in-javascript/
-export const hexToRGB = (h: string) => {
+/**
+ * hexToRGB converts a hex color to rgb
+ * @param H hex string beginning with '#'
+ * @returns {number[] | undefined} [r, g, b] if conversion succeeds
+ */
+export const hexToRGB = (H: string): number[] | undefined => {
+  // Based on https://css-tricks.com/converting-color-spaces-in-javascript/
   let r: string, g: string, b: string;
 
-  if (h.length == 4) {
+  if (H.length == 4) {
     // 3 character hex
-    r = "0x" + h[1] + h[1];
-    g = "0x" + h[2] + h[2];
-    b = "0x" + h[3] + h[3];
-  } else if (h.length == 7) {
+    r = "0x" + H[1] + H[1];
+    g = "0x" + H[2] + H[2];
+    b = "0x" + H[3] + H[3];
+  } else if (H.length == 7) {
     // 6 character hex
-    r = "0x" + h[1] + h[2];
-    g = "0x" + h[3] + h[4];
-    b = "0x" + h[5] + h[6];
+    r = "0x" + H[1] + H[2];
+    g = "0x" + H[3] + H[4];
+    b = "0x" + H[5] + H[6];
   } else {
     return;
   }
@@ -19,8 +24,13 @@ export const hexToRGB = (h: string) => {
   return [+r, +g, +b];
 };
 
-// Based on https://css-tricks.com/converting-color-spaces-in-javascript/
-export const hexToHSL = (H: string) => {
+/**
+ * hexToHSL converts a hex color to hsl
+ * @param H hex string beginning with '#'
+ * @returns {number[] | undefined} [h, s, l] if conversion succeeds
+ */
+export const hexToHSL = (H: string): number[] | undefined => {
+  // Based on https://css-tricks.com/converting-color-spaces-in-javascript/
   // Convert hex to RGB first
   const rgb = hexToRGB(H);
   if (!rgb || rgb.length !== 3) {
@@ -55,7 +65,12 @@ export const hexToHSL = (H: string) => {
   return [h, s, l];
 };
 
-export const luminanceFromRGB = (rgb: number[]) => {
+/**
+ * luminanceFromRGB converts a rgb color string to
+ * @param H [r, g, b]
+ * @returns {number | undefined} luminance if conversion succeeds
+ */
+export const luminanceFromRGB = (rgb: number[]): number | undefined => {
   if (rgb.length !== 3 || rgb.some((v) => v > 255 || v < 0)) {
     return;
   }
@@ -67,17 +82,24 @@ export const luminanceFromRGB = (rgb: number[]) => {
   return a[0] * 0.2126 + a[1] * 0.7152 + a[2] * 0.0722;
 };
 
-// WCAG 2.1 SC 1.4.3 (Level AA)
-// The visual presentation of text and images of text has a contrast ratio of at least 4.5:1, except for
-// large-scale text and images of large-scale text have a contrast ratio of at least 3:1.
-// Large-scale text means with at least 18 point or 14 point bold.
-// Based on https://dev.to/alvaromontoro/building-your-own-color-contrast-checker-4j7o
+/**
+ * passesWcagAAColorContrast checks color contrast based on WCAG 2.1 SC 1.4.3 (Level AA)
+ * The visual presentation of text and images of text has a contrast ratio of at least 4.5:1, except for
+ * large-scale text and images of large-scale text have a contrast ratio of at least 3:1.
+ * Large-scale text means with at least 18 point or 14 point bold.
+ * @param rgb1 [r, g, b]
+ * @param rgb2 [r, g, b]
+ * @param fontSizePt the font size in points
+ * @param fontWeight the numerical font weight (100-900)
+ * @returns {boolean} Whether the colors pass the contrast check. False if color conversion fails
+ */
 export const passesWcagAAColorContrast = (
   rgb1: number[],
   rgb2: number[],
   fontSizePt: number,
   fontWeight: number
-) => {
+): boolean => {
+  // Based on https://dev.to/alvaromontoro/building-your-own-color-contrast-checker-4j7o
   if (rgb1.length !== 3 || rgb2.length !== 3) {
     return false;
   }
@@ -99,13 +121,20 @@ export const passesWcagAAColorContrast = (
   }
 };
 
-// getContrastingColor returns the hex code for white or black
-// depending on which meets WCAG color contrast standards
+/**
+ * getContrastingColor returns the hex code for white or black
+ * depending on which meets WCAG color contrast standards
+ * @param hexColor the hex string to contrast with
+ * @param fontSizePx the font size in pixels (determines minimum contrast ratio)
+ * @param fontWeight the numerical font weight (100-900) (determines minimum contrast ratio)
+ * @returns '#000000' or '#FFFFFF' depending on which has proper contrast with hexColor.
+ *          '#000000' is returned if color conversions fail.
+ */
 export const getContrastingColor = (
   hexColor: string,
   fontSizePx: number,
   fontWeight: number
-) => {
+): string => {
   const rgb = hexToRGB(hexColor);
   const fontSizePt = fontSizePx * 0.75;
 
@@ -127,9 +156,21 @@ export const getContrastingColor = (
   return `#000000`;
 };
 
-export const srgbToHsl = (r: number, g: number, b: number) => {
+/**
+ * srgbToHSL converts srgb colors to hsl values.
+ * @param rgb [r, g, b]
+ * @returns {number[] | undefined} [h, s, l] if conversion suceeeds
+ */
+export const srgbToHSL = (rgb: number[]): number[] | undefined => {
   // based on https://codepen.io/himonoye/pen/ByaraoG?editors=1111
   // and https://www.rapidtables.com/convert/color/rgb-to-hsl.html
+  if (rgb.length !== 3 || rgb.some((v) => v > 1 || v < 0)) {
+    return;
+  }
+
+  const r = rgb[0],
+    g = rgb[1],
+    b = rgb[2];
   const max = Math.max(r, g, b);
   const min = Math.min(r, g, b);
   const sum = min + max;

--- a/packages/visual-editor/src/utils/index.ts
+++ b/packages/visual-editor/src/utils/index.ts
@@ -18,6 +18,8 @@ export {
   backgroundColors,
   defaultThemeTailwindExtensions,
   type BackgroundStyle,
+  letterSpacingOptions,
+  textTransformOptions,
 } from "./themeConfigOptions.ts";
 export { applyAnalytics } from "./applyAnalytics.ts";
 export { getPageMetadata } from "./getPageMetadata.ts";

--- a/packages/visual-editor/src/utils/themeConfigOptions.ts
+++ b/packages/visual-editor/src/utils/themeConfigOptions.ts
@@ -130,6 +130,6 @@ export const letterSpacingOptions = [
 export const textTransformOptions = [
   { label: "Normal", value: "none" },
   { label: "Uppercase", value: "uppercase" },
-  { label: "lowercase", value: "lowercase" },
-  { label: "capitalize", value: "capitalize" },
+  { label: "Lowercase", value: "lowercase" },
+  { label: "Capitalize", value: "capitalize" },
 ];

--- a/packages/visual-editor/src/utils/themeConfigOptions.ts
+++ b/packages/visual-editor/src/utils/themeConfigOptions.ts
@@ -101,6 +101,10 @@ export const defaultThemeTailwindExtensions = {
     "palette-primary-dark": "hsl(from var(--colors-palette-primary) h s 20)",
     "palette-secondary-dark":
       "hsl(from var(--colors-palette-secondary) h s 20)",
+    "palette-primary-contrast": "var(--colors-palette-primary-contrast)",
+    "palette-secondary-contrast": "var(--colors-palette-secondary-contrast)",
+    "palette-tertiary-contrast": "var(--colors-palette-tertiary-contrast)",
+    "palette-quaternary-contrast": "var(--colors-palette-quaternary-contrast)",
     gray: {
       100: "#F9F9F9",
       200: "#EDEDED",
@@ -113,3 +117,19 @@ export const defaultThemeTailwindExtensions = {
     },
   },
 };
+
+export const letterSpacingOptions = [
+  { label: "Tighter", value: "-0.05em" },
+  { label: "Tight", value: "-0.025em" },
+  { label: "Normal", value: "0em" },
+  { label: "Wide", value: "0.025em" },
+  { label: "Wider", value: "0.05em" },
+  { label: "Widest", value: "0.1em" },
+];
+
+export const textTransformOptions = [
+  { label: "Normal", value: "none" },
+  { label: "Uppercase", value: "uppercase" },
+  { label: "lowercase", value: "lowercase" },
+  { label: "capitalize", value: "capitalize" },
+];

--- a/starter/theme.config.ts
+++ b/starter/theme.config.ts
@@ -4,20 +4,11 @@ import {
   FontRegistry,
   getFontWeightOptions,
   constructFontSelectOptions,
-  getBorderRadiusOptions,
   getFontSizeOptions,
   getSpacingOptions,
+  letterSpacingOptions,
+  textTransformOptions,
 } from "@yext/visual-editor";
-
-const getColorOptions = () => {
-  return [
-    { label: "Primary", value: "var(--colors-palette-primary)" },
-    { label: "Secondary", value: "var(--colors-palette-secondary)" },
-    { label: "Accent", value: "var(--colors-palette-accent)" },
-    { label: "Text", value: "var(--colors-palette-text)" },
-    { label: "Background", value: "var(--colors-palette-background)" },
-  ];
-};
 
 const fonts: FontRegistry = {
   // other developer defined fonts here
@@ -276,114 +267,93 @@ export const themeConfig: ThemeConfig = {
       },
     },
   },
-  header: {
-    label: "Header",
+  button: {
+    label: "Button",
     styles: {
-      backgroundColor: {
-        label: "Background Color",
+      fontFamily: {
+        label: "Font",
         type: "select",
-        plugin: "backgroundColor",
-        options: getColorOptions(),
-        default: "var(--colors-palette-background)",
-      },
-      linkColor: {
-        label: "Link Color",
-        type: "select",
-        plugin: "colors",
-        options: getColorOptions(),
-        default: "var(--colors-palette-primary)",
-      },
-      linkFontSize: {
-        label: "Link Font Size",
-        type: "select",
-        plugin: "fontSize",
-        options: getFontSizeOptions(false),
-        default: "16px",
-      },
-    },
-  },
-  footer: {
-    label: "Footer",
-    styles: {
-      backgroundColor: {
-        label: "Background Color",
-        type: "select",
-        plugin: "backgroundColor",
-        options: getColorOptions(),
-        default: "var(--colors-palette-background)",
-      },
-      linkColor: {
-        label: "Link Color",
-        type: "select",
-        plugin: "colors",
-        options: getColorOptions(),
-        default: "var(--colors-palette-primary)",
-      },
-      linkFontSize: {
-        label: "Link Font Size",
-        type: "select",
-        plugin: "fontSize",
-        options: getFontSizeOptions(false),
-        default: "16px",
-      },
-    },
-  },
-  link: {
-    label: "Link Styling",
-    styles: {
-      color: {
-        label: "Text Color",
-        type: "select",
-        plugin: "colors",
-        options: getColorOptions(),
-        default: "var(--colors-palette-primary)",
+        plugin: "fontFamily",
+        options: fontOptions,
+        default: "'Open Sans', sans-serif",
       },
       fontSize: {
         label: "Font Size",
         type: "select",
         plugin: "fontSize",
-        options: getFontSizeOptions(false),
-        default: "12px",
-      },
-    },
-  },
-  button: {
-    label: "Button",
-    styles: {
-      borderRadius: {
-        label: "Border Radius",
-        type: "select",
-        plugin: "borderRadius",
-        options: getBorderRadiusOptions(),
+        options: getFontSizeOptions(),
         default: "16px",
       },
       fontWeight: {
         label: "Font Weight",
         type: "select",
         plugin: "fontWeight",
-        options: fontWeightOptions("--fontFamily-body-fontFamily"),
+        options: fontWeightOptions("--fontFamily-button-fontFamily"),
         default: "400",
+      },
+      textTransform: {
+        label: "Text Transform",
+        type: "select",
+        plugin: "textTransform",
+        options: textTransformOptions,
+        default: "none",
+      },
+      letterSpacing: {
+        label: "Letter Spacing",
+        type: "select",
+        plugin: "letterSpacing",
+        options: letterSpacingOptions,
+        default: "0em",
+      },
+    },
+  },
+  link: {
+    label: "Links",
+    styles: {
+      fontFamily: {
+        label: "Font",
+        type: "select",
+        plugin: "fontFamily",
+        options: fontOptions,
+        default: "'Open Sans', sans-serif",
       },
       fontSize: {
         label: "Font Size",
         type: "select",
         plugin: "fontSize",
-        options: getFontSizeOptions(false),
-        default: "12px",
+        options: getFontSizeOptions(),
+        default: "16px",
       },
-      backgroundColor: {
-        label: "Background Color",
+      fontWeight: {
+        label: "Font Weight",
         type: "select",
-        plugin: "backgroundColor",
-        options: getColorOptions(),
-        default: "var(--colors-palette-background)",
+        plugin: "fontWeight",
+        options: fontWeightOptions("--fontFamily-link-fontFamily"),
+        default: "400",
       },
-      textColor: {
-        label: "Text Color",
-        plugin: "colors",
+      textTransform: {
+        label: "Text Transform",
         type: "select",
-        options: getColorOptions(),
-        default: "var(--colors-palette-text)",
+        plugin: "textTransform",
+        options: textTransformOptions,
+        default: "none",
+      },
+      letterSpacing: {
+        label: "Letter Spacing",
+        type: "select",
+        plugin: "letterSpacing",
+        options: letterSpacingOptions,
+        default: "0em",
+      },
+      caret: {
+        label: "Include Caret",
+        type: "select",
+        plugin: "display",
+        options: [
+          { label: "Yes", value: "block" },
+          { label: "No", value: "none" },
+        ],
+        default: "visible",
       },
     },
   },

--- a/starter/theme.config.ts
+++ b/starter/theme.config.ts
@@ -353,7 +353,7 @@ export const themeConfig: ThemeConfig = {
           { label: "Yes", value: "block" },
           { label: "No", value: "none" },
         ],
-        default: "visible",
+        default: "block",
       },
     },
   },


### PR DESCRIPTION
- Adds a few utilities in `packages/visual-editor/src/utils/colors.ts` to support checking color contrast
- Automatically adds either black or white as a contrasting color for each of the 4 colors in the palette
- Updates the theme.config with new fields for Link and Button