### PR TITLE
fix: rename phone atom and wrapper

### DIFF
--- a/packages/visual-editor/src/components/puck/NearbyLocations.tsx
+++ b/packages/visual-editor/src/components/puck/NearbyLocations.tsx
@@ -11,7 +11,7 @@ import {
   ThemeOptions,
   HeadingLevel,
   Section,
-  Phone,
+  PhoneAtom,
   fetchNearbyLocations,
 } from "../../index.js";
 import { useQuery } from "@tanstack/react-query";
@@ -195,7 +195,7 @@ const LocationCard = ({
           </div>
         )}
         {mainPhone && (
-          <Phone
+          <PhoneAtom
             phoneNumber={mainPhone}
             format={cards.phoneNumberFormat}
             includeHyperlink={cards.phoneNumberLink}

--- a/packages/visual-editor/src/components/puck/Phone.tsx
+++ b/packages/visual-editor/src/components/puck/Phone.tsx
@@ -6,16 +6,16 @@ import {
   EntityField,
   YextEntityField,
   YextEntityFieldSelector,
-  Phone,
+  PhoneAtom,
 } from "../../index.js";
 
-export interface PhoneWrapperProps {
+export interface PhoneProps {
   phone: YextEntityField<string>;
   format?: "domestic" | "international";
   includeHyperlink: boolean;
 }
 
-const PhoneFields: Fields<PhoneWrapperProps> = {
+const PhoneFields: Fields<PhoneProps> = {
   phone: YextEntityFieldSelector({
     label: "Phone Number",
     filter: {
@@ -40,7 +40,7 @@ const PhoneFields: Fields<PhoneWrapperProps> = {
   },
 };
 
-const PhoneComponent: React.FC<PhoneWrapperProps> = ({
+const PhoneComponent: React.FC<PhoneProps> = ({
   phone,
   format,
   includeHyperlink,
@@ -58,7 +58,7 @@ const PhoneComponent: React.FC<PhoneWrapperProps> = ({
       fieldId={phone.field}
       constantValueEnabled={phone.constantValueEnabled}
     >
-      <Phone
+      <PhoneAtom
         phoneNumber={resolvedPhone}
         format={format}
         includeHyperlink={includeHyperlink}
@@ -67,7 +67,7 @@ const PhoneComponent: React.FC<PhoneWrapperProps> = ({
   );
 };
 
-export const PhoneWrapper: ComponentConfig<PhoneWrapperProps> = {
+export const Phone: ComponentConfig<PhoneProps> = {
   label: "Phone",
   fields: PhoneFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/puck/atoms/index.ts
+++ b/packages/visual-editor/src/components/puck/atoms/index.ts
@@ -5,4 +5,4 @@ export { Heading, type HeadingProps, headingVariants } from "./heading.tsx";
 export { Image, type ImageProps } from "./image.tsx";
 export { MaybeLink, type MaybeLinkProps } from "./maybeLink.tsx";
 export { Section, type SectionProps, sectionVariants } from "./section.tsx";
-export { Phone, type PhoneProps } from "./phone.tsx";
+export { PhoneAtom, type PhoneAtomProps } from "./phone.tsx";

--- a/packages/visual-editor/src/components/puck/atoms/phone.tsx
+++ b/packages/visual-editor/src/components/puck/atoms/phone.tsx
@@ -3,13 +3,13 @@ import { CTA, Body } from "../index.ts";
 import * as React from "react";
 import parsePhoneNumber from "libphonenumber-js";
 
-export type PhoneProps = {
+export type PhoneAtomProps = {
   phoneNumber: string;
   format: "domestic" | "international" | undefined;
   includeHyperlink: boolean;
 };
 
-export const Phone = (props: PhoneProps) => {
+export const PhoneAtom = (props: PhoneAtomProps) => {
   const formattedPhoneNumber = formatPhoneNumber(
     props.phoneNumber,
     props.format

--- a/packages/visual-editor/src/components/puck/index.ts
+++ b/packages/visual-editor/src/components/puck/index.ts
@@ -19,7 +19,7 @@ export { HoursStatus, type HoursStatusProps } from "./HoursStatus.tsx";
 export { HoursTable, type HoursTableProps } from "./HoursTable.tsx";
 export { ImageWrapper, type ImageWrapperProps } from "./Image.tsx";
 export { MapboxStaticMap, type MapboxStaticProps } from "./MapboxStaticMap.tsx";
-export { PhoneWrapper, type PhoneWrapperProps } from "./Phone.tsx";
+export { Phone, type PhoneProps } from "./Phone.tsx";
 export {
   PhotoGallerySection,
   type PhotoGallerySectionProps,

--- a/starter/src/ve.config.tsx
+++ b/starter/src/ve.config.tsx
@@ -28,8 +28,8 @@ import {
   HoursStatusProps,
   ImageWrapper,
   ImageWrapperProps,
-  PhoneWrapper,
-  PhoneWrapperProps,
+  Phone,
+  PhoneProps,
   TextList,
   TextListProps,
   Header,
@@ -82,7 +82,7 @@ type MainProps = {
   HoursStatus: HoursStatusProps;
   ImageWrapper: ImageWrapperProps;
   MapboxStaticMap: MapboxStaticProps;
-  PhoneWrapper: PhoneWrapperProps;
+  Phone: PhoneProps;
   ProductsSection: ProductsSectionProps;
   Promo: PromoProps;
   TextList: TextListProps;
@@ -110,7 +110,7 @@ const components: Config<MainProps>["components"] = {
   HoursStatus,
   HoursTable,
   ImageWrapper,
-  PhoneWrapper,
+  Phone,
   TextList,
   Header,
   Footer,
@@ -153,7 +153,7 @@ const contentBlocks: (keyof MainProps)[] = [
   "HoursTable",
   "ImageWrapper",
   "MapboxStaticMap",
-  "PhoneWrapper",
+  "Phone",
   "TextList",
 ];
 


### PR DESCRIPTION
Renames the phone atom to "PhoneAtom"

Changes the name of the Phone component back from "PhoneWrapper" to "Phone"

This prevents breaking sites with a ve.config.ts that had the original "Phone" component