### PR TITLE
fix: update BasicSelector to correctly handle objects

### DIFF
--- a/packages/visual-editor/src/components/editor/BasicSelector.tsx
+++ b/packages/visual-editor/src/components/editor/BasicSelector.tsx
@@ -3,10 +3,19 @@ import { Field, FieldLabel } from "@measured/puck";
 import { ChevronDown } from "lucide-react";
 import { Combobox } from "../../internal/puck/ui/Combobox.tsx";
 
-export const BasicSelector = (
-  label: string,
-  options: { label: string; value: any; color?: string }[]
-): Field => {
+type Option = {
+  label: string;
+  value: any;
+  color?: string;
+};
+
+type StringifiedOption = {
+  label: string;
+  value: string;
+  color?: string;
+};
+
+export const BasicSelector = (label: string, options: Option[]): Field => {
   return {
     type: "custom",
     render: ({
@@ -16,14 +25,34 @@ export const BasicSelector = (
       value: any;
       onChange: (selectedOption: any) => void;
     }) => {
+      if (!options || options.length === 0) {
+        return (
+          <FieldLabel label={label} icon={<ChevronDown size={16} />}>
+            <p>No options available</p>
+          </FieldLabel>
+        );
+      }
+      const stringifiedValue: string = JSON.stringify(value);
+      const stringifiedOptions: StringifiedOption[] = options.map((option) => ({
+        ...option,
+        value: JSON.stringify(option.value) as string,
+      }));
       return (
         <FieldLabel label={label} icon={<ChevronDown size={16} />}>
           <Combobox
             defaultValue={
-              options.find((option) => option.value === value) ?? options[0]
+              stringifiedOptions.find(
+                (option) => option.value === stringifiedValue
+              ) ?? stringifiedOptions[0]
             }
-            onChange={onChange}
-            options={options}
+            onChange={(selectedOption) =>
+              onChange(
+                options.find(
+                  (option) => JSON.stringify(option.value) === selectedOption
+                )?.value ?? options[0].value
+              )
+            }
+            options={stringifiedOptions}
           />
         </FieldLabel>
       );

--- a/packages/visual-editor/src/internal/puck/ui/Combobox.tsx
+++ b/packages/visual-editor/src/internal/puck/ui/Combobox.tsx
@@ -21,7 +21,7 @@ type ComboboxOption = {
 
 type ComboboxProps = {
   defaultValue: ComboboxOption;
-  onChange: (value: any) => void;
+  onChange: (value: string) => void;
   options: Array<ComboboxOption>;
 };
 
@@ -75,10 +75,7 @@ export const Combobox = ({
                   key={option.label}
                   value={option.value.toString()}
                   onSelect={(currentValue) => {
-                    onChange(
-                      options.find((o) => o.value.toString() === currentValue)
-                        ?.value ?? options[0]?.value
-                    );
+                    onChange(currentValue);
                     setOpen(false);
                   }}
                 >


### PR DESCRIPTION
This updates BasicSelector to handle option stringification itself before sending the options to the Combobox. It now correctly compares object values and works as expected. Tested with the Background Color selector.