### PR TITLE
fix: search combobox options by label

### DIFF
--- a/packages/visual-editor/src/components/editor/BasicSelector.tsx
+++ b/packages/visual-editor/src/components/editor/BasicSelector.tsx
@@ -26,27 +26,32 @@ export const BasicSelector = (label: string, options: Option[]): Field => {
           </FieldLabel>
         );
       }
-      const stringifiedValue: string = JSON.stringify(value);
-      const stringifiedOptions: Option<string>[] = options.map((option) => ({
+
+      // The values that we pass into the Combobox should match the labels
+      // so that the search functionality works as expected.
+      const labelOptions: Option<string>[] = options.map((option) => ({
         ...option,
-        value: JSON.stringify(option.value) as string,
+        value: option.label,
       }));
+
       return (
         <FieldLabel label={label} icon={<ChevronDown size={16} />}>
           <Combobox
             defaultValue={
-              stringifiedOptions.find(
-                (option) => option.value === stringifiedValue
-              ) ?? stringifiedOptions[0]
+              labelOptions[
+                options.findIndex(
+                  (option) =>
+                    JSON.stringify(option.value) === JSON.stringify(value)
+                )
+              ] ?? labelOptions[0]
             }
             onChange={(selectedOption) =>
               onChange(
-                options.find(
-                  (option) => JSON.stringify(option.value) === selectedOption
-                )?.value ?? options[0].value
+                options.find((option) => option.label === selectedOption)
+                  ?.value ?? options[0].value
               )
             }
-            options={stringifiedOptions}
+            options={labelOptions}
           />
         </FieldLabel>
       );


### PR DESCRIPTION
shadcn's combobox component searches by value, but the values we pass in are often completely different from the labels that the user sees. This change passes the options from the BasicSelector into the combobox with the values set to match the labels, since the combobox component doesn't need to know what the actual values are. This way, the combobox searches by the values, it's really searching by labels, which is more intuitive for the user. 

Verified that the search functionality on the BasicSelector works for options with strings, numbers, or objects as values, and it still correctly selects options as expected.

https://github.com/user-attachments/assets/995bf259-a150-42da-bb76-196db2ea152e

