### PR TITLE
fix: don't render sample text if field is mapped

### DIFF
--- a/packages/visual-editor/src/components/TextList.tsx
+++ b/packages/visual-editor/src/components/TextList.tsx
@@ -26,14 +26,12 @@ const TextListComponent: React.FC<TextListProps> = ({
   list: textListField,
 }) => {
   const document = useDocument();
-  let resolvedTextList: any = resolveYextEntityField(document, textListField);
+  let resolvedTextList = resolveYextEntityField(document, textListField);
 
   // When constantValueEnabled is true but no constant values have been set yet, show defaults
   if (
     textListField.constantValueEnabled &&
-    (!textListField.constantValue ||
-      (Array.isArray(textListField.constantValue) &&
-        textListField.constantValue.length === 0))
+    !textListField.constantValue?.length
   ) {
     resolvedTextList = ["Sample text 1", "Sample text 2", "Sample text 3"];
   } else if (resolvedTextList && !Array.isArray(resolvedTextList)) {
@@ -49,7 +47,7 @@ const TextListComponent: React.FC<TextListProps> = ({
     >
       {resolvedTextList && resolvedTextList.length > 0 ? (
         <ul className="components list-disc list-inside text-body-fontSize font-body-fontFamily font-body-fontWeight">
-          {resolvedTextList.map((text: any, index: any) => (
+          {resolvedTextList.map((text, index) => (
             <li key={index} className="mb-2">
               {text}
             </li>

--- a/packages/visual-editor/src/components/TextList.tsx
+++ b/packages/visual-editor/src/components/TextList.tsx
@@ -27,9 +27,17 @@ const TextListComponent: React.FC<TextListProps> = ({
 }) => {
   const document = useDocument();
   let resolvedTextList: any = resolveYextEntityField(document, textListField);
-  if (!resolvedTextList) {
+
+  // When constantValueEnabled is true but no constant values have been set yet, show defaults
+  if (
+    textListField.constantValueEnabled &&
+    (!textListField.constantValue ||
+      (Array.isArray(textListField.constantValue) &&
+        textListField.constantValue.length === 0))
+  ) {
     resolvedTextList = ["Sample text 1", "Sample text 2", "Sample text 3"];
-  } else if (!Array.isArray(resolvedTextList)) {
+  } else if (resolvedTextList && !Array.isArray(resolvedTextList)) {
+    // If there's a value but it's not an array, convert it to array
     resolvedTextList = [resolvedTextList];
   }
 
@@ -39,13 +47,15 @@ const TextListComponent: React.FC<TextListProps> = ({
       fieldId={textListField.field}
       constantValueEnabled={textListField.constantValueEnabled}
     >
-      <ul className="components list-disc list-inside text-body-fontSize font-body-fontFamily font-body-fontWeight">
-        {resolvedTextList.map((text: any, index: any) => (
-          <li key={index} className="mb-2">
-            {text}
-          </li>
-        ))}
-      </ul>
+      {resolvedTextList && resolvedTextList.length > 0 ? (
+        <ul className="components list-disc list-inside text-body-fontSize font-body-fontFamily font-body-fontWeight">
+          {resolvedTextList.map((text: any, index: any) => (
+            <li key={index} className="mb-2">
+              {text}
+            </li>
+          ))}
+        </ul>
+      ) : null}
     </EntityField>
   );
 };


### PR DESCRIPTION
Ran locally and verified that the sample text is only rendered when no field is mapped. Otherwise it will be the mapped value, even if empty.