### PR TITLE
fix: list constant value input

### DIFF
--- a/packages/visual-editor/src/internal/puck/constant-value-fields/TextList.tsx
+++ b/packages/visual-editor/src/internal/puck/constant-value-fields/TextList.tsx
@@ -23,7 +23,8 @@ export const TEXT_LIST_CONSTANT_CONFIG: CustomField<string[]> = {
       onChange(updatedItems);
     };
 
-    const addItem = () => {
+    const addItem = (e?: MouseEvent) => {
+      e?.preventDefault();
       setLocalItems([...localItems, ""]);
     };
 


### PR DESCRIPTION
Some change seems to have broken the input -- when you clicked the plus button, it switched back to entity fields