### PR TITLE
fix: image import build error

### DIFF
--- a/packages/visual-editor/src/components/puck/Card.tsx
+++ b/packages/visual-editor/src/components/puck/Card.tsx
@@ -13,14 +13,13 @@ import {
   getFontWeightOverrideOptions,
   Image,
   ImageProps,
-  ImageWrapperFields,
   ImageWrapperProps,
-  resolvedImageFields,
   backgroundColors,
   BackgroundStyle,
   headingLevelOptions,
   HeadingLevel,
 } from "../../index.js";
+import { resolvedImageFields, ImageWrapperFields } from "./Image.js";
 import { Body } from "./atoms/body.js";
 import { CTA, CTAProps, linkTypeFields } from "./atoms/cta.js";
 import { Heading, HeadingProps } from "./atoms/heading.js";

--- a/packages/visual-editor/src/components/puck/Promo.tsx
+++ b/packages/visual-editor/src/components/puck/Promo.tsx
@@ -14,11 +14,10 @@ import {
   BackgroundStyle,
   backgroundColors,
   BodyProps,
-  ImageWrapperFields,
   ImageWrapperProps,
-  resolvedImageFields,
   headingLevelOptions,
 } from "../../index.js";
+import { resolvedImageFields, ImageWrapperFields } from "./Image.js";
 import { CTA, CTAProps } from "./atoms/cta.js";
 import { Heading, HeadingProps } from "./atoms/heading.js";
 import { Section } from "./atoms/section.js";

--- a/packages/visual-editor/src/components/puck/index.ts
+++ b/packages/visual-editor/src/components/puck/index.ts
@@ -13,12 +13,7 @@ export { Header, type HeaderProps } from "./Header.tsx";
 export { HeadingText, type HeadingTextProps } from "./HeadingText.tsx";
 export { HoursTable, type HoursTableProps } from "./HoursTable.tsx";
 export { HoursStatus, type HoursStatusProps } from "./HoursStatus.tsx";
-export {
-  ImageWrapper,
-  type ImageWrapperProps,
-  ImageWrapperFields,
-  resolvedImageFields,
-} from "./Image.tsx";
+export { ImageWrapper, type ImageWrapperProps } from "./Image.tsx";
 export { Phone, type PhoneProps } from "./Phone.tsx";
 export { Promo, type PromoProps } from "./Promo.tsx";
 export { TextList, type TextListProps } from "./TextList.tsx";


### PR DESCRIPTION
Was getting `[vite:css] [postcss] Cannot access 'Ur' before initialization` -- `Ur` is the minified name of `ImageWrapperFields`

I suggested to move the ImageWrapper imports to be from the package in #300 but that was a bad suggestion. Basically, you can't do `../../index.js` imports if the object you are importing is exported at the same level as the file that is importing it. The declaration is hoisted but it's not been initialized yet.

I think we can just do the direct import for now since we're probably adding a YextField helper soon