### PR TITLE
fix: character escaping breaks editor

### DIFF
--- a/packages/visual-editor/src/internal/hooks/layout/useMessageReceivers.ts
+++ b/packages/visual-editor/src/internal/hooks/layout/useMessageReceivers.ts
@@ -3,7 +3,6 @@ import { DevLogger } from "../../../utils/devLogger.ts";
 import { LayoutSaveState } from "../../types/saveState.ts";
 import { useReceiveMessage, TARGET_ORIGINS } from "../useMessage.ts";
 import { useCommonMessageSenders } from "../useMessageSenders.ts";
-import { jsonFromEscapedJsonString } from "../../utils/jsonFromEscapedJsonString.ts";
 
 const devLogger = new DevLogger();
 
@@ -25,7 +24,7 @@ export const useLayoutMessageReceivers = (localDev: boolean) => {
     if (payload?.history) {
       receivedLayoutSaveState = {
         hash: payload.hash,
-        history: jsonFromEscapedJsonString(payload.history),
+        history: JSON.parse(payload.history),
       } as LayoutSaveState;
     }
     devLogger.logData("LAYOUT_SAVE_STATE", receivedLayoutSaveState);

--- a/packages/visual-editor/src/internal/hooks/theme/useMessageReceivers.ts
+++ b/packages/visual-editor/src/internal/hooks/theme/useMessageReceivers.ts
@@ -3,7 +3,6 @@ import { DevLogger } from "../../../utils/devLogger.ts";
 import { ThemeSaveState } from "../../types/themeData.ts";
 import { useReceiveMessage, TARGET_ORIGINS } from "../useMessage.ts";
 import { useCommonMessageSenders } from "../useMessageSenders.ts";
-import { jsonFromEscapedJsonString } from "../../utils/jsonFromEscapedJsonString.ts";
 
 const devLogger = new DevLogger();
 
@@ -27,7 +26,7 @@ export const useThemeMessageReceivers = (localDev: boolean) => {
     if (payload?.history) {
       receivedThemeSaveState = {
         hash: payload.hash,
-        history: { data: jsonFromEscapedJsonString(payload.history) },
+        history: { data: JSON.parse(payload.history) },
       } as ThemeSaveState;
     }
     devLogger.logData("THEME_SAVE_STATE", receivedThemeSaveState);

--- a/packages/visual-editor/src/internal/hooks/useMessageReceivers.ts
+++ b/packages/visual-editor/src/internal/hooks/useMessageReceivers.ts
@@ -6,7 +6,6 @@ import {
 } from "../types/templateMetadata.ts";
 import { DevLogger } from "../../utils/devLogger.ts";
 import { Config, Data } from "@measured/puck";
-import { jsonFromEscapedJsonString } from "../utils/jsonFromEscapedJsonString.ts";
 import { useCommonMessageSenders } from "./useMessageSenders.ts";
 import { ThemeData } from "../types/themeData.ts";
 
@@ -86,7 +85,7 @@ export const useCommonMessageReceivers = (
   });
 
   useReceiveMessage("getLayoutData", TARGET_ORIGINS, (send, payload) => {
-    const data = jsonFromEscapedJsonString(payload.layoutData) as Data;
+    const data = JSON.parse(payload.layoutData) as Data;
     devLogger.logData("LAYOUT_DATA", data);
     setLayoutData(data);
     setLayoutDataFetched(true);
@@ -98,9 +97,7 @@ export const useCommonMessageReceivers = (
 
   useReceiveMessage("getThemeData", TARGET_ORIGINS, (send, payload) => {
     const payloadString = payload as unknown as string;
-    const themeData = payloadString
-      ? jsonFromEscapedJsonString(payloadString)
-      : {};
+    const themeData = payloadString ? JSON.parse(payloadString) : {};
     devLogger.logData("THEME_DATA", themeData);
     setThemeData(themeData as ThemeData);
     setThemeDataFetched(true);

--- a/packages/visual-editor/src/internal/utils/jsonFromEscapedJsonString.ts
+++ b/packages/visual-editor/src/internal/utils/jsonFromEscapedJsonString.ts
@@ -1,9 +1,0 @@
-/**
- * jsonFromEscapedJsonString parses a string into a JSON object,
- * and fixes escaped "" characters
- * @param escapedJsonString a stringified JSON object
- * @returns a parsed JSON object
- */
-export const jsonFromEscapedJsonString = (escapedJsonString: string) => {
-  return JSON.parse(escapedJsonString.replace(/\\"/g, '"'));
-};


### PR DESCRIPTION
`jsonFromEscapedJsonString` isn't necessary anymore and was actually breaking the editor if `"` was in a text field

Tested on a live site loading the editor with published+save state for layout+theme