### PR TITLE
fix: guard link in CTA atom

### DIFF
--- a/packages/visual-editor/src/components/puck/atoms/cta.tsx
+++ b/packages/visual-editor/src/components/puck/atoms/cta.tsx
@@ -40,8 +40,8 @@ export const CTA = ({
     >
       <Link
         cta={{
-          link: link ?? "",
-          linkType: linkType,
+          link: link ?? "#",
+          linkType: linkType ?? "URL",
         }}
         eventName={eventName}
         target={target}


### PR DESCRIPTION
Almost everywhere we use the CTA atom, we pass <variable> ?? "#"
as the link.

This simply adds the "#" check into the CTA atom itself so we shouldn't
have issues anymore.

We can remove all of the ?? "#" checks in other places with this change.