### PR TITLE
fix: default address to entity value

### DIFF
--- a/packages/visual-editor/src/components/Address.tsx
+++ b/packages/visual-editor/src/components/Address.tsx
@@ -90,7 +90,6 @@ export const Address: ComponentConfig<AddressProps> = {
         postalCode: "",
         countryCode: "",
       },
-      constantValueEnabled: true,
     },
     showGetDirections: true,
   },


### PR DESCRIPTION
Ran locally and verified that the component value default to the entity mapping.