### PR TITLE
fix: adjust header

### DIFF
--- a/packages/visual-editor/src/components/puck/Header.tsx
+++ b/packages/visual-editor/src/components/puck/Header.tsx
@@ -116,7 +116,7 @@ const HeaderLinks = (props: { links: CTA[] }) => {
         {props.links.map((item: CTA, idx) => (
           <li key={item.link}>
             <Link
-              className="text-header-linkColor text-header-linkFontSize hover:underline"
+              className="text-palette-primary-dark text-link-fontSize hover:underline"
               cta={item}
               eventName={`headerlink${idx}`}
             />
@@ -146,7 +146,7 @@ const HeaderMobileMenu = (props: HeaderMobileMenuProps) => {
           {links.map((item: CTA, idx) => (
             <li key={item.link}>
               <Link
-                className="py-3 block text-header-linkColor text-header-linkFontSize"
+                className="py-3 block text-palette-primary-dark text-link-fontSize"
                 cta={item}
                 eventName={`headermobilelink${idx}`}
               />


### PR DESCRIPTION
Header theme config no longer exists so removed those tailwind usages. 

TODO in future: 
- Use Puck Permissions to prevent a user from dragging more than one Header component onto the page. 