### PR TITLE
feat: add categories to the components list

### DIFF
--- a/starter/src/ve.config.tsx
+++ b/starter/src/ve.config.tsx
@@ -1,4 +1,4 @@
-import { type Config } from "@measured/puck";
+import { DropZone, type Config } from "@measured/puck";
 import "@yext/visual-editor/style.css";
 import "./index.css";
 import {
@@ -67,33 +67,67 @@ type MainProps = {
   TextList: TextListProps;
 };
 
+const components: Config<MainProps>["components"] = {
+  Banner,
+  Card,
+  Promo,
+  Flex,
+  Grid,
+  Address,
+  BodyText,
+  CTA,
+  Emails,
+  GetDirections,
+  HeadingText,
+  HoursStatus,
+  HoursTable,
+  ImageWrapper,
+  Phone,
+  TextList,
+  Header,
+  Footer,
+  Directory,
+  Breadcrumbs,
+};
+
+const pageSections: (keyof MainProps)[] = ["Banner", "Card", "Promo"];
+
+const layoutBlocks: (keyof MainProps)[] = ["Flex", "Grid"];
+
+const contentBlocks: (keyof MainProps)[] = [
+  "Address",
+  "BodyText",
+  "CTA",
+  "Emails",
+  "GetDirections",
+  "HeadingText",
+  "HoursStatus",
+  "HoursTable",
+  "ImageWrapper",
+  "Phone",
+  "TextList",
+];
+
 // All the available components for locations
 export const mainConfig: Config<MainProps> = {
-  components: {
-    Address,
-    Banner,
-    BodyText,
-    Breadcrumbs,
-    Card,
-    CTA,
-    Directory,
-    Emails,
-    Flex,
-    Footer,
-    GetDirections,
-    Grid,
-    Header,
-    HeadingText,
-    HoursTable,
-    HoursStatus,
-    ImageWrapper,
-    Phone,
-    Promo,
-    TextList,
+  components,
+  categories: {
+    pageSections: {
+      title: "Page Sections",
+      components: pageSections,
+    },
+    layoutBlocks: {
+      title: "Layout Blocks",
+      components: layoutBlocks,
+    },
+    contentBlocks: {
+      title: "Content Blocks",
+      components: contentBlocks,
+    },
   },
   root: {
-    render: ({ children }) => {
-      return <>{children}</>;
+    render: () => {
+      return <DropZone zone="root" disallow={contentBlocks} />;
     },
   },
 };

--- a/starter/src/ve.config.tsx
+++ b/starter/src/ve.config.tsx
@@ -1,4 +1,4 @@
-import { DropZone, type Config } from "@measured/puck";
+import { type Config } from "@measured/puck";
 import "@yext/visual-editor/style.css";
 import "./index.css";
 import {
@@ -126,8 +126,8 @@ export const mainConfig: Config<MainProps> = {
     },
   },
   root: {
-    render: () => {
-      return <DropZone zone="root" disallow={contentBlocks} />;
+    render: ({ children }) => {
+      return <>{children}</>;
     },
   },
 };


### PR DESCRIPTION
- adds categories to the sidebar (any item not in a category will be in "other"
- disallows using content blocks at the root level 

<img width="1840" alt="Screenshot 2025-03-28 at 5 14 52 PM" src="https://github.com/user-attachments/assets/f37142ef-cac5-47d8-bda4-959f8a1c1fb5" />
