### PR TITLE
fix: mobile footer and entity field wrapper

### DIFF
--- a/packages/visual-editor/src/components/editor/EntityField.tsx
+++ b/packages/visual-editor/src/components/editor/EntityField.tsx
@@ -47,7 +47,7 @@ export const EntityField = ({
   }
 
   return (
-    <div className="ve-w-fit">
+    <div>
       <TooltipProvider>
         <Tooltip open={!!tooltipContent && tooltipsVisible}>
           <TooltipTrigger asChild>

--- a/packages/visual-editor/src/components/puck/Footer.tsx
+++ b/packages/visual-editor/src/components/puck/Footer.tsx
@@ -153,7 +153,7 @@ const FooterLinks = (props: { links: CTAType[] }) => {
             eventName={`footerlink${idx}`}
             variant="link"
             alwaysHideCaret={true}
-            className="pr-8"
+            className="sm:pr-8"
           />
         </li>
       ))}


### PR DESCRIPTION
- the footer padding should not apply on mobile
- the w-fit for the entity field wrapper was causing issue with w-full for CTAs. While this change makes the Entity Field tooltip outline larger than it should be, it's a better UX because the editor's layout matches the live page layout for mobile