### PR TITLE
fix: console warnings

### DIFF
--- a/packages/visual-editor/src/components/editor/YextEntityFieldSelector.tsx
+++ b/packages/visual-editor/src/components/editor/YextEntityFieldSelector.tsx
@@ -15,6 +15,7 @@ import { TEXT_LIST_CONSTANT_CONFIG } from "../../internal/puck/constant-value-fi
 import { CTA_CONSTANT_CONFIG } from "../../internal/puck/constant-value-fields/CallToAction.tsx";
 import { PHONE_CONSTANT_CONFIG } from "../../internal/puck/constant-value-fields/Phone.tsx";
 import { BasicSelector } from "./BasicSelector.tsx";
+import { useEntityFields } from "../../hooks/useEntityFields.tsx";
 
 const devLogger = new DevLogger();
 
@@ -308,12 +309,14 @@ const EntityFieldInput = <T extends Record<string, any>>({
   onChange,
   value,
 }: InputProps<T>) => {
+  const entityFields = useEntityFields();
+
   const basicSelectorField = React.useMemo(() => {
-    let filteredEntityFields = getFilteredEntityFields(filter);
+    let filteredEntityFields = getFilteredEntityFields(entityFields, filter);
 
     // If there are no direct children, return the parent field if it is a list
     if (filter.directChildrenOf && filteredEntityFields.length === 0) {
-      filteredEntityFields = getFilteredEntityFields({
+      filteredEntityFields = getFilteredEntityFields(entityFields, {
         allowList: [filter.directChildrenOf],
         types: filter.types,
         includeListsOnly: true,
@@ -329,7 +332,7 @@ const EntityFieldInput = <T extends Record<string, any>>({
         };
       }),
     ]);
-  }, [filter]);
+  }, [entityFields, filter]);
 
   return (
     <div className={"ve-inline-block ve-w-full ve-pt-4"}>

--- a/packages/visual-editor/src/components/puck/Address.tsx
+++ b/packages/visual-editor/src/components/puck/Address.tsx
@@ -13,7 +13,6 @@ import {
   YextEntityField,
   YextEntityFieldSelector,
   CTA,
-  Body,
 } from "../../index.ts";
 
 export type AddressProps = {
@@ -57,12 +56,12 @@ const AddressComponent = ({
           fieldId={addressField.field}
           constantValueEnabled={addressField.constantValueEnabled}
         >
-          <Body variant="base">
+          <div className="font-body-fontFamily font-body-fontWeight text-body-fontSize">
             <RenderAddress
               address={address as AddressType}
               lines={[["line1"], ["line2", "city", "region", "postalCode"]]}
             />
-          </Body>
+          </div>
           {coordinates && showGetDirections && (
             <CTA
               link={coordinates}

--- a/packages/visual-editor/src/components/puck/registry/components.ts
+++ b/packages/visual-editor/src/components/puck/registry/components.ts
@@ -72,7 +72,7 @@ export const ui: Registry["items"] = [
   {
     name: "Address",
     type: "registry:ui",
-    registryDependencies: ["body", "cta"],
+    registryDependencies: ["cta"],
     files: [{ path: "Address.tsx", type: "registry:ui" }],
   },
   {

--- a/packages/visual-editor/src/internal/utils/getFilteredEntityFields.test.ts
+++ b/packages/visual-editor/src/internal/utils/getFilteredEntityFields.test.ts
@@ -1,20 +1,10 @@
-import { describe, test, expect, beforeEach, vi } from "vitest";
+import { describe, test, expect, vi } from "vitest";
 import { getFilteredEntityFields } from "./getFilteredEntityFields.ts";
-import { useEntityFields } from "../../hooks/useEntityFields.tsx";
 import { YextSchemaField } from "../../types/entityFields.ts";
 
-// Mock the useEntityFields hook
-vi.mock("../../hooks/useEntityFields.tsx", () => ({
-  useEntityFields: vi.fn(),
-}));
-
 describe("getFilteredEntityFields", () => {
-  beforeEach(() => {
-    vi.mocked(useEntityFields).mockReturnValue(mockEntityFields);
-  });
-
   test("filters out default disallowed fields", () => {
-    const result = getFilteredEntityFields({ types: [] });
+    const result = getFilteredEntityFields(mockEntityFields, { types: [] });
     expect(result.find((field) => field.name === "uid")).toBeUndefined();
     expect(result.find((field) => field.name === "meta")).toBeUndefined();
     expect(result.find((field) => field.name === "slug")).toBeUndefined();
@@ -27,7 +17,7 @@ describe("getFilteredEntityFields", () => {
   });
 
   test("applies allowList filter", () => {
-    const result = getFilteredEntityFields({
+    const result = getFilteredEntityFields(mockEntityFields, {
       allowList: ["name"],
       types: ["type.string"],
     });
@@ -36,7 +26,7 @@ describe("getFilteredEntityFields", () => {
   });
 
   test("applies disallowList filter", () => {
-    const result = getFilteredEntityFields({
+    const result = getFilteredEntityFields(mockEntityFields, {
       disallowList: ["address"],
       types: ["type.address", "type.string"],
     });
@@ -44,7 +34,9 @@ describe("getFilteredEntityFields", () => {
   });
 
   test("applies types filter", () => {
-    const result = getFilteredEntityFields({ types: ["type.string"] });
+    const result = getFilteredEntityFields(mockEntityFields, {
+      types: ["type.string"],
+    });
     expect(result.map((field) => field.name)).toEqual(
       expect.arrayContaining([
         "id",
@@ -73,7 +65,7 @@ describe("getFilteredEntityFields", () => {
   });
 
   test("handles nested fields correctly", () => {
-    const result = getFilteredEntityFields({
+    const result = getFilteredEntityFields(mockEntityFields, {
       allowList: ["address"],
       types: ["type.string"],
     });
@@ -93,7 +85,7 @@ describe("getFilteredEntityFields", () => {
   });
 
   test("correctly handles top level fields and subfields", () => {
-    const result = getFilteredEntityFields({
+    const result = getFilteredEntityFields(mockEntityFields, {
       types: ["type.image", "type.hours", "type.address"],
     });
 
@@ -114,7 +106,7 @@ describe("getFilteredEntityFields", () => {
   });
 
   test("combines multiple filters", () => {
-    const result = getFilteredEntityFields({
+    const result = getFilteredEntityFields(mockEntityFields, {
       allowList: ["name", "address"],
       types: ["type.string"],
     });
@@ -133,7 +125,7 @@ describe("getFilteredEntityFields", () => {
 
   test("warns about non-existent fields in allowList", () => {
     const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    getFilteredEntityFields({
+    getFilteredEntityFields(mockEntityFields, {
       allowList: ["nonexistent"],
       types: ["type.string"],
     });
@@ -144,14 +136,16 @@ describe("getFilteredEntityFields", () => {
   });
 
   test("handles custom fields correctly", () => {
-    const result = getFilteredEntityFields({ types: ["c_productSection"] });
+    const result = getFilteredEntityFields(mockEntityFields, {
+      types: ["c_productSection"],
+    });
     expect(result.map((field) => field.name)).toEqual(
       expect.arrayContaining(["c_productSection"])
     );
   });
 
   test("handles list fields correctly", () => {
-    const result = getFilteredEntityFields({
+    const result = getFilteredEntityFields(mockEntityFields, {
       allowList: ["emails"],
       types: ["type.string"],
     });
@@ -159,7 +153,7 @@ describe("getFilteredEntityFields", () => {
   });
 
   test("handles list fields with no type filter specified", () => {
-    const result = getFilteredEntityFields({
+    const result = getFilteredEntityFields(mockEntityFields, {
       includeListsOnly: true,
     });
     expect(result.length).toBe(5);
@@ -175,7 +169,7 @@ describe("getFilteredEntityFields", () => {
   });
 
   test("handles directChildrenOf correctly", () => {
-    const result = getFilteredEntityFields({
+    const result = getFilteredEntityFields(mockEntityFields, {
       directChildrenOf: "c_productSection.linkedProducts",
     });
     expect(result.map((field) => field.name)).toEqual(

--- a/packages/visual-editor/src/internal/utils/getFilteredEntityFields.ts
+++ b/packages/visual-editor/src/internal/utils/getFilteredEntityFields.ts
@@ -1,4 +1,3 @@
-import { useEntityFields } from "../../hooks/useEntityFields.tsx";
 import { YextSchemaField } from "../../types/entityFields.ts";
 
 type Only<T, U> = {
@@ -144,14 +143,14 @@ const getEntityTypeToFieldNames = (
 };
 
 export const getFilteredEntityFields = <T extends Record<string, any>>(
+  allEntityFields: YextSchemaField[] | null,
   filter: RenderEntityFieldFilter<T>
 ) => {
-  const entityFields = useEntityFields();
-  if (!entityFields) {
+  if (!allEntityFields) {
     return [];
   }
 
-  let filteredEntityFields = entityFields.filter(
+  let filteredEntityFields = allEntityFields.filter(
     (field) => !DEFAULT_DISALLOWED_ENTITY_FIELDS.includes(field.name)
   );
 


### PR DESCRIPTION
Fixes the React hook inside a hook warning by moving the useContext outside of the useMemo

Fixes the valid DOM nesting because Address was inside a `<p>`