### PR TITLE
fix: miscellaneous component updates

### DIFF
--- a/packages/visual-editor/src/components/editor/EntityField.test.tsx
+++ b/packages/visual-editor/src/components/editor/EntityField.test.tsx
@@ -3,8 +3,8 @@ import { render, screen, act } from "@testing-library/react";
 import { describe, it, expect, beforeAll } from "vitest";
 import {
   EntityField,
-  EntityFieldProvider,
-  useEntityField,
+  EntityTooltipsProvider,
+  useEntityTooltips,
 } from "./EntityField.tsx";
 
 beforeAll(() => {
@@ -15,10 +15,14 @@ beforeAll(() => {
   };
 });
 
-describe("EntityField component", () => {
+describe("Entity Tooltips", () => {
   it("renders the children and displays a tooltip when tooltips are toggled", () => {
     const TestComponent = () => {
-      const { toggleTooltips } = useEntityField();
+      const tooltipsContext = useEntityTooltips();
+      if (!tooltipsContext) {
+        return;
+      }
+      const { toggleTooltips } = tooltipsContext;
 
       return (
         <>
@@ -31,9 +35,9 @@ describe("EntityField component", () => {
     };
 
     render(
-      <EntityFieldProvider>
+      <EntityTooltipsProvider>
         <TestComponent />
-      </EntityFieldProvider>
+      </EntityTooltipsProvider>
     );
 
     expect(screen.getByText("Content")).toBeDefined();
@@ -45,5 +49,22 @@ describe("EntityField component", () => {
 
     expect(screen.getByText("Content")).toBeDefined();
     expect(screen.queryAllByText("Test Field (123)")).toBeDefined();
+  });
+
+  it("renders the children without the tooltips when outside the context", () => {
+    const TestComponent = () => {
+      return (
+        <>
+          <EntityField displayName="Test Field" fieldId="123">
+            <div>Content</div>
+          </EntityField>
+        </>
+      );
+    };
+
+    render(<TestComponent />);
+
+    expect(screen.getByText("Content")).toBeDefined();
+    expect(screen.queryAllByText("Test Field (123)")).toHaveLength(0);
   });
 });

--- a/packages/visual-editor/src/components/editor/EntityField.tsx
+++ b/packages/visual-editor/src/components/editor/EntityField.tsx
@@ -29,11 +29,13 @@ export const EntityField = ({
   constantValueEnabled,
   children,
 }: EntityFieldProps) => {
-  const { tooltipsVisible } = useEntityField();
+  const tooltipsContext = useEntityTooltips();
 
-  if (constantValueEnabled) {
+  if (!tooltipsContext || constantValueEnabled) {
     return children;
   }
+
+  const { tooltipsVisible } = tooltipsContext;
 
   let tooltipContent = "";
   if (displayName && fieldId) {
@@ -45,7 +47,7 @@ export const EntityField = ({
   }
 
   return (
-    <div>
+    <div id="tooltip" className="ve-w-fit">
       <TooltipProvider>
         <Tooltip open={!!tooltipContent && tooltipsVisible}>
           <TooltipTrigger asChild>
@@ -69,16 +71,16 @@ export const EntityField = ({
   );
 };
 
-type EntityFieldContextProps = {
+type EntityTooltipsContext = {
   tooltipsVisible: boolean;
   toggleTooltips: () => void;
 };
 
-const EntityFieldContext = createContext<EntityFieldContextProps | undefined>(
+const EntityTooltipsContext = createContext<EntityTooltipsContext | undefined>(
   undefined
 );
 
-export const EntityFieldProvider = ({
+export const EntityTooltipsProvider = ({
   children,
 }: {
   children: React.ReactNode;
@@ -90,19 +92,12 @@ export const EntityFieldProvider = ({
   };
 
   return (
-    <EntityFieldContext.Provider value={{ tooltipsVisible, toggleTooltips }}>
+    <EntityTooltipsContext.Provider value={{ tooltipsVisible, toggleTooltips }}>
       {children}
-    </EntityFieldContext.Provider>
+    </EntityTooltipsContext.Provider>
   );
 };
 
-export const useEntityField = () => {
-  const context = useContext(EntityFieldContext);
-  if (!context) {
-    return {
-      tooltipsVisible: false,
-      toggleTooltips: () => {},
-    };
-  }
-  return context;
+export const useEntityTooltips = () => {
+  return useContext(EntityTooltipsContext);
 };

--- a/packages/visual-editor/src/components/editor/EntityField.tsx
+++ b/packages/visual-editor/src/components/editor/EntityField.tsx
@@ -47,7 +47,7 @@ export const EntityField = ({
   }
 
   return (
-    <div id="tooltip" className="ve-w-fit">
+    <div className="ve-w-fit">
       <TooltipProvider>
         <Tooltip open={!!tooltipContent && tooltipsVisible}>
           <TooltipTrigger asChild>

--- a/packages/visual-editor/src/components/puck/Footer.tsx
+++ b/packages/visual-editor/src/components/puck/Footer.tsx
@@ -153,6 +153,7 @@ const FooterLinks = (props: { links: CTAType[] }) => {
             eventName={`footerlink${idx}`}
             variant="link"
             alwaysHideCaret={true}
+            className="pr-8"
           />
         </li>
       ))}

--- a/packages/visual-editor/src/components/puck/atoms/button.tsx
+++ b/packages/visual-editor/src/components/puck/atoms/button.tsx
@@ -5,7 +5,7 @@ import { themeManagerCn } from "../../../index.ts";
 import { srgbToHSL } from "./srgbToHSL.ts";
 
 const buttonVariants = cva(
-  "components h-fit flex items-center justify-center whitespace-nowrap transition-colors",
+  "components h-fit flex items-center justify-center whitespace-nowrap",
   {
     variants: {
       variant: {
@@ -112,6 +112,8 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           if (hsl?.[2] && !isNaN(hsl[2])) {
             setHasDarkBackground(hsl[2] < 50);
           }
+        } else {
+          setHasDarkBackground(false);
         }
       }
 

--- a/packages/visual-editor/src/internal/components/InternalLayoutEditor.tsx
+++ b/packages/visual-editor/src/internal/components/InternalLayoutEditor.tsx
@@ -9,7 +9,7 @@ import {
 import React from "react";
 import { useState, useRef, useCallback } from "react";
 import { TemplateMetadata } from "../types/templateMetadata.ts";
-import { EntityFieldProvider } from "../../components/editor/EntityField.tsx";
+import { EntityTooltipsProvider } from "../../components/editor/EntityField.tsx";
 import { LayoutSaveState } from "../types/saveState.ts";
 import { LayoutHeader } from "../puck/components/LayoutHeader.tsx";
 import { DevLogger } from "../../utils/devLogger.ts";
@@ -158,7 +158,7 @@ export const InternalLayoutEditor = ({
   }, [puckConfig]);
 
   return (
-    <EntityFieldProvider>
+    <EntityTooltipsProvider>
       <Puck
         config={puckConfigWithRootFields}
         data={{}} // we use puckInitialHistory instead
@@ -177,6 +177,6 @@ export const InternalLayoutEditor = ({
           ),
         }}
       />
-    </EntityFieldProvider>
+    </EntityTooltipsProvider>
   );
 };

--- a/packages/visual-editor/src/internal/components/InternalThemeEditor.tsx
+++ b/packages/visual-editor/src/internal/components/InternalThemeEditor.tsx
@@ -2,7 +2,7 @@ import { Puck, Config, InitialHistory } from "@measured/puck";
 import React, { useCallback, useEffect, useRef } from "react";
 import { useState } from "react";
 import { TemplateMetadata } from "../types/templateMetadata.ts";
-import { EntityFieldProvider } from "../../components/editor/EntityField.tsx";
+import { EntityTooltipsProvider } from "../../components/editor/EntityField.tsx";
 import { DevLogger } from "../../utils/devLogger.ts";
 import { ThemeEditorRightSidebar } from "../puck/components/theme-editor-sidebars/ThemeEditorRightSidebar.tsx";
 import { ThemeConfig } from "../../utils/themeResolver.ts";
@@ -152,7 +152,7 @@ export const InternalThemeEditor = ({
   }, []);
 
   return (
-    <EntityFieldProvider>
+    <EntityTooltipsProvider>
       <Puck
         config={puckConfig}
         data={{}} // we use puckInitialHistory instead
@@ -184,6 +184,6 @@ export const InternalThemeEditor = ({
           fields: fieldsOverride,
         }}
       />
-    </EntityFieldProvider>
+    </EntityTooltipsProvider>
   );
 };

--- a/packages/visual-editor/src/internal/puck/ui/EntityFieldsToggle.tsx
+++ b/packages/visual-editor/src/internal/puck/ui/EntityFieldsToggle.tsx
@@ -1,7 +1,7 @@
 import "./puck.css";
 import React from "react";
 import { Switch } from "../ui/switch.tsx";
-import { useEntityField } from "../../../components/editor/EntityField.tsx";
+import { useEntityTooltips } from "../../../components/editor/EntityField.tsx";
 import {
   Tooltip,
   TooltipArrow,
@@ -12,7 +12,13 @@ import {
 import "../../../components/editor/index.css";
 
 export const EntityFieldsToggle = () => {
-  const { toggleTooltips, tooltipsVisible } = useEntityField();
+  const tooltipsContext = useEntityTooltips();
+  if (!tooltipsContext) {
+    return;
+  }
+
+  const { toggleTooltips, tooltipsVisible } = tooltipsContext;
+
   return (
     <TooltipProvider>
       <Tooltip>


### PR DESCRIPTION
Entity Field Tooltips
- rename `useEntityField` => `useEntityTooltips` because we also have `useEntityFields`
- if `useEntityTooltips` is undefined (because it is being called on the actual page, not the editor), return children directly rather than adding wrapping divs
- Set the tooltip div to be `width: fit-content` so the outline boxes match the underlying component

Footer
- Add padding to links to match Figma

CTAs/Buttons
- fix issue where background isn't updated when switched from Primary to Secondary
- eliminate unnecessary color transition