### PR TITLE
refactor: image, promo, card

### DIFF
--- a/packages/visual-editor/src/components/puck/Card.tsx
+++ b/packages/visual-editor/src/components/puck/Card.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { ComponentConfig, Fields } from "@measured/puck";
-import { ImageType } from "@yext/pages-components";
 import {
   themeManagerCn,
   useDocument,
@@ -28,6 +27,11 @@ import {
   backgroundColors,
   BackgroundStyle,
 } from "../../utils/themeConfigOptions.js";
+import {
+  ImageWrapperFields,
+  ImageWrapperProps,
+  resolvedImageFields,
+} from "./Image.js";
 
 const PLACEHOLDER_IMAGE_URL = "https://placehold.co/640x360";
 
@@ -51,10 +55,7 @@ interface CardProps {
     text: YextEntityField<string>;
     variant: BodyProps["variant"];
   };
-  image: {
-    image: YextEntityField<any>;
-    aspectRatio: ImageProps["aspectRatio"];
-  };
+  image: ImageWrapperProps;
   cta: {
     entityField: YextEntityField<CTAProps>;
     linkType: CTAProps["linkType"];
@@ -136,18 +137,7 @@ const cardFields: Fields<CardProps> = {
     type: "object",
     label: "Image",
     objectFields: {
-      image: YextEntityFieldSelector<any, ImageType>({
-        label: "Image",
-        filter: {
-          types: ["type.image"],
-        },
-      }),
-      aspectRatio: BasicSelector("Aspect Ratio", [
-        { label: "Auto", value: "auto" },
-        { label: "Square", value: "square" },
-        { label: "Video (16:9)", value: "video" },
-        { label: "Portrait (3:4)", value: "portrait" },
-      ]),
+      ...ImageWrapperFields,
     },
   },
   cta: {
@@ -207,7 +197,9 @@ const CardWrapper = ({
             >
               <Image
                 image={resolvedImage}
-                resize={"auto"}
+                layout={image.layout}
+                width={image.width}
+                height={image.height}
                 aspectRatio={image.aspectRatio}
               />
             </EntityField>
@@ -299,11 +291,14 @@ export const CardComponent: ComponentConfig<CardProps> = {
       image: {
         field: "primaryPhoto",
         constantValue: {
+          height: 360,
+          width: 640,
           url: PLACEHOLDER_IMAGE_URL,
         },
         constantValueEnabled: true,
       },
-      aspectRatio: "auto",
+      layout: "auto",
+      aspectRatio: 1.78,
     },
     cta: {
       entityField: {
@@ -356,6 +351,11 @@ export const CardComponent: ComponentConfig<CardProps> = {
           ...cardFields.body.objectFields,
           weight: BasicSelector("Font Weight", bodyFontWeightOptions),
         },
+      },
+      image: {
+        ...cardFields.image,
+        // @ts-expect-error ts(2322) 'objectFields' does not exist in type 'TextField'
+        objectFields: resolvedImageFields(data.props.image.layout),
       },
     };
   },

--- a/packages/visual-editor/src/components/puck/Card.tsx
+++ b/packages/visual-editor/src/components/puck/Card.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { ComponentConfig, Fields } from "@measured/puck";
-import { Image, ImageProps, ImageType } from "@yext/pages-components";
+import { ImageType } from "@yext/pages-components";
 import {
   themeManagerCn,
   useDocument,
@@ -12,6 +12,8 @@ import {
   BasicSelector,
   BodyProps,
   getFontWeightOverrideOptions,
+  Image,
+  ImageProps,
 } from "../../index.js";
 import { Body } from "./atoms/body.js";
 import { CTA, CTAProps, linkTypeFields } from "./atoms/cta.js";
@@ -22,7 +24,6 @@ import {
   headingOptions,
 } from "./atoms/heading.js";
 import { Section } from "./atoms/section.js";
-import { imageWrapperVariants, ImageWrapperProps } from "./Image.js";
 import {
   backgroundColors,
   BackgroundStyle,
@@ -53,10 +54,8 @@ interface CardProps {
     transform: BodyProps["textTransform"];
   };
   image: {
-    image: YextEntityField<ImageType>;
-    size: ImageWrapperProps["size"];
-    aspectRatio: ImageWrapperProps["aspectRatio"];
-    rounded: ImageWrapperProps["rounded"];
+    image: YextEntityField<any>;
+    aspectRatio: ImageProps["aspectRatio"];
   };
   cta: {
     entityField: YextEntityField<CTAProps>;
@@ -144,24 +143,11 @@ const cardFields: Fields<CardProps> = {
           types: ["type.image"],
         },
       }),
-      size: BasicSelector("Size", [
-        { label: "Small", value: "small" },
-        { label: "Medium", value: "medium" },
-        { label: "Large", value: "large" },
-        { label: "Full Width", value: "full" },
-      ]),
       aspectRatio: BasicSelector("Aspect Ratio", [
         { label: "Auto", value: "auto" },
         { label: "Square", value: "square" },
         { label: "Video (16:9)", value: "video" },
         { label: "Portrait (3:4)", value: "portrait" },
-      ]),
-      rounded: BasicSelector("Rounded Corners", [
-        { label: "None", value: "none" },
-        { label: "Small", value: "small" },
-        { label: "Medium", value: "medium" },
-        { label: "Large", value: "large" },
-        { label: "Full", value: "full" },
       ]),
     },
   },
@@ -220,21 +206,11 @@ const CardWrapper = ({
               fieldId={image.image.field}
               constantValueEnabled={image.image.constantValueEnabled}
             >
-              <div
-                className={themeManagerCn(
-                  imageWrapperVariants({
-                    size: image.size,
-                    rounded: image.rounded,
-                    aspectRatio: image.aspectRatio,
-                  }),
-                  "overflow-hidden"
-                )}
-              >
-                <Image
-                  image={resolvedImage}
-                  className="w-full h-full object-cover"
-                />
-              </div>
+              <Image
+                image={resolvedImage}
+                resize={"auto"}
+                aspectRatio={image.aspectRatio}
+              />
             </EntityField>
           </div>
         )}
@@ -330,15 +306,10 @@ export const CardComponent: ComponentConfig<CardProps> = {
       image: {
         field: "primaryPhoto",
         constantValue: {
-          alternateText: "",
-          height: 360,
-          width: 640,
           url: PLACEHOLDER_IMAGE_URL,
         },
         constantValueEnabled: true,
       },
-      size: "full",
-      rounded: "none",
       aspectRatio: "auto",
     },
     cta: {

--- a/packages/visual-editor/src/components/puck/Card.tsx
+++ b/packages/visual-editor/src/components/puck/Card.tsx
@@ -13,6 +13,9 @@ import {
   getFontWeightOverrideOptions,
   Image,
   ImageProps,
+  ImageWrapperFields,
+  ImageWrapperProps,
+  resolvedImageFields,
 } from "../../index.js";
 import { Body } from "./atoms/body.js";
 import { CTA, CTAProps, linkTypeFields } from "./atoms/cta.js";
@@ -27,11 +30,6 @@ import {
   backgroundColors,
   BackgroundStyle,
 } from "../../utils/themeConfigOptions.js";
-import {
-  ImageWrapperFields,
-  ImageWrapperProps,
-  resolvedImageFields,
-} from "./Image.js";
 
 const PLACEHOLDER_IMAGE_URL = "https://placehold.co/640x360";
 

--- a/packages/visual-editor/src/components/puck/Image.tsx
+++ b/packages/visual-editor/src/components/puck/Image.tsx
@@ -6,7 +6,6 @@ import {
   EntityField,
   YextEntityField,
   YextEntityFieldSelector,
-  BasicSelector,
   Image,
   ImageProps,
 } from "../../index.js";
@@ -15,40 +14,69 @@ import { ImageType } from "@yext/pages-components";
 const PLACEHOLDER_IMAGE_URL = "https://placehold.co/640x360";
 
 interface ImageWrapperProps {
-  image: YextEntityField<any>;
-  resize: ImageProps["resize"];
-  aspectRatio: ImageProps["aspectRatio"];
+  image: YextEntityField<ImageType>;
+  layout: ImageProps["layout"];
+  aspectRatio?: ImageProps["aspectRatio"];
   width?: ImageProps["width"];
+  height?: ImageProps["height"];
 }
 
-const imageWrapperFields: Fields<ImageWrapperProps> = {
+const ImageWrapperFields: Fields<ImageWrapperProps> = {
   image: YextEntityFieldSelector<any, ImageType>({
     label: "Image",
     filter: {
       types: ["type.image"],
     },
   }),
-  resize: {
-    label: "Size",
+  layout: {
+    label: "Layout",
     type: "radio",
     options: [
       { label: "Auto", value: "auto" },
       { label: "Fixed", value: "fixed" },
     ],
   },
-  aspectRatio: BasicSelector("Aspect Ratio", [
-    { label: "Auto", value: "auto" },
-    { label: "Square", value: "square" },
-    { label: "Video (16:9)", value: "video" },
-    { label: "Portrait (3:4)", value: "portrait" },
-  ]),
+  width: {
+    label: "Width",
+    type: "number",
+    min: 0,
+  },
+  height: {
+    label: "Height",
+    type: "number",
+    min: 0,
+  },
+  aspectRatio: {
+    label: "Aspect Ratio",
+    type: "select",
+    options: [
+      { label: "1:1", value: 1 },
+      { label: "5:4", value: 1.25 },
+      { label: "4:3", value: 1.33 },
+      { label: "3:2", value: 1.5 },
+      { label: "5:3", value: 1.67 },
+      { label: "16:9", value: 1.78 },
+      { label: "2:1", value: 2 },
+      { label: "3:1", value: 3 },
+      { label: "4:1", value: 4 },
+      { label: "4:5", value: 0.8 },
+      { label: "3:4", value: 0.75 },
+      { label: "2:3", value: 0.67 },
+      { label: "3:5", value: 0.6 },
+      { label: "9:16", value: 0.56 },
+      { label: "1:2", value: 0.5 },
+      { label: "1:3", value: 0.33 },
+      { label: "1:4", value: 0.25 },
+    ],
+  },
 };
 
 const ImageWrapper: React.FC<ImageWrapperProps> = ({
   image: imageField,
-  resize,
+  layout,
   aspectRatio,
   width,
+  height,
 }) => {
   const document = useDocument();
   const resolvedImage = resolveYextEntityField<ImageProps["image"]>(
@@ -68,43 +96,55 @@ const ImageWrapper: React.FC<ImageWrapperProps> = ({
     >
       <Image
         image={resolvedImage}
-        resize={resize}
+        layout={layout}
         aspectRatio={aspectRatio}
         width={width}
+        height={height}
       />
     </EntityField>
   );
 };
 
+const resolvedImageFields = (layout: "auto" | "fixed") => {
+  return {
+    image: ImageWrapperFields["image"],
+    layout: ImageWrapperFields["layout"],
+    ...(layout === "auto"
+      ? {
+          aspectRatio: ImageWrapperFields["aspectRatio"],
+        }
+      : {
+          height: ImageWrapperFields["height"],
+          width: ImageWrapperFields["width"],
+        }),
+  };
+};
+
 const ImageWrapperComponent: ComponentConfig<ImageWrapperProps> = {
   label: "Image",
-  fields: imageWrapperFields,
+  fields: ImageWrapperFields,
   defaultProps: {
     image: {
       field: "primaryPhoto",
       constantValue: {
         url: PLACEHOLDER_IMAGE_URL,
+        height: 360,
+        width: 640,
       },
       constantValueEnabled: true,
     },
-    resize: "auto",
-    aspectRatio: "auto",
-    width: 640,
+    layout: "auto",
+    aspectRatio: 1.78,
   },
   resolveFields(data) {
-    if (data.props.resize === "fixed") {
-      return {
-        ...imageWrapperFields,
-        width: {
-          label: "Width",
-          type: "number",
-          min: 0,
-        },
-      };
-    }
-    return imageWrapperFields;
+    return resolvedImageFields(data.props.layout);
   },
   render: (props) => <ImageWrapper {...props} />,
 };
 
-export { ImageWrapperComponent as ImageWrapper, type ImageWrapperProps };
+export {
+  ImageWrapperComponent as ImageWrapper,
+  type ImageWrapperProps,
+  ImageWrapperFields,
+  resolvedImageFields,
+};

--- a/packages/visual-editor/src/components/puck/Promo.tsx
+++ b/packages/visual-editor/src/components/puck/Promo.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { ComponentConfig, Fields } from "@measured/puck";
-import { Image, ImageProps, ImageType } from "@yext/pages-components";
 import {
   themeManagerCn,
   useDocument,
@@ -10,12 +9,14 @@ import {
   YextEntityFieldSelector,
   FontSizeSelector,
   BasicSelector,
+  ImageProps,
+  Image,
 } from "../../index.js";
 import { Body, BodyProps } from "./atoms/body.js";
 import { CTA, CTAProps, linkTypeFields } from "./atoms/cta.js";
 import { Heading, HeadingProps } from "./atoms/heading.js";
 import { Section } from "./atoms/section.js";
-import { imageWrapperVariants, ImageWrapperProps } from "./Image.js";
+import { ImageType } from "@yext/pages-components";
 
 const PLACEHOLDER_IMAGE_URL = "https://placehold.co/640x360";
 
@@ -32,10 +33,8 @@ interface PromoProps {
     transform: BodyProps["textTransform"];
   };
   image: {
-    image: YextEntityField<ImageType>;
-    size: ImageWrapperProps["size"];
-    aspectRatio: ImageWrapperProps["aspectRatio"];
-    rounded: ImageWrapperProps["rounded"];
+    image: YextEntityField<any>;
+    aspectRatio: ImageProps["aspectRatio"];
   };
   cta: {
     entityField: YextEntityField<CTAProps>;
@@ -98,24 +97,11 @@ const promoFields: Fields<PromoProps> = {
           types: ["type.image"],
         },
       }),
-      size: BasicSelector("Size", [
-        { label: "Small", value: "small" },
-        { label: "Medium", value: "medium" },
-        { label: "Large", value: "large" },
-        { label: "Full Width", value: "full" },
-      ]),
       aspectRatio: BasicSelector("Aspect Ratio", [
         { label: "Auto", value: "auto" },
         { label: "Square", value: "square" },
         { label: "Video (16:9)", value: "video" },
         { label: "Portrait (3:4)", value: "portrait" },
-      ]),
-      rounded: BasicSelector("Rounded Corners", [
-        { label: "None", value: "none" },
-        { label: "Small", value: "small" },
-        { label: "Medium", value: "medium" },
-        { label: "Large", value: "large" },
-        { label: "Full", value: "full" },
       ]),
     },
   },
@@ -171,21 +157,11 @@ const PromoWrapper: React.FC<PromoProps> = ({
             fieldId={image.image.field}
             constantValueEnabled={image.image.constantValueEnabled}
           >
-            <div
-              className={themeManagerCn(
-                imageWrapperVariants({
-                  size: image.size,
-                  rounded: image.rounded,
-                  aspectRatio: image.aspectRatio,
-                }),
-                "overflow-hidden"
-              )}
-            >
-              <Image
-                image={resolvedImage}
-                className="w-full h-full object-cover"
-              />
-            </div>
+            <Image
+              image={resolvedImage}
+              resize={"auto"}
+              aspectRatio={image.aspectRatio}
+            />
           </EntityField>
         )}
         <div className="flex flex-col justify-center gap-y-4 md:gap-y-8 p-4 md:px-16 md:py-0 w-full break-all">
@@ -244,15 +220,10 @@ export const PromoComponent: ComponentConfig<PromoProps> = {
       image: {
         field: "primaryPhoto",
         constantValue: {
-          alternateText: "",
-          height: 360,
-          width: 640,
           url: PLACEHOLDER_IMAGE_URL,
         },
         constantValueEnabled: true,
       },
-      size: "medium",
-      rounded: "none",
       aspectRatio: "auto",
     },
     cta: {

--- a/packages/visual-editor/src/components/puck/Promo.tsx
+++ b/packages/visual-editor/src/components/puck/Promo.tsx
@@ -18,15 +18,16 @@ import {
 import { CTA, CTAProps } from "./atoms/cta.js";
 import { Heading, HeadingProps, headingOptions } from "./atoms/heading.js";
 import { Section } from "./atoms/section.js";
-import { ImageType } from "@yext/pages-components";
+import {
+  ImageWrapperFields,
+  ImageWrapperProps,
+  resolvedImageFields,
+} from "./Image.js";
 
 const PLACEHOLDER_IMAGE_URL = "https://placehold.co/640x360";
 
 interface PromoProps {
-  image: {
-    image: YextEntityField<any>;
-    aspectRatio: ImageProps["aspectRatio"];
-  };
+  image: ImageWrapperProps;
   title: {
     text: YextEntityField<string>;
     level: HeadingProps["level"];
@@ -51,18 +52,7 @@ const promoFields: Fields<PromoProps> = {
     type: "object",
     label: "Image",
     objectFields: {
-      image: YextEntityFieldSelector<any, ImageType>({
-        label: "Image",
-        filter: {
-          types: ["type.image"],
-        },
-      }),
-      aspectRatio: BasicSelector("Aspect Ratio", [
-        { label: "Auto", value: "auto" },
-        { label: "Square", value: "square" },
-        { label: "Video (16:9)", value: "video" },
-        { label: "Portrait (3:4)", value: "portrait" },
-      ]),
+      ...ImageWrapperFields,
     },
   },
   title: {
@@ -179,7 +169,9 @@ const PromoWrapper: React.FC<PromoProps> = ({
           >
             <Image
               image={resolvedImage}
-              resize={"auto"}
+              layout={image.layout}
+              width={image.width}
+              height={image.height}
               aspectRatio={image.aspectRatio}
             />
           </EntityField>
@@ -216,11 +208,14 @@ const Promo: ComponentConfig<PromoProps> = {
       image: {
         field: "primaryPhoto",
         constantValue: {
+          height: 360,
+          width: 640,
           url: PLACEHOLDER_IMAGE_URL,
         },
         constantValueEnabled: true,
       },
-      aspectRatio: "auto",
+      layout: "auto",
+      aspectRatio: 1.78,
     },
     title: {
       text: {
@@ -251,6 +246,15 @@ const Promo: ComponentConfig<PromoProps> = {
       backgroundColor: backgroundColors.background1.value,
       orientation: "left",
     },
+  },
+  resolveFields(data) {
+    return {
+      ...promoFields,
+      image: {
+        ...promoFields.image,
+        objectFields: resolvedImageFields(data.props.image.layout),
+      },
+    };
   },
   render: (props) => <PromoWrapper {...props} />,
 };

--- a/packages/visual-editor/src/components/puck/Promo.tsx
+++ b/packages/visual-editor/src/components/puck/Promo.tsx
@@ -14,15 +14,13 @@ import {
   BackgroundStyle,
   backgroundColors,
   BodyProps,
+  ImageWrapperFields,
+  ImageWrapperProps,
+  resolvedImageFields,
 } from "../../index.js";
 import { CTA, CTAProps } from "./atoms/cta.js";
 import { Heading, HeadingProps, headingOptions } from "./atoms/heading.js";
 import { Section } from "./atoms/section.js";
-import {
-  ImageWrapperFields,
-  ImageWrapperProps,
-  resolvedImageFields,
-} from "./Image.js";
 
 const PLACEHOLDER_IMAGE_URL = "https://placehold.co/640x360";
 

--- a/packages/visual-editor/src/components/puck/atoms/image.tsx
+++ b/packages/visual-editor/src/components/puck/atoms/image.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import { Image as ImageComponent, ImageType } from "@yext/pages-components";
+import { cva, VariantProps } from "class-variance-authority";
+import { themeManagerCn } from "../../../index.ts";
+
+export const imageVariants = cva("", {
+  variants: {
+    aspectRatio: {
+      auto: "aspect-auto",
+      square: "aspect-square",
+      video: "aspect-video",
+      portrait: "aspect-[3/4]",
+    },
+  },
+  defaultVariants: {
+    aspectRatio: "auto",
+  },
+});
+
+export interface ImageProps extends VariantProps<typeof imageVariants> {
+  image: ImageType;
+  resize: "auto" | "fixed";
+  width?: number;
+}
+
+export const Image: React.FC<ImageProps> = ({
+  image,
+  resize,
+  aspectRatio,
+  width,
+}) => {
+  return (
+    <div
+      className={themeManagerCn(
+        imageVariants({ aspectRatio }),
+        "overflow-hidden"
+      )}
+      style={{ width: resize === "auto" ? "auto" : `${width}px` }}
+    >
+      <ImageComponent image={image} className="w-full h-full object-cover" />
+    </div>
+  );
+};

--- a/packages/visual-editor/src/components/puck/atoms/image.tsx
+++ b/packages/visual-editor/src/components/puck/atoms/image.tsx
@@ -1,43 +1,40 @@
 import * as React from "react";
 import { Image as ImageComponent, ImageType } from "@yext/pages-components";
-import { cva, VariantProps } from "class-variance-authority";
 import { themeManagerCn } from "../../../index.ts";
 
-export const imageVariants = cva("", {
-  variants: {
-    aspectRatio: {
-      auto: "aspect-auto",
-      square: "aspect-square",
-      video: "aspect-video",
-      portrait: "aspect-[3/4]",
-    },
-  },
-  defaultVariants: {
-    aspectRatio: "auto",
-  },
-});
-
-export interface ImageProps extends VariantProps<typeof imageVariants> {
+export interface ImageProps {
   image: ImageType;
-  resize: "auto" | "fixed";
+  layout: "auto" | "fixed";
+  aspectRatio?: number;
   width?: number;
+  height?: number;
 }
 
 export const Image: React.FC<ImageProps> = ({
   image,
-  resize,
+  layout,
   aspectRatio,
   width,
+  height,
 }) => {
   return (
-    <div
-      className={themeManagerCn(
-        imageVariants({ aspectRatio }),
-        "overflow-hidden"
+    <div className={themeManagerCn("overflow-hidden w-full")}>
+      {layout === "auto" && aspectRatio ? (
+        <ImageComponent
+          image={image}
+          layout={"aspect"}
+          aspectRatio={aspectRatio}
+          className="object-cover w-full"
+        />
+      ) : (
+        <ImageComponent
+          image={image}
+          layout={"fixed"}
+          width={width}
+          height={height}
+          className="object-cover"
+        />
       )}
-      style={{ width: resize === "auto" ? "auto" : `${width}px` }}
-    >
-      <ImageComponent image={image} className="w-full h-full object-cover" />
     </div>
   );
 };

--- a/packages/visual-editor/src/components/puck/atoms/index.ts
+++ b/packages/visual-editor/src/components/puck/atoms/index.ts
@@ -3,3 +3,4 @@ export { Button, type ButtonProps, buttonVariants } from "./button.tsx";
 export { CTA, type CTAProps } from "./cta.tsx";
 export { Heading, type HeadingProps, headingVariants } from "./heading.tsx";
 export { Section, type SectionProps, sectionVariants } from "./section.tsx";
+export { Image, type ImageProps, imageVariants } from "./image.tsx";

--- a/packages/visual-editor/src/components/puck/atoms/index.ts
+++ b/packages/visual-editor/src/components/puck/atoms/index.ts
@@ -3,4 +3,4 @@ export { Button, type ButtonProps, buttonVariants } from "./button.tsx";
 export { CTA, type CTAProps } from "./cta.tsx";
 export { Heading, type HeadingProps, headingVariants } from "./heading.tsx";
 export { Section, type SectionProps, sectionVariants } from "./section.tsx";
-export { Image, type ImageProps, imageVariants } from "./image.tsx";
+export { Image, type ImageProps } from "./image.tsx";

--- a/packages/visual-editor/src/components/puck/index.ts
+++ b/packages/visual-editor/src/components/puck/index.ts
@@ -13,7 +13,12 @@ export { Header, type HeaderProps } from "./Header.tsx";
 export { HeadingText, type HeadingTextProps } from "./HeadingText.tsx";
 export { HoursTable, type HoursTableProps } from "./HoursTable.tsx";
 export { HoursStatus, type HoursStatusProps } from "./HoursStatus.tsx";
-export { ImageWrapper, type ImageWrapperProps } from "./Image.tsx";
+export {
+  ImageWrapper,
+  type ImageWrapperProps,
+  ImageWrapperFields,
+  resolvedImageFields,
+} from "./Image.tsx";
 export { Phone, type PhoneProps } from "./Phone.tsx";
 export { Promo, type PromoProps } from "./Promo.tsx";
 export { TextList, type TextListProps } from "./TextList.tsx";

--- a/packages/visual-editor/src/components/puck/registry/components.ts
+++ b/packages/visual-editor/src/components/puck/registry/components.ts
@@ -26,6 +26,11 @@ export const ui: Registry["items"] = [
     files: [{ path: "atoms/cta.tsx", type: "registry:component" }],
   },
   {
+    name: "image",
+    type: "registry:component",
+    files: [{ path: "atoms/image.tsx", type: "registry:component" }],
+  },
+  {
     name: "section",
     type: "registry:component",
     files: [{ path: "atoms/section.tsx", type: "registry:component" }],
@@ -139,6 +144,7 @@ export const ui: Registry["items"] = [
   {
     name: "Image",
     type: "registry:ui",
+    registryDependencies: ["image"],
     files: [{ path: "Image.tsx", type: "registry:ui" }],
   },
   {
@@ -155,12 +161,12 @@ export const ui: Registry["items"] = [
     name: "Promo",
     type: "registry:ui",
     files: [{ path: "Promo.tsx", type: "registry:ui" }],
-    registryDependencies: ["section", "heading", "cta", "body", "Image"],
+    registryDependencies: ["section", "heading", "cta", "body", "image"],
   },
   {
     name: "Card",
     type: "registry:ui",
     files: [{ path: "Card.tsx", type: "registry:ui" }],
-    registryDependencies: ["section", "heading", "cta", "body", "Image"],
+    registryDependencies: ["section", "heading", "cta", "body", "image"],
   },
 ];

--- a/packages/visual-editor/src/internal/puck/constant-value-fields/Image.tsx
+++ b/packages/visual-editor/src/internal/puck/constant-value-fields/Image.tsx
@@ -10,24 +10,9 @@ export const IMAGE_CONSTANT_CONFIG: CustomField<ImageType> = {
       value: value,
       fields: [
         {
-          label: "Alternate Text",
-          field: "alternateText",
-          fieldType: "text",
-        },
-        {
           label: "URL",
           field: "url",
           fieldType: "text",
-        },
-        {
-          label: "Height",
-          field: "height",
-          fieldType: "number",
-        },
-        {
-          label: "Width",
-          field: "width",
-          fieldType: "number",
         },
       ],
     });


### PR DESCRIPTION
Added an image atom to be used in other components. 

If `auto` -> fills entire container matching aspectRatio
if `fixed` -> user can set the width and height


Video of how excessively large fixed width is handled
https://github.com/user-attachments/assets/53285f5a-12a9-4cbf-83b4-df9609b4656a


