### PR TITLE
feat: add YextField 

### DIFF
--- a/packages/visual-editor/src/components/Address.tsx
+++ b/packages/visual-editor/src/components/Address.tsx
@@ -11,8 +11,8 @@ import {
   resolveYextEntityField,
   EntityField,
   YextEntityField,
-  YextEntityFieldSelector,
   CTA,
+  YextField,
 } from "@yext/visual-editor";
 
 export type AddressProps = {
@@ -21,18 +21,17 @@ export type AddressProps = {
 };
 
 const addressFields: Fields<AddressProps> = {
-  address: YextEntityFieldSelector<any, AddressType>({
-    label: "Address",
+  address: YextField<AddressType>("Address", {
+    type: "entity",
     filter: { types: ["type.address"] },
   }),
-  showGetDirections: {
-    label: "Show Get Directions Link",
+  showGetDirections: YextField("Show Get Directions Link", {
     type: "radio",
     options: [
       { label: "Yes", value: true },
       { label: "No", value: false },
     ],
-  },
+  }),
 };
 
 const AddressComponent = ({

--- a/packages/visual-editor/src/components/Banner.tsx
+++ b/packages/visual-editor/src/components/Banner.tsx
@@ -2,14 +2,11 @@ import * as React from "react";
 import {
   YextEntityField,
   resolveYextEntityField,
-  YextEntityFieldSelector,
   useDocument,
-  BasicSelector,
-  ThemeOptions,
   Body,
   PageSection,
+  YextField,
 } from "@yext/visual-editor";
-
 import { ComponentConfig, Fields } from "@measured/puck";
 import {
   backgroundColors,
@@ -23,21 +20,21 @@ export type BannerSectionProps = {
 };
 
 const bannerSectionFields: Fields<BannerSectionProps> = {
-  text: YextEntityFieldSelector<any, string>({
-    label: "Text",
+  text: YextField<string>("Text", {
+    type: "entity",
     filter: {
       types: ["type.string"],
     },
   }),
-  textAlignment: {
-    label: "Text Alignment",
+  textAlignment: YextField("Text Alignment", {
     type: "radio",
-    options: ThemeOptions.ALIGNMENT,
-  },
-  backgroundColor: BasicSelector(
-    "Background Color",
-    ThemeOptions.DARK_BACKGROUND_COLOR
-  ),
+    options: "ALIGNMENT",
+  }),
+  backgroundColor: YextField("Background Color", {
+    type: "select",
+    hasSearch: true,
+    options: "DARK_BACKGROUND_COLOR",
+  }),
 };
 
 const BannerComponent = ({

--- a/packages/visual-editor/src/components/BodyText.tsx
+++ b/packages/visual-editor/src/components/BodyText.tsx
@@ -7,8 +7,7 @@ import {
   resolveYextEntityField,
   EntityField,
   YextEntityField,
-  YextEntityFieldSelector,
-  ThemeOptions,
+  YextField,
 } from "@yext/visual-editor";
 
 export interface BodyTextProps extends BodyProps {
@@ -16,17 +15,16 @@ export interface BodyTextProps extends BodyProps {
 }
 
 const bodyTextFields: Fields<BodyTextProps> = {
-  text: YextEntityFieldSelector({
-    label: "Text",
+  text: YextField<string>("Text", {
+    type: "entity",
     filter: {
       types: ["type.string"],
     },
   }),
-  variant: {
-    label: "Variant",
+  variant: YextField("Variant", {
     type: "radio",
-    options: ThemeOptions.BODY_VARIANT,
-  },
+    options: "BODY_VARIANT",
+  }),
 };
 
 const BodyTextComponent = React.forwardRef<HTMLParagraphElement, BodyTextProps>(

--- a/packages/visual-editor/src/components/Collection.tsx
+++ b/packages/visual-editor/src/components/Collection.tsx
@@ -9,7 +9,6 @@ import {
   WithId,
 } from "@measured/puck";
 import {
-  OptionalNumberField,
   YextCollection,
   CardCategory,
   themeManagerCn,
@@ -34,8 +33,8 @@ const collectionFields: Fields<CollectionProps> = {
           includeListsOnly: true,
         },
       }),
-      limit: OptionalNumberField({
-        fieldLabel: "Items Limit",
+      limit: YextField("Items Limit", {
+        type: "optionalNumber",
         hideNumberFieldRadioLabel: "All",
         showNumberFieldRadioLabel: "Limit",
         defaultCustomValue: 3,
@@ -130,8 +129,8 @@ export const Collection: ComponentConfig<CollectionProps> = {
         objectFields: {
           // @ts-expect-error ts(2339) objectFields exists
           ...fields.collection.objectFields,
-          limit: OptionalNumberField({
-            fieldLabel: "Items Limit",
+          limit: YextField("Items Limit", {
+            type: "optionalNumber",
             hideNumberFieldRadioLabel: "All",
             showNumberFieldRadioLabel: "Limit",
             defaultCustomValue: 3,

--- a/packages/visual-editor/src/components/Collection.tsx
+++ b/packages/visual-editor/src/components/Collection.tsx
@@ -9,11 +9,11 @@ import {
   WithId,
 } from "@measured/puck";
 import {
-  YextEntityFieldSelector,
   OptionalNumberField,
   YextCollection,
   CardCategory,
   themeManagerCn,
+  YextField,
 } from "@yext/visual-editor";
 
 export interface CollectionProps {
@@ -24,12 +24,11 @@ export interface CollectionProps {
 }
 
 const collectionFields: Fields<CollectionProps> = {
-  collection: {
+  collection: YextField("Collection", {
     type: "object",
-    label: "Collection",
     objectFields: {
-      items: YextEntityFieldSelector<any, Array<any>>({
-        label: "Items",
+      items: YextField<Array<any>>("Items", {
+        type: "entity",
         isCollection: true,
         filter: {
           includeListsOnly: true,
@@ -42,7 +41,7 @@ const collectionFields: Fields<CollectionProps> = {
         defaultCustomValue: 3,
       }),
     },
-  },
+  }),
 };
 
 const CollectionSectionWrapper: React.FC<
@@ -104,24 +103,22 @@ export const Collection: ComponentConfig<CollectionProps> = {
       delete fields.collection.objectFields.limit;
       return {
         ...fields,
-        layout: {
-          label: "Layout",
+        layout: YextField("Layout", {
           type: "radio",
           options: [
             { label: "Flex", value: "flex" },
             { label: "Grid", value: "grid" },
           ],
-        },
+        }),
         ...(data.props.layout === "flex"
           ? {
-              direction: {
-                label: "Direction",
+              direction: YextField("Direction", {
                 type: "radio",
                 options: [
                   { label: "Horizontal", value: "flex-row" },
                   { label: "Vertical", value: "flex-col" },
                 ],
-              },
+              }),
             }
           : {}),
       };

--- a/packages/visual-editor/src/components/CoreInfoSection.tsx
+++ b/packages/visual-editor/src/components/CoreInfoSection.tsx
@@ -13,9 +13,6 @@ import {
   YextEntityField,
   HeadingLevel,
   BackgroundStyle,
-  BasicSelector,
-  ThemeOptions,
-  YextEntityFieldSelector,
   useDocument,
   resolveYextEntityField,
   PageSection,
@@ -26,6 +23,7 @@ import {
   Body,
   PhoneAtom,
   Background,
+  YextField,
 } from "@yext/visual-editor";
 
 export interface CoreInfoSectionProps {
@@ -61,144 +59,134 @@ export interface CoreInfoSectionProps {
 }
 
 const coreInfoSectionFields: Fields<CoreInfoSectionProps> = {
-  styles: {
-    label: "Styles",
+  styles: YextField("Styles", {
     type: "object",
     objectFields: {
-      headingLevel: BasicSelector("Heading Level", ThemeOptions.HEADING_LEVEL),
-      backgroundColor: BasicSelector(
-        "Background Color",
-        ThemeOptions.BACKGROUND_COLOR
-      ),
-    },
-  },
-  address: {
-    label: "Info Column - Address",
-    type: "object",
-    objectFields: {
-      headingText: YextEntityFieldSelector({
-        label: "Heading Text",
+      headingLevel: YextField<string>("Heading Level", {
+        type: "entity",
         filter: {
           types: ["type.string"],
         },
       }),
-      address: YextEntityFieldSelector({
-        label: "Address",
-        filter: {
-          types: ["type.address"],
-        },
+      backgroundColor: YextField("Background Color", {
+        type: "select",
+        hasSearch: true,
+        options: "BACKGROUND_COLOR",
       }),
-      showGetDirectionsLink: {
-        label: "Show Get Directions Link",
+    },
+  }),
+  address: YextField("Info Column - Address", {
+    type: "object",
+    objectFields: {
+      headingText: YextField("Heading Text", {
+        type: "entity",
+        filter: { types: ["type.string"] },
+      }),
+      address: YextField<AddressType>("Address", {
+        type: "entity",
+        filter: { types: ["type.address"] },
+      }),
+      showGetDirectionsLink: YextField("Show Get Directions Link", {
         type: "radio",
         options: [
           { label: "Yes", value: true },
           { label: "No", value: false },
         ],
-      },
+      }),
     },
-  },
-  phoneNumbers: {
-    label: "Info Column - Phone",
+  }),
+  phoneNumbers: YextField("Info Column - Phone", {
     type: "object",
     objectFields: {
-      phoneNumber: {
-        label: "Phone Numbers",
+      phoneNumber: YextField("Phone Numbers", {
         type: "array",
         arrayFields: {
-          number: YextEntityFieldSelector({
-            label: "Phone Number",
+          number: YextField("Phone Number", {
+            type: "entity",
             filter: {
               types: ["type.phone"],
             },
           }),
-          label: {
-            label: "Label",
+          label: YextField("Label", {
             type: "text",
-          },
+          }),
         },
         getItemSummary: (item) => item.label || "Item",
-      },
-      phoneFormat: {
-        label: "Phone Format",
+      }),
+      phoneFormat: YextField("Phone Format", {
         type: "radio",
-        options: ThemeOptions.PHONE_OPTIONS,
-      },
-      includePhoneHyperlink: {
-        label: "Include Phone Hyperlink",
+        options: "PHONE_OPTIONS",
+      }),
+      includePhoneHyperlink: YextField("Include Phone Hyperlink", {
         type: "radio",
         options: [
           { label: "Yes", value: true },
           { label: "No", value: false },
         ],
-      },
+      }),
     },
-  },
-  emails: {
-    label: "Info Column - Emails",
+  }),
+  emails: YextField("Info Column - Emails", {
     type: "object",
     objectFields: {
-      emails: YextEntityFieldSelector({
-        label: "Emails",
+      emails: YextField("Emails", {
+        type: "entity",
         filter: {
           types: ["type.string"],
           includeListsOnly: true,
           allowList: ["emails"],
         },
       }),
-      listLength: { type: "number", label: "List Length", min: 0, max: 3 },
+      listLength: YextField("List Length", { type: "number", min: 0, max: 3 }),
     },
-  },
-  hours: {
-    label: "Info Column - Hours",
+  }),
+  hours: YextField("Info Column - Hours", {
     type: "object",
     objectFields: {
-      headingText: YextEntityFieldSelector({
-        label: "Heading Text",
+      headingText: YextField("Heading Text", {
+        type: "entity",
         filter: {
           types: ["type.string"],
         },
       }),
-      hours: YextEntityFieldSelector({
-        label: "Hours",
+      hours: YextField("Hours", {
+        type: "entity",
         filter: {
           types: ["type.hours"],
         },
       }),
-      startOfWeek: BasicSelector(
-        "Start of the Week",
-        ThemeOptions.HOURS_OPTIONS
-      ),
-      collapseDays: {
-        label: "Collapse Days",
+      startOfWeek: YextField("Start of the Week", {
+        type: "select",
+        hasSearch: true,
+        options: "HOURS_OPTIONS",
+      }),
+      collapseDays: YextField("Collapse Days", {
         type: "radio",
         options: [
           { label: "Yes", value: true },
           { label: "No", value: false },
         ],
-      },
-      showAdditionalHoursText: {
-        label: "Show additional hours text",
+      }),
+      showAdditionalHoursText: YextField("Show additional hours text", {
         type: "radio",
         options: [
           { label: "Yes", value: true },
           { label: "No", value: false },
         ],
-      },
+      }),
     },
-  },
-  services: {
-    label: "Info Column - Services",
+  }),
+  services: YextField("Info Column - Services", {
     type: "object",
     objectFields: {
-      headingText: YextEntityFieldSelector({
-        label: "Heading Text",
+      headingText: YextField("Heading Text", {
+        type: "entity",
         filter: {
           types: ["type.string"],
         },
       }),
-      servicesList: YextEntityFieldSelector({
-        label: "Text List",
+      servicesList: YextField("Text List", {
+        type: "entity",
         filter: {
           types: ["type.string"],
           includeListsOnly: true,
@@ -206,7 +194,7 @@ const coreInfoSectionFields: Fields<CoreInfoSectionProps> = {
         },
       }),
     },
-  },
+  }),
 };
 
 const CoreInfoSectionWrapper = ({

--- a/packages/visual-editor/src/components/CtaWrapper.tsx
+++ b/packages/visual-editor/src/components/CtaWrapper.tsx
@@ -5,10 +5,9 @@ import {
   resolveYextEntityField,
   EntityField,
   YextEntityField,
-  YextEntityFieldSelector,
-  ThemeOptions,
   CTA,
   CTAProps,
+  YextField,
 } from "@yext/visual-editor";
 
 export interface CTAWrapperProps {
@@ -18,17 +17,16 @@ export interface CTAWrapperProps {
 }
 
 const ctaWrapperFields: Fields<CTAWrapperProps> = {
-  entityField: YextEntityFieldSelector({
-    label: "CTA",
+  entityField: YextField("CTA", {
+    type: "entity",
     filter: {
       types: ["type.cta"],
     },
   }),
-  variant: {
-    label: "Variant",
+  variant: YextField("Variant", {
     type: "radio",
-    options: ThemeOptions.CTA_VARIANT,
-  },
+    options: "CTA_VARIANT",
+  }),
 };
 
 const CTAWrapperComponent: React.FC<CTAWrapperProps> = ({

--- a/packages/visual-editor/src/components/Emails.tsx
+++ b/packages/visual-editor/src/components/Emails.tsx
@@ -6,9 +6,9 @@ import {
   resolveYextEntityField,
   EntityField,
   YextEntityField,
-  YextEntityFieldSelector,
   CTA,
   Body,
+  YextField,
 } from "@yext/visual-editor";
 
 export interface EmailsProps {
@@ -18,28 +18,26 @@ export interface EmailsProps {
 }
 
 const EmailsFields: Fields<EmailsProps> = {
-  list: YextEntityFieldSelector({
-    label: "Emails",
+  list: YextField("Emails", {
+    type: "entity",
     filter: {
       types: ["type.string"],
       allowList: ["emails"],
       includeListsOnly: true,
     },
   }),
-  includeHyperlink: {
-    label: "Include Hyperlink",
+  includeHyperlink: YextField("Include Hyperlink", {
     type: "radio",
     options: [
       { label: "Yes", value: true },
       { label: "No", value: false },
     ],
-  },
-  listLength: {
+  }),
+  listLength: YextField("List Length", {
     type: "number",
-    label: "List Length",
     min: 1,
     max: 100,
-  },
+  }),
 };
 
 const EmailsComponent: React.FC<EmailsProps> = ({

--- a/packages/visual-editor/src/components/FAQs.tsx
+++ b/packages/visual-editor/src/components/FAQs.tsx
@@ -4,15 +4,13 @@ import {
   useDocument,
   resolveYextEntityField,
   YextEntityField,
-  YextEntityFieldSelector,
   Body,
-  BasicSelector,
-  ThemeOptions,
   HeadingProps,
   BackgroundStyle,
   PageSection,
   Heading,
   backgroundColors,
+  YextField,
 } from "@yext/visual-editor";
 import {
   Accordion,
@@ -42,43 +40,44 @@ export interface FAQsSectionProps {
 }
 
 const FAQsSectionFields: Fields<FAQsSectionProps> = {
-  styles: {
-    label: "Styles",
+  styles: YextField("Styles", {
     type: "object",
     objectFields: {
-      backgroundColor: BasicSelector(
-        "Background Color",
-        ThemeOptions.BACKGROUND_COLOR
-      ),
+      backgroundColor: YextField("Background Color", {
+        type: "select",
+        hasSearch: true,
+        options: "BACKGROUND_COLOR",
+      }),
     },
-  },
-  sectionHeading: {
+  }),
+  sectionHeading: YextField("Section Heading", {
     type: "object",
-    label: "Section Heading",
     objectFields: {
-      text: YextEntityFieldSelector<any, string>({
-        label: "Text",
+      text: YextField<string>("Text", {
+        type: "entity",
         filter: {
           types: ["type.string"],
         },
       }),
-      level: BasicSelector("Heading Level", ThemeOptions.HEADING_LEVEL),
+      level: YextField("Heading Level", {
+        type: "select",
+        hasSearch: true,
+        options: "HEADING_LEVEL",
+      }),
     },
-  },
-  cards: {
+  }),
+  cards: YextField("FAQs", {
     type: "array",
-    label: "FAQs",
     arrayFields: {
-      question: {
-        label: "Question",
+      question: YextField("Question", {
         type: "text",
-      },
-      answer: {
-        label: "Answer",
-        type: "textarea",
-      },
+      }),
+      answer: YextField("Answer", {
+        type: "text",
+        isMultiline: true,
+      }),
     },
-  },
+  }),
 };
 
 const FAQsSectionWrapper: React.FC<FAQsSectionProps> = ({

--- a/packages/visual-editor/src/components/Flex.tsx
+++ b/packages/visual-editor/src/components/Flex.tsx
@@ -4,11 +4,11 @@ import { layoutFields, layoutProps, layoutVariants } from "./Layout.tsx";
 import {
   backgroundColors,
   themeManagerCn,
-  ThemeOptions,
   Background,
   CardCategory,
   ContentBlockCategory,
   LayoutBlockCategory,
+  YextField,
 } from "@yext/visual-editor";
 
 export interface FlexProps extends layoutProps {
@@ -66,27 +66,24 @@ const FlexContainer = React.forwardRef<HTMLDivElement, FlexProps>(
 FlexContainer.displayName = "Flex";
 
 const flexContainerFields: Fields<FlexProps> = {
-  direction: {
-    label: "Direction",
+  direction: YextField("Direction", {
     type: "radio",
     options: [
       { label: "Horizontal", value: "flex-row" },
       { label: "Vertical", value: "flex-col" },
     ],
-  },
-  justifyContent: {
-    label: "Justify Content",
+  }),
+  justifyContent: YextField("Justify Content", {
     type: "radio",
-    options: ThemeOptions.JUSTIFY_CONTENT,
-  },
-  wrap: {
-    label: "Wrap",
+    options: "JUSTIFY_CONTENT",
+  }),
+  wrap: YextField("Wrap", {
     type: "radio",
     options: [
       { label: "No Wrap", value: "nowrap" },
       { label: "Wrap", value: "wrap" },
     ],
-  },
+  }),
   ...layoutFields,
 };
 

--- a/packages/visual-editor/src/components/Footer.tsx
+++ b/packages/visual-editor/src/components/Footer.tsx
@@ -5,12 +5,11 @@ import {
   Body,
   EntityField,
   useDocument,
-  BasicSelector,
   CTA,
   type BackgroundStyle,
   backgroundColors,
-  ThemeOptions,
   PageSection,
+  YextField,
 } from "@yext/visual-editor";
 import {
   FaFacebook,
@@ -34,10 +33,11 @@ type FooterProps = {
 };
 
 const footerFields: Fields<FooterProps> = {
-  backgroundColor: BasicSelector(
-    "Background Color",
-    ThemeOptions.BACKGROUND_COLOR
-  ),
+  backgroundColor: YextField("Background Color", {
+    type: "select",
+    hasSearch: true,
+    options: "BACKGROUND_COLOR",
+  }),
 };
 
 const Footer: ComponentConfig<FooterProps> = {

--- a/packages/visual-editor/src/components/GetDirections.tsx
+++ b/packages/visual-editor/src/components/GetDirections.tsx
@@ -4,13 +4,12 @@ import { getDirections, Coordinate } from "@yext/pages-components";
 import "@yext/pages-components/style.css";
 import {
   YextEntityField,
-  YextEntityFieldSelector,
   useDocument,
   resolveYextEntityField,
   EntityField,
   CTA,
   CTAProps,
-  ThemeOptions,
+  YextField,
 } from "@yext/visual-editor";
 
 export type GetDirectionsProps = {
@@ -19,15 +18,14 @@ export type GetDirectionsProps = {
 };
 
 const getDirectionsFields: Fields<GetDirectionsProps> = {
-  coordinate: YextEntityFieldSelector<any, Coordinate>({
-    label: "Coordinates",
+  coordinate: YextField<Coordinate>("Coordinates", {
+    type: "entity",
     filter: { types: ["type.coordinate"] },
   }),
-  variant: {
-    label: "Variant",
+  variant: YextField("Variant", {
     type: "radio",
-    options: ThemeOptions.CTA_VARIANT,
-  },
+    options: "CTA_VARIANT",
+  }),
 };
 
 const GetDirectionsComponent = ({

--- a/packages/visual-editor/src/components/Grid.tsx
+++ b/packages/visual-editor/src/components/Grid.tsx
@@ -7,6 +7,7 @@ import {
   ContentBlockCategory,
   CardCategory,
   LayoutBlockCategory,
+  YextField,
 } from "@yext/visual-editor";
 import { layoutFields, layoutProps, layoutVariants } from "./Layout.tsx";
 
@@ -72,12 +73,11 @@ const GridSection = React.forwardRef<HTMLDivElement, GridProps>(
 GridSection.displayName = "GridSection";
 
 const gridSectionFields: Fields<GridProps> = {
-  columns: {
+  columns: YextField("Columns", {
     type: "number",
-    label: "Columns",
     min: 1,
     max: 12,
-  },
+  }),
   ...layoutFields,
 };
 

--- a/packages/visual-editor/src/components/HeadingText.tsx
+++ b/packages/visual-editor/src/components/HeadingText.tsx
@@ -5,11 +5,9 @@ import {
   resolveYextEntityField,
   EntityField,
   YextEntityField,
-  YextEntityFieldSelector,
-  BasicSelector,
-  ThemeOptions,
   Heading,
   HeadingProps,
+  YextField,
 } from "@yext/visual-editor";
 
 export interface HeadingTextProps extends HeadingProps {
@@ -38,13 +36,17 @@ const HeadingTextWrapper = React.forwardRef<
 HeadingTextWrapper.displayName = "HeadingText";
 
 const headingTextFields: Fields<HeadingTextProps> = {
-  text: YextEntityFieldSelector({
-    label: "Text",
+  text: YextField<string>("Text", {
+    type: "entity",
     filter: {
       types: ["type.string"],
     },
   }),
-  level: BasicSelector("Heading Level", ThemeOptions.HEADING_LEVEL),
+  level: YextField("Heading Level", {
+    type: "select",
+    hasSearch: true,
+    options: "HEADING_LEVEL",
+  }),
 };
 
 export const HeadingText: ComponentConfig<HeadingTextProps> = {

--- a/packages/visual-editor/src/components/HeroSection.tsx
+++ b/packages/visual-editor/src/components/HeroSection.tsx
@@ -6,19 +6,17 @@ import {
   resolveYextEntityField,
   EntityField,
   YextEntityField,
-  YextEntityFieldSelector,
-  BasicSelector,
   Image,
   ImageProps,
   ImageWrapperProps,
   backgroundColors,
   BackgroundStyle,
   HeadingLevel,
-  ThemeOptions,
   CTA,
   CTAProps,
   Heading,
   PageSection,
+  YextField,
 } from "@yext/visual-editor";
 import { ImageWrapperFields, resolvedImageFields } from "./Image.js";
 
@@ -66,108 +64,110 @@ const heroSectionFields: Fields<HeroSectionProps> = {
       },
     },
   },
-  businessName: {
-    label: "Business Name",
+  businessName: YextField("Business Name", {
     type: "object",
     objectFields: {
-      entityField: YextEntityFieldSelector({
-        label: "Value",
+      entityField: YextField("Value", {
+        type: "entity",
         filter: {
           types: ["type.string"],
         },
       }),
-      level: BasicSelector("Heading Level", ThemeOptions.HEADING_LEVEL),
+      level: YextField("Heading Level", {
+        type: "select",
+        hasSearch: true,
+        options: "HEADING_LEVEL",
+      }),
     },
-  },
-  localGeoModifier: {
-    label: "Local GeoModifier",
+  }),
+  localGeoModifier: YextField("Local GeoModifier", {
     type: "object",
     objectFields: {
-      entityField: YextEntityFieldSelector({
-        label: "Value",
+      entityField: YextField("Value", {
+        type: "entity",
         filter: {
           types: ["type.string"],
         },
       }),
-      level: BasicSelector("Heading Level", ThemeOptions.HEADING_LEVEL),
+      level: YextField("Heading Level", {
+        type: "select",
+        hasSearch: true,
+        options: "HEADING_LEVEL",
+      }),
     },
-  },
-  hours: {
-    label: "Hours",
+  }),
+  hours: YextField("Hours", {
     type: "object",
     objectFields: {
-      entityField: YextEntityFieldSelector({
-        label: "Hours Field",
+      entityField: YextField("Hours Field", {
+        type: "entity",
         filter: {
           types: ["type.hours"],
         },
       }),
-      showHours: {
-        label: "Show Hours",
+      showHours: YextField("Show Hours", {
         type: "radio",
         options: [
           { label: "Show", value: true },
           { label: "Hide", value: false },
         ],
-      },
+      }),
     },
-  },
-  primaryCta: {
-    label: "Primary CTA",
+  }),
+  primaryCta: YextField("Primary CTA", {
     type: "object",
     objectFields: {
-      entityField: YextEntityFieldSelector({
-        label: "Value",
+      entityField: YextField("Value", {
+        type: "entity",
         filter: {
           types: ["type.cta"],
         },
       }),
-      variant: BasicSelector("Button Variant", ThemeOptions.CTA_VARIANT),
-      showCTA: {
-        label: "CTA",
+      variant: YextField("Button Variant", {
+        type: "radio",
+        options: "CTA_VARIANT",
+      }),
+      showCTA: YextField("CTA", {
         type: "radio",
         options: [
           { label: "Show", value: true },
           { label: "Hide", value: false },
         ],
-      },
+      }),
     },
-  },
-  secondaryCta: {
-    label: "Secondary CTA",
+  }),
+  secondaryCta: YextField("Secondary CTA", {
     type: "object",
     objectFields: {
-      entityField: YextEntityFieldSelector({
-        label: "Value",
+      entityField: YextField("Value", {
+        type: "entity",
         filter: {
           types: ["type.cta"],
         },
       }),
-      variant: BasicSelector("Button Variant", ThemeOptions.CTA_VARIANT),
-      showCTA: {
-        label: "CTA",
+      variant: YextField("Button Variant", {
         type: "radio",
-        options: [
-          { label: "Show", value: true },
-          { label: "Hide", value: false },
-        ],
-      },
+        options: "CTA_VARIANT",
+      }),
     },
-  },
-  styles: {
-    label: "Styles",
+  }),
+  styles: YextField("Styles", {
     type: "object",
     objectFields: {
-      backgroundColor: BasicSelector(
-        "Background Color",
-        ThemeOptions.BACKGROUND_COLOR
-      ),
-      imageOrientation: BasicSelector("Image Orientation", [
-        { label: "Left", value: "left" },
-        { label: "Right", value: "right" },
-      ]),
+      backgroundColor: YextField("Background Color", {
+        type: "select",
+        hasSearch: true,
+        options: "BACKGROUND_COLOR",
+      }),
+      imageOrientation: YextField("Image Orientation", {
+        type: "radio",
+        options: [
+          { label: "Left", value: "left" },
+          { label: "Right", value: "right" },
+        ],
+      }),
     },
-  },
+  }),
 };
 
 const HeroSectionWrapper = ({

--- a/packages/visual-editor/src/components/HoursStatus.tsx
+++ b/packages/visual-editor/src/components/HoursStatus.tsx
@@ -10,7 +10,7 @@ import {
   resolveYextEntityField,
   EntityField,
   YextEntityField,
-  YextEntityFieldSelector,
+  YextField,
 } from "@yext/visual-editor";
 
 export interface HoursStatusProps {
@@ -23,44 +23,40 @@ export interface HoursStatusProps {
 }
 
 const hoursStatusWrapperFields: Fields<HoursStatusProps> = {
-  hours: YextEntityFieldSelector({
-    label: "Hours",
+  hours: YextField("Hours", {
+    type: "entity",
     filter: {
       types: ["type.hours"],
     },
   }),
-  showCurrentStatus: {
+  showCurrentStatus: YextField("Show Current Status", {
     type: "radio",
-    label: "Show Current Status",
     options: [
       { label: "Yes", value: true },
       { label: "No", value: false },
     ],
-  },
-  timeFormat: {
+  }),
+  timeFormat: YextField("Time Format", {
     type: "radio",
-    label: "Time Format",
     options: [
       { label: "12-hour", value: "12h" },
       { label: "24-hour", value: "24h" },
     ],
-  },
-  showDayNames: {
+  }),
+  showDayNames: YextField("Show Day Names", {
     type: "radio",
-    label: "Show Day Names",
     options: [
       { label: "Yes", value: true },
       { label: "No", value: false },
     ],
-  },
-  dayOfWeekFormat: {
+  }),
+  dayOfWeekFormat: YextField("Day of Week Format", {
     type: "radio",
-    label: "Day of Week Format",
     options: [
       { label: "Short", value: "short" },
       { label: "Long", value: "long" },
     ],
-  },
+  }),
 };
 
 const HoursStatusWrapper: React.FC<HoursStatusProps> = ({

--- a/packages/visual-editor/src/components/HoursTable.tsx
+++ b/packages/visual-editor/src/components/HoursTable.tsx
@@ -7,13 +7,11 @@ import {
 } from "@yext/pages-components";
 import "@yext/pages-components/style.css";
 import {
-  BasicSelector,
   EntityField,
   resolveYextEntityField,
-  ThemeOptions,
   useDocument,
   YextEntityField,
-  YextEntityFieldSelector,
+  YextField,
 } from "@yext/visual-editor";
 
 export type HoursTableProps = {
@@ -25,37 +23,38 @@ export type HoursTableProps = {
 };
 
 const hoursTableFields: Fields<HoursTableProps> = {
-  hours: YextEntityFieldSelector({
-    label: "Hours",
+  hours: YextField("Hours", {
+    type: "entity",
     filter: {
       types: ["type.hours"],
     },
   }),
-  startOfWeek: BasicSelector("Start of the Week", ThemeOptions.HOURS_OPTIONS),
-  collapseDays: {
-    label: "Collapse days",
+  startOfWeek: YextField("Start of the Week", {
+    type: "select",
+    hasSearch: true,
+    options: "HOURS_OPTIONS",
+  }),
+  collapseDays: YextField("Collapse days", {
     type: "radio",
     options: [
       { label: "Yes", value: true },
       { label: "No", value: false },
     ],
-  },
-  showAdditionalHoursText: {
-    label: "Show additional hours text",
+  }),
+  showAdditionalHoursText: YextField("Show additional hours text", {
     type: "radio",
     options: [
       { label: "Yes", value: true },
       { label: "No", value: false },
     ],
-  },
-  alignment: {
-    label: "Align card",
+  }),
+  alignment: YextField("Align card", {
     type: "radio",
     options: [
       { label: "Left", value: "items-start" },
       { label: "Center", value: "items-center" },
     ],
-  },
+  }),
 };
 
 const VisualEditorHoursTable = ({

--- a/packages/visual-editor/src/components/Image.tsx
+++ b/packages/visual-editor/src/components/Image.tsx
@@ -5,9 +5,9 @@ import {
   resolveYextEntityField,
   EntityField,
   YextEntityField,
-  YextEntityFieldSelector,
   Image,
   ImageProps,
+  YextField,
 } from "@yext/visual-editor";
 import { ImageType } from "@yext/pages-components";
 
@@ -22,32 +22,28 @@ export interface ImageWrapperProps {
 }
 
 export const ImageWrapperFields: Fields<ImageWrapperProps> = {
-  image: YextEntityFieldSelector<any, ImageType>({
-    label: "Image",
+  image: YextField<ImageType>("Image", {
+    type: "entity",
     filter: {
       types: ["type.image"],
     },
   }),
-  layout: {
-    label: "Layout",
+  layout: YextField("Layout", {
     type: "radio",
     options: [
       { label: "Auto", value: "auto" },
       { label: "Fixed", value: "fixed" },
     ],
-  },
-  width: {
-    label: "Width",
+  }),
+  width: YextField("Width", {
     type: "number",
     min: 0,
-  },
-  height: {
-    label: "Height",
+  }),
+  height: YextField("Height", {
     type: "number",
     min: 0,
-  },
-  aspectRatio: {
-    label: "Aspect Ratio",
+  }),
+  aspectRatio: YextField("Aspect Ratio", {
     type: "select",
     options: [
       { label: "1:1", value: 1 },
@@ -68,7 +64,7 @@ export const ImageWrapperFields: Fields<ImageWrapperProps> = {
       { label: "1:3", value: 0.33 },
       { label: "1:4", value: 0.25 },
     ],
-  },
+  }),
 };
 
 const ImageWrapperComponent: React.FC<ImageWrapperProps> = ({

--- a/packages/visual-editor/src/components/Layout.tsx
+++ b/packages/visual-editor/src/components/Layout.tsx
@@ -2,9 +2,8 @@ import { cva, VariantProps } from "class-variance-authority";
 import { Fields } from "@measured/puck";
 import {
   SpacingSelector,
-  BasicSelector,
-  ThemeOptions,
   BackgroundStyle,
+  YextField,
 } from "@yext/visual-editor";
 
 export const layoutVariants = cva("components w-full", {
@@ -103,10 +102,11 @@ export interface layoutProps
 }
 
 export const layoutFields: Fields<layoutProps> = {
-  backgroundColor: BasicSelector(
-    "Background Color",
-    ThemeOptions.BACKGROUND_COLOR
-  ),
+  backgroundColor: YextField("Background Color", {
+    type: "select",
+    hasSearch: true,
+    options: "BACKGROUND_COLOR",
+  }),
   gap: SpacingSelector("Gap", "gap", false),
   verticalPadding: SpacingSelector("Top/Bottom Padding", "padding", true),
   horizontalPadding: SpacingSelector("Left/Right Padding", "padding", false),

--- a/packages/visual-editor/src/components/MapboxStaticMap.tsx
+++ b/packages/visual-editor/src/components/MapboxStaticMap.tsx
@@ -4,7 +4,7 @@ import {
   resolveYextEntityField,
   useDocument,
   YextEntityField,
-  YextEntityFieldSelector,
+  YextField,
 } from "@yext/visual-editor";
 import { ComponentConfig, Fields } from "@measured/puck";
 
@@ -18,12 +18,11 @@ type MapboxStaticProps = {
 };
 
 const mapboxFields: Fields<MapboxStaticProps> = {
-  apiKey: {
-    label: "API Key",
+  apiKey: YextField("API Key", {
     type: "text",
-  },
-  coordinate: YextEntityFieldSelector<any, Coordinate>({
-    label: "Coordinates",
+  }),
+  coordinate: YextField<Coordinate>("Coordinates", {
+    type: "entity",
     filter: { types: ["type.coordinate"] },
   }),
 };

--- a/packages/visual-editor/src/components/NearbyLocations.tsx
+++ b/packages/visual-editor/src/components/NearbyLocations.tsx
@@ -3,17 +3,15 @@ import {
   resolveYextEntityField,
   useDocument,
   YextEntityField,
-  YextEntityFieldSelector,
   Heading,
   BackgroundStyle,
-  BasicSelector,
   backgroundColors,
-  ThemeOptions,
   HeadingLevel,
   PageSection,
   PhoneAtom,
   fetchNearbyLocations,
   Background,
+  YextField,
 } from "@yext/visual-editor";
 import { useQuery } from "@tanstack/react-query";
 import { Address, Coordinate, HoursStatus } from "@yext/pages-components";
@@ -45,109 +43,104 @@ export interface NearbyLocationsSectionProps {
 }
 
 const nearbyLocationsSectionFields: Fields<NearbyLocationsSectionProps> = {
-  styles: {
-    label: "Styles",
+  styles: YextField("Styles", {
     type: "object",
     objectFields: {
-      backgroundColor: BasicSelector(
-        "Background Color",
-        ThemeOptions.BACKGROUND_COLOR
-      ),
-      cardBackgroundColor: BasicSelector(
-        "Card Background Color",
-        ThemeOptions.BACKGROUND_COLOR
-      ),
+      backgroundColor: YextField("Background Color", {
+        type: "select",
+        hasSearch: true,
+        options: "BACKGROUND_COLOR",
+      }),
+      cardBackgroundColor: YextField("Card Background Color", {
+        type: "select",
+        hasSearch: true,
+        options: "BACKGROUND_COLOR",
+      }),
     },
-  },
-  heading: {
-    label: "Section Heading",
+  }),
+  heading: YextField("Section Heading", {
     type: "object",
     objectFields: {
-      text: YextEntityFieldSelector({
-        label: "Text",
+      text: YextField<string>("Text", {
+        type: "entity",
         filter: {
           types: ["type.string"],
         },
       }),
-      level: BasicSelector("Heading Level", ThemeOptions.HEADING_LEVEL),
+      level: YextField("Heading Level", {
+        type: "select",
+        hasSearch: true,
+        options: "HEADING_LEVEL",
+      }),
     },
-  },
-  cards: {
-    label: "Cards",
+  }),
+  cards: YextField("Cards", {
     type: "object",
     objectFields: {
-      headingLevel: BasicSelector("Heading Level", ThemeOptions.HEADING_LEVEL),
-      hours: {
-        label: "Hours",
+      headingLevel: YextField("Heading Level", {
+        type: "select",
+        hasSearch: true,
+        options: "HEADING_LEVEL",
+      }),
+      hours: YextField("Hours", {
         type: "object",
         objectFields: {
-          showCurrentStatus: {
+          showCurrentStatus: YextField("Show Current Status", {
             type: "radio",
-            label: "Show Current Status",
             options: [
               { label: "Yes", value: true },
               { label: "No", value: false },
             ],
-          },
-          timeFormat: {
+          }),
+          timeFormat: YextField("Time Format", {
             type: "radio",
-            label: "Time Format",
             options: [
               { label: "12-hour", value: "12h" },
               { label: "24-hour", value: "24h" },
             ],
-          },
-          showDayNames: {
+          }),
+          showDayNames: YextField("Show Day Names", {
             type: "radio",
-            label: "Show Day Names",
             options: [
               { label: "Yes", value: true },
               { label: "No", value: false },
             ],
-          },
-          dayOfWeekFormat: {
+          }),
+          dayOfWeekFormat: YextField("Day of Week Format", {
             type: "radio",
-            label: "Day of Week Format",
             options: [
               { label: "Short", value: "short" },
               { label: "Long", value: "long" },
             ],
-          },
+          }),
         },
-      },
-      phoneNumberFormat: {
-        label: "Phone Number Format",
+      }),
+      phoneNumberFormat: YextField("Phone Number Format", {
         type: "radio",
-        options: [
-          { label: "Domestic", value: "domestic" },
-          { label: "International", value: "international" },
-        ],
-      },
-      phoneNumberLink: {
-        label: "Include Phone Number Hyperlink",
+        options: "PHONE_OPTIONS",
+      }),
+      includePhoneHyperlink: YextField("Include Phone Hyperlink", {
         type: "radio",
         options: [
           { label: "Yes", value: true },
           { label: "No", value: false },
         ],
-      },
+      }),
     },
-  },
-  coordinate: YextEntityFieldSelector<any, Coordinate>({
-    label: "Coordinates",
+  }),
+  coordinate: YextField<Coordinate>("Coordinates", {
+    type: "entity",
     filter: { types: ["type.coordinate"] },
   }),
-  radius: {
-    label: "Radius (Miles)",
+  radius: YextField("Radius (Miles)", {
     type: "number",
     min: 0,
-  },
-  limit: {
-    label: "Limit",
+  }),
+  limit: YextField("Limit", {
     type: "number",
     min: 0,
     max: 50,
-  },
+  }),
 };
 
 const LocationCard = ({

--- a/packages/visual-editor/src/components/People.tsx
+++ b/packages/visual-editor/src/components/People.tsx
@@ -3,11 +3,8 @@ import { ComponentConfig, Fields, ArrayField } from "@measured/puck";
 import { FaEnvelope, FaPhone } from "react-icons/fa";
 import {
   YextEntityField,
-  YextEntityFieldSelector,
   useDocument,
   resolveYextEntityField,
-  BasicSelector,
-  ThemeOptions,
   Heading,
   HeadingLevel,
   Body,
@@ -21,6 +18,7 @@ import {
   ImageProps,
   ImageWrapperProps,
   Background,
+  YextField,
 } from "@yext/visual-editor";
 import { resolvedImageFields, ImageWrapperFields } from "./Image.js";
 
@@ -43,67 +41,69 @@ export interface PeopleProps {
 }
 
 const peopleFields: Fields<PeopleProps> = {
-  backgroundColor: BasicSelector(
-    "Background Color",
-    ThemeOptions.BACKGROUND_COLOR
-  ),
-  sectionHeading: {
+  backgroundColor: YextField("Background Color", {
+    type: "select",
+    hasSearch: true,
+    options: "BACKGROUND_COLOR",
+  }),
+  sectionHeading: YextField("Section Heading", {
     type: "object",
-    label: "Section Heading",
     objectFields: {
-      text: YextEntityFieldSelector<any, string>({
-        label: "Text",
+      text: YextField<string>("Text", {
+        type: "entity",
         filter: {
           types: ["type.string"],
         },
       }),
-      level: BasicSelector("Heading Level", ThemeOptions.HEADING_LEVEL),
+      level: YextField("Heading Level", {
+        type: "select",
+        hasSearch: true,
+        options: "HEADING_LEVEL",
+      }),
     },
-  },
-  people: {
+  }),
+  people: YextField("People", {
     type: "array",
-    label: "People",
     arrayFields: {
-      headshot: {
+      headshot: YextField("Headshot", {
         type: "object",
-        label: "Headshot",
         objectFields: {
           ...ImageWrapperFields,
         },
-      },
-      name: YextEntityFieldSelector<any, string>({
-        label: "Name",
+      }),
+      name: YextField<string>("Name", {
+        type: "entity",
         filter: {
           types: ["type.string"],
         },
       }),
-      title: YextEntityFieldSelector<any, string>({
-        label: "Title",
+      title: YextField<string>("Title", {
+        type: "entity",
         filter: {
           types: ["type.string"],
         },
       }),
-      phone: YextEntityFieldSelector<any, string>({
-        label: "Phone",
+      number: YextField<string>("Phone Number", {
+        type: "entity",
         filter: {
           types: ["type.phone"],
         },
       }),
-      email: YextEntityFieldSelector<any, string>({
-        label: "Email",
+      email: YextField<string>("Email", {
+        type: "entity",
         filter: {
           types: ["type.string"],
           allowList: ["emails"],
         },
       }),
-      cta: YextEntityFieldSelector<any, CTAProps>({
-        label: "CTA",
+      cta: YextField<CTAProps>("CTA", {
+        type: "entity",
         filter: {
           types: ["type.cta"],
         },
       }),
     },
-  },
+  }),
 };
 
 interface PersonCardProps {

--- a/packages/visual-editor/src/components/Phone.tsx
+++ b/packages/visual-editor/src/components/Phone.tsx
@@ -5,9 +5,8 @@ import {
   resolveYextEntityField,
   EntityField,
   YextEntityField,
-  YextEntityFieldSelector,
   PhoneAtom,
-  ThemeOptions,
+  YextField,
 } from "@yext/visual-editor";
 
 export interface PhoneProps {
@@ -17,25 +16,23 @@ export interface PhoneProps {
 }
 
 const PhoneFields: Fields<PhoneProps> = {
-  phone: YextEntityFieldSelector({
-    label: "Phone Number",
+  phone: YextField("Phone Number", {
+    type: "entity",
     filter: {
       types: ["type.phone"],
     },
   }),
-  format: {
-    label: "Format",
+  format: YextField("Format", {
     type: "radio",
-    options: ThemeOptions.PHONE_OPTIONS,
-  },
-  includeHyperlink: {
-    label: "Include Hyperlink",
+    options: "PHONE_OPTIONS",
+  }),
+  includeHyperlink: YextField("Include Hyperlink", {
     type: "radio",
     options: [
       { label: "Yes", value: true },
       { label: "No", value: false },
     ],
-  },
+  }),
 };
 
 const PhoneComponent: React.FC<PhoneProps> = ({

--- a/packages/visual-editor/src/components/PhotoGallerySection.tsx
+++ b/packages/visual-editor/src/components/PhotoGallerySection.tsx
@@ -12,7 +12,6 @@ import "pure-react-carousel/dist/react-carousel.es.css";
 import {
   backgroundColors,
   BackgroundStyle,
-  BasicSelector,
   EntityField,
   Heading,
   HeadingLevel,
@@ -22,11 +21,10 @@ import {
   resolveYextEntityField,
   PageSection,
   themeManagerCn,
-  ThemeOptions,
   useBackground,
   useDocument,
   YextEntityField,
-  YextEntityFieldSelector,
+  YextField,
 } from "@yext/visual-editor";
 import { resolvedImageFields, ImageWrapperFields } from "./Image.js";
 import { FaArrowLeft, FaArrowRight } from "react-icons/fa";
@@ -71,34 +69,36 @@ const DynamicChildColors = ({
 };
 
 const photoGallerySectionFields: Fields<PhotoGallerySectionProps> = {
-  styles: {
-    label: "Styles",
+  styles: YextField("Styles", {
     type: "object",
     objectFields: {
-      backgroundColor: BasicSelector(
-        "Background Color",
-        ThemeOptions.BACKGROUND_COLOR
-      ),
+      backgroundColor: YextField("Background Color", {
+        type: "select",
+        hasSearch: true,
+        options: "BACKGROUND_COLOR",
+      }),
     },
-  },
-  sectionHeading: {
+  }),
+  sectionHeading: YextField("Section Heading", {
     type: "object",
-    label: "Section Heading",
     objectFields: {
-      text: YextEntityFieldSelector<any, string>({
-        label: "Text",
+      text: YextField<string>("Text", {
+        type: "entity",
         filter: {
           types: ["type.string"],
         },
       }),
-      level: BasicSelector("Heading Level", ThemeOptions.HEADING_LEVEL),
+      level: YextField("Heading Level", {
+        type: "select",
+        hasSearch: true,
+        options: "HEADING_LEVEL",
+      }),
     },
-  },
-  images: {
+  }),
+  images: YextField("Images", {
     type: "array",
-    label: "Images",
     arrayFields: { ...ImageWrapperFields },
-  },
+  }),
 };
 
 const PhotoGallerySectionWrapper = ({

--- a/packages/visual-editor/src/components/Promo.tsx
+++ b/packages/visual-editor/src/components/Promo.tsx
@@ -6,8 +6,6 @@ import {
   resolveYextEntityField,
   EntityField,
   YextEntityField,
-  YextEntityFieldSelector,
-  BasicSelector,
   ImageProps,
   Image,
   Body,
@@ -15,12 +13,12 @@ import {
   backgroundColors,
   BodyProps,
   ImageWrapperProps,
-  ThemeOptions,
   Heading,
   HeadingProps,
   CTA,
   CTAProps,
   PageSection,
+  YextField,
 } from "@yext/visual-editor";
 import { resolvedImageFields, ImageWrapperFields } from "./Image.js";
 
@@ -48,82 +46,82 @@ export interface PromoSectionProps {
 }
 
 const promoSectionFields: Fields<PromoSectionProps> = {
-  image: {
+  image: YextField("Image", {
     type: "object",
-    label: "Image",
     objectFields: {
       ...ImageWrapperFields,
     },
-  },
-  title: {
+  }),
+  title: YextField("Business Name Heading", {
     type: "object",
-    label: "Business Name Heading",
     objectFields: {
-      text: YextEntityFieldSelector<any, string>({
-        label: "Value",
+      text: YextField<string>("Value", {
+        type: "entity",
         filter: {
           types: ["type.string"],
         },
       }),
-      level: BasicSelector("Level", ThemeOptions.HEADING_LEVEL),
+      level: YextField("Level", {
+        type: "select",
+        hasSearch: true,
+        options: "HEADING_LEVEL",
+      }),
     },
-  },
-  description: {
+  }),
+  description: YextField("Description", {
     type: "object",
-    label: "Description",
     objectFields: {
-      text: YextEntityFieldSelector<any, string>({
-        label: "Value",
+      text: YextField<string>("Value", {
+        type: "entity",
         filter: {
           types: ["type.string"],
         },
       }),
-      variant: {
-        label: "Variant",
+      variant: YextField("Variant", {
         type: "radio",
-        options: ThemeOptions.BODY_VARIANT,
-      },
+        options: "BODY_VARIANT",
+      }),
     },
-  },
-  cta: {
+  }),
+  cta: YextField("Primary CTA", {
     type: "object",
-    label: "Primary CTA",
     objectFields: {
-      entityField: YextEntityFieldSelector({
-        label: "Value",
+      entityField: YextField("Value", {
+        type: "entity",
         filter: {
           types: ["type.cta"],
         },
       }),
-      variant: {
-        label: "Variant",
+      variant: YextField("Variant", {
         type: "radio",
-        options: ThemeOptions.CTA_VARIANT,
-      },
-      visible: {
-        label: "Show Primary CTA",
+        options: "CTA_VARIANT",
+      }),
+      visible: YextField("Show Primary CTA", {
         type: "radio",
         options: [
           { label: "Show", value: true },
           { label: "Hide", value: false },
         ],
-      },
+      }),
     },
-  },
-  styles: {
-    label: "Styles",
+  }),
+  styles: YextField("Styles", {
     type: "object",
     objectFields: {
-      backgroundColor: BasicSelector(
-        "Background Color",
-        ThemeOptions.BACKGROUND_COLOR
-      ),
-      orientation: BasicSelector("Image Orientation", [
-        { label: "Left", value: "left" },
-        { label: "Right", value: "right" },
-      ]),
+      backgroundColor: YextField("Background Color", {
+        type: "select",
+        hasSearch: true,
+        options: "BACKGROUND_COLOR",
+      }),
+      imageOrientation: YextField("Image Orientation", {
+        type: "radio",
+        options: [
+          { label: "Left", value: "left" },
+          { label: "Right", value: "right" },
+        ],
+      }),
     },
-  },
+  }),
 };
 
 const PromoWrapper: React.FC<PromoSectionProps> = ({

--- a/packages/visual-editor/src/components/SectionContainer.tsx
+++ b/packages/visual-editor/src/components/SectionContainer.tsx
@@ -4,8 +4,6 @@ import {
   Heading,
   BackgroundStyle,
   YextEntityField,
-  BasicSelector,
-  YextEntityFieldSelector,
   ThemeOptions,
   resolveYextEntityField,
   HeadingProps,
@@ -13,6 +11,7 @@ import {
   OtherCategory,
   PageSectionCategory,
   useDocument,
+  YextField,
 } from "@yext/visual-editor";
 import {
   ComponentConfig,
@@ -32,23 +31,31 @@ export type SectionContainerProps = {
 };
 
 const sectionContainerFields: Fields<SectionContainerProps> = {
-  background: BasicSelector("Background Color", ThemeOptions.BACKGROUND_COLOR),
-  sectionHeading: {
+  background: YextField("Background Color", {
+    type: "select",
+    hasSearch: true,
+    options: "BACKGROUND_COLOR",
+  }),
+  sectionHeading: YextField("Section Heading", {
     type: "object",
-    label: "Section Heading",
     objectFields: {
-      text: YextEntityFieldSelector<any, string>({
-        label: "Section Heading Text",
-        filter: { types: ["type.string"] },
+      text: YextField<string>("Text", {
+        type: "entity",
+        filter: {
+          types: ["type.string"],
+        },
       }),
-      level: BasicSelector("Heading Level", ThemeOptions.HEADING_LEVEL),
-      alignment: {
-        label: "Alignment",
+      level: YextField("Heading Level", {
+        type: "select",
+        hasSearch: true,
+        options: "HEADING_LEVEL",
+      }),
+      alignment: YextField("Alignment", {
         type: "radio",
         options: ThemeOptions.ALIGNMENT,
-      },
+      }),
     },
-  },
+  }),
 };
 
 const SectionContainerComponent = (

--- a/packages/visual-editor/src/components/TextList.tsx
+++ b/packages/visual-editor/src/components/TextList.tsx
@@ -5,7 +5,7 @@ import {
   resolveYextEntityField,
   EntityField,
   YextEntityField,
-  YextEntityFieldSelector,
+  YextField,
 } from "@yext/visual-editor";
 
 export interface TextListProps {
@@ -13,8 +13,8 @@ export interface TextListProps {
 }
 
 const textListFields: Fields<TextListProps> = {
-  list: YextEntityFieldSelector({
-    label: "Values",
+  list: YextField("Values", {
+    type: "entity",
     filter: {
       types: ["type.string"],
       includeListsOnly: true,

--- a/packages/visual-editor/src/components/cards/EventCard.tsx
+++ b/packages/visual-editor/src/components/cards/EventCard.tsx
@@ -10,10 +10,10 @@ import {
   YextCollection,
   resolveYextSubfield,
   handleResolveFieldsForCollections,
-  YextCollectionSubfieldSelector,
   CTAProps,
   EntityField,
   CTA,
+  YextField,
 } from "@yext/visual-editor";
 import { handleComplexImages } from "../atoms/image.js";
 import { ImageType } from "@yext/pages-components";
@@ -160,44 +160,43 @@ export const EventCard: ComponentConfig<EventCardProps> = {
     // Update each subfield based on isCollection
     return {
       ...params.lastFields,
-      card: {
-        label: "Card",
+      card: YextField("Card", {
         type: "object",
         objectFields: {
-          title: YextCollectionSubfieldSelector<any, string>({
-            label: "Title",
+          title: YextField<string>("Title", {
+            type: "entity",
             isCollection: isCollection,
             filter: {
               directChildrenOf: directChildrenFilter,
               types: ["type.string"],
             },
           }),
-          image: YextCollectionSubfieldSelector<any, ImageType>({
-            label: "Image",
+          image: YextField<ImageType>("Image", {
+            type: "entity",
             isCollection: isCollection,
             filter: {
               directChildrenOf: directChildrenFilter,
               types: ["type.image"],
             },
           }),
-          dateTime: YextCollectionSubfieldSelector<any, string>({
-            label: "Date Time",
+          dateTime: YextField<string>("Date Time", {
+            type: "entity",
             isCollection: isCollection,
             filter: {
               directChildrenOf: directChildrenFilter,
               types: ["type.string"],
             },
           }),
-          description: YextCollectionSubfieldSelector<any, string>({
-            label: "Description",
+          description: YextField<string>("Description", {
+            type: "entity",
             isCollection: isCollection,
             filter: {
               directChildrenOf: directChildrenFilter,
               types: ["type.string"],
             },
           }),
-          cta: YextCollectionSubfieldSelector<any, CTAProps>({
-            label: "CTA",
+          cta: YextField<CTAProps>("CTA", {
+            type: "entity",
             isCollection: isCollection,
             filter: {
               directChildrenOf: directChildrenFilter,
@@ -205,7 +204,7 @@ export const EventCard: ComponentConfig<EventCardProps> = {
             },
           }),
         },
-      },
+      }),
     } as Fields<EventCardProps>;
   },
   defaultProps: {

--- a/packages/visual-editor/src/components/cards/ExampleRepeatableItem.tsx
+++ b/packages/visual-editor/src/components/cards/ExampleRepeatableItem.tsx
@@ -6,10 +6,10 @@ import {
   YextEntityField,
   Image,
   resolveYextSubfield,
-  YextCollectionSubfieldSelector,
   handleResolveFieldsForCollections,
   Body,
   YextCollection,
+  YextField,
 } from "@yext/visual-editor";
 import { ComplexImageType, ImageType } from "@yext/pages-components";
 import { handleComplexImages } from "../atoms/image.js";
@@ -107,16 +107,16 @@ export const ExampleRepeatableItemComponent: ComponentConfig<ExampleRepeatableIt
       // Update each subfield based on isCollection
       return {
         ...params.lastFields,
-        text: YextCollectionSubfieldSelector<any, string>({
-          label: "Text",
+        text: YextField<string>("Text", {
+          type: "entity",
           isCollection: isCollection,
           filter: {
             directChildrenOf: directChildrenFilter,
             types: ["type.string"],
           },
         }),
-        image: YextCollectionSubfieldSelector<any, ImageType>({
-          label: "Image",
+        image: YextField<ImageType>("Image", {
+          type: "entity",
           isCollection: isCollection,
           filter: {
             directChildrenOf: directChildrenFilter,

--- a/packages/visual-editor/src/components/cards/InsightCard.tsx
+++ b/packages/visual-editor/src/components/cards/InsightCard.tsx
@@ -12,10 +12,10 @@ import {
   YextCollection,
   resolveYextSubfield,
   handleResolveFieldsForCollections,
-  YextCollectionSubfieldSelector,
   CTAProps,
   EntityField,
   CTA,
+  YextField,
 } from "@yext/visual-editor";
 import { handleComplexImages } from "../atoms/image.js";
 import { ImageType } from "@yext/pages-components";
@@ -175,52 +175,51 @@ export const InsightCard: ComponentConfig<InsightCardProps> = {
     // Update each subfield based on isCollection
     return {
       ...params.lastFields,
-      card: {
-        label: "Card",
+      card: YextField("Card", {
         type: "object",
         objectFields: {
-          image: YextCollectionSubfieldSelector<any, ImageType>({
-            label: "Image",
+          image: YextField<ImageType>("Image", {
+            type: "entity",
             isCollection: isCollection,
             filter: {
               directChildrenOf: directChildrenFilter,
               types: ["type.image"],
             },
           }),
-          title: YextCollectionSubfieldSelector<any, string>({
-            label: "Title",
+          title: YextField<string>("Title", {
+            type: "entity",
             isCollection: isCollection,
             filter: {
               directChildrenOf: directChildrenFilter,
               types: ["type.string"],
             },
           }),
-          category: YextCollectionSubfieldSelector<any, string>({
-            label: "Category",
+          category: YextField<string>("Category", {
+            type: "entity",
             isCollection: isCollection,
             filter: {
               directChildrenOf: directChildrenFilter,
               types: ["type.string"],
             },
           }),
-          date: YextCollectionSubfieldSelector<any, string>({
-            label: "Date",
+          date: YextField<string>("Date", {
+            type: "entity",
             isCollection: isCollection,
             filter: {
               directChildrenOf: directChildrenFilter,
               types: ["type.string"],
             },
           }),
-          description: YextCollectionSubfieldSelector<any, string>({
-            label: "Description",
+          description: YextField<string>("Description", {
+            type: "entity",
             isCollection: isCollection,
             filter: {
               directChildrenOf: directChildrenFilter,
               types: ["type.string"],
             },
           }),
-          cta: YextCollectionSubfieldSelector<any, CTAProps>({
-            label: "CTA",
+          cta: YextField<CTAProps>("CTA", {
+            type: "entity",
             isCollection: isCollection,
             filter: {
               directChildrenOf: directChildrenFilter,
@@ -228,7 +227,7 @@ export const InsightCard: ComponentConfig<InsightCardProps> = {
             },
           }),
         },
-      },
+      }),
     } as Fields<InsightCardProps>;
   },
   defaultProps: {

--- a/packages/visual-editor/src/components/cards/PersonCard.tsx
+++ b/packages/visual-editor/src/components/cards/PersonCard.tsx
@@ -5,8 +5,6 @@ import {
   YextEntityField,
   useDocument,
   resolveYextEntityField,
-  BasicSelector,
-  ThemeOptions,
   Heading,
   handleResolveFieldsForCollections,
   Body,
@@ -20,7 +18,7 @@ import {
   ImageWrapperProps,
   YextCollection,
   resolveYextSubfield,
-  YextCollectionSubfieldSelector,
+  YextField,
 } from "@yext/visual-editor";
 
 const PLACEHOLDER_IMAGE_URL = "https://placehold.co/640x360";
@@ -41,16 +39,16 @@ export interface PersonCardProps {
 }
 
 const PersonCardItemFields: Fields<PersonCardProps> = {
-  styles: {
-    label: "Styles",
+  styles: YextField("Styles", {
     type: "object",
     objectFields: {
-      cardBackgroundColor: BasicSelector(
-        "Card Background Color",
-        ThemeOptions.BACKGROUND_COLOR
-      ),
+      cardBackgroundColor: YextField("Card Background Color", {
+        type: "select",
+        hasSearch: true,
+        options: "BACKGROUND_COLOR",
+      }),
     },
-  },
+  }),
 };
 
 const PersonCardItem = ({
@@ -241,36 +239,35 @@ export const PersonCard: ComponentConfig<PersonCardProps> = {
     // Update each subfield based on isCollection
     return {
       ...params.lastFields,
-      card: {
-        label: "Card",
+      card: YextField("Card", {
         type: "object",
         objectFields: {
-          headshot: YextCollectionSubfieldSelector<any, ImageWrapperProps>({
-            label: "Headshot",
+          headshot: YextField<ImageWrapperProps>("Headshot", {
+            type: "entity",
             isCollection: isCollection,
             filter: {
               directChildrenOf: directChildrenFilter,
               types: ["type.image"],
             },
           }),
-          name: YextCollectionSubfieldSelector<any, string>({
-            label: "Name",
+          name: YextField<string>("Name", {
+            type: "entity",
             isCollection: isCollection,
             filter: {
               directChildrenOf: directChildrenFilter,
               types: ["type.string"],
             },
           }),
-          title: YextCollectionSubfieldSelector<any, string>({
-            label: "Title",
+          title: YextField<string>("Title", {
+            type: "entity",
             isCollection: isCollection,
             filter: {
               directChildrenOf: directChildrenFilter,
               types: ["type.string"],
             },
           }),
-          email: YextCollectionSubfieldSelector<any, string>({
-            label: "Email",
+          email: YextField<string>("Email", {
+            type: "entity",
             isCollection: isCollection,
             filter: {
               directChildrenOf: directChildrenFilter,
@@ -278,16 +275,16 @@ export const PersonCard: ComponentConfig<PersonCardProps> = {
               allowList: ["emails"],
             },
           }),
-          phone: YextCollectionSubfieldSelector<any, string>({
-            label: "Phone",
+          phone: YextField<string>("Phone", {
+            type: "entity",
             isCollection: isCollection,
             filter: {
               directChildrenOf: directChildrenFilter,
               types: ["type.phone"],
             },
           }),
-          cta: YextCollectionSubfieldSelector<any, CTAProps>({
-            label: "CTA",
+          cta: YextField<CTAProps>("CTA", {
+            type: "entity",
             isCollection: isCollection,
             filter: {
               directChildrenOf: directChildrenFilter,
@@ -295,7 +292,7 @@ export const PersonCard: ComponentConfig<PersonCardProps> = {
             },
           }),
         },
-      },
+      }),
     } as Fields<PersonCardProps>;
   },
   defaultProps: {

--- a/packages/visual-editor/src/components/cards/ProductCard.tsx
+++ b/packages/visual-editor/src/components/cards/ProductCard.tsx
@@ -5,18 +5,16 @@ import {
   useDocument,
   YextEntityField,
   resolveYextSubfield,
-  YextCollectionSubfieldSelector,
   handleResolveFieldsForCollections,
   YextCollection,
   BackgroundStyle,
-  BasicSelector,
-  ThemeOptions,
   backgroundColors,
   CTA,
   Body,
   Heading,
   Image,
   Background,
+  YextField,
 } from "@yext/visual-editor";
 import { ImageType } from "@yext/pages-components";
 import { handleComplexImages } from "../atoms/image.js";
@@ -38,16 +36,16 @@ export type ProductCardProps = {
 };
 
 const ProductCardItemFields: Fields<ProductCardProps> = {
-  styles: {
-    label: "Styles",
+  styles: YextField("Styles", {
     type: "object",
     objectFields: {
-      cardBackgroundColor: BasicSelector(
-        "Card Background Color",
-        ThemeOptions.BACKGROUND_COLOR
-      ),
+      cardBackgroundColor: YextField("Card Background Color", {
+        type: "select",
+        hasSearch: true,
+        options: "BACKGROUND_COLOR",
+      }),
     },
-  },
+  }),
 };
 
 const ProductCardItem = ({
@@ -168,44 +166,43 @@ export const ProductCard: ComponentConfig<ProductCardProps> = {
     // Update each subfield based on isCollection
     return {
       ...params.lastFields,
-      card: {
-        label: "Card",
+      card: YextField("Card", {
         type: "object",
         objectFields: {
-          image: YextCollectionSubfieldSelector<any, ImageType>({
-            label: "Image",
+          image: YextField<ImageType>("Image", {
+            type: "entity",
             isCollection: isCollection,
             filter: {
               directChildrenOf: directChildrenFilter,
               types: ["type.image"],
             },
           }),
-          heading: YextCollectionSubfieldSelector<any, string>({
-            label: "Heading",
+          heading: YextField<string>("Heading", {
+            type: "entity",
             isCollection: isCollection,
             filter: {
               directChildrenOf: directChildrenFilter,
               types: ["type.string"],
             },
           }),
-          category: YextCollectionSubfieldSelector<any, string>({
-            label: "Category",
+          category: YextField<string>("Category", {
+            type: "entity",
             isCollection: isCollection,
             filter: {
               directChildrenOf: directChildrenFilter,
               types: ["type.string"],
             },
           }),
-          description: YextCollectionSubfieldSelector<any, string>({
-            label: "Description",
+          description: YextField<string>("Description", {
+            type: "entity",
             isCollection: isCollection,
             filter: {
               directChildrenOf: directChildrenFilter,
               types: ["type.string"],
             },
           }),
-          cta: YextCollectionSubfieldSelector<any, string>({
-            label: "CTA",
+          cta: YextField<string>("CTA", {
+            type: "entity",
             isCollection: isCollection,
             filter: {
               directChildrenOf: directChildrenFilter,
@@ -213,7 +210,7 @@ export const ProductCard: ComponentConfig<ProductCardProps> = {
             },
           }),
         },
-      },
+      }),
     } as Fields<ProductCardProps>;
   },
   defaultProps: {

--- a/packages/visual-editor/src/components/cards/TestimonialCard.tsx
+++ b/packages/visual-editor/src/components/cards/TestimonialCard.tsx
@@ -4,8 +4,6 @@ import {
   YextEntityField,
   useDocument,
   resolveYextEntityField,
-  BasicSelector,
-  ThemeOptions,
   Heading,
   Body,
   Background,
@@ -14,7 +12,7 @@ import {
   YextCollection,
   resolveYextSubfield,
   handleResolveFieldsForCollections,
-  YextCollectionSubfieldSelector,
+  YextField,
 } from "@yext/visual-editor";
 
 export type TestimonialCardProps = {
@@ -30,16 +28,16 @@ export type TestimonialCardProps = {
 };
 
 const TestimonialCardItemFields: Fields<TestimonialCardProps> = {
-  styles: {
-    label: "Styles",
+  styles: YextField("Styles", {
     type: "object",
     objectFields: {
-      cardBackgroundColor: BasicSelector(
-        "Card Background Color",
-        ThemeOptions.BACKGROUND_COLOR
-      ),
+      cardBackgroundColor: YextField("Card Background Color", {
+        type: "select",
+        hasSearch: true,
+        options: "BACKGROUND_COLOR",
+      }),
     },
-  },
+  }),
 };
 
 const TestimonialCardItem = ({
@@ -130,28 +128,27 @@ export const TestimonialCard: ComponentConfig<TestimonialCardProps> = {
     // Update each subfield based on isCollection
     return {
       ...params.lastFields,
-      card: {
-        label: "Card",
+      card: YextField("Card", {
         type: "object",
         objectFields: {
-          testimonial: YextCollectionSubfieldSelector<any, string>({
-            label: "Testimonial",
+          testimonial: YextField<string>("Testimonial", {
+            type: "entity",
             isCollection: isCollection,
             filter: {
               directChildrenOf: directChildrenFilter,
               types: ["type.string"],
             },
           }),
-          authorName: YextCollectionSubfieldSelector<any, string>({
-            label: "Author Name",
+          authorName: YextField<string>("Author Name", {
+            type: "entity",
             isCollection: isCollection,
             filter: {
               directChildrenOf: directChildrenFilter,
               types: ["type.string"],
             },
           }),
-          date: YextCollectionSubfieldSelector<any, string>({
-            label: "Date",
+          date: YextField<string>("Date", {
+            type: "entity",
             isCollection: isCollection,
             filter: {
               directChildrenOf: directChildrenFilter,
@@ -159,7 +156,7 @@ export const TestimonialCard: ComponentConfig<TestimonialCardProps> = {
             },
           }),
         },
-      },
+      }),
     } as Fields<TestimonialCardProps>;
   },
   defaultProps: {

--- a/packages/visual-editor/src/editor/README.md
+++ b/packages/visual-editor/src/editor/README.md
@@ -257,3 +257,232 @@ const myComponentFields: Fields<MyComponentProps> = {
   }),
 };
 ```
+
+## YextField
+
+`YextField` provides a unified utility for creating typed field configurations in a [Puck](https://github.com/measuredco/puck) and Yext Visual Editor integration context. It abstracts over common field types and includes special handling for Yext's [BasicSelector](##BasicSelector), [OptionalNumberField](##OptionalNumberField), [YextEntityFieldSelector](##YextEntityFieldSelector), and [YextCollectionSubfieldSelector](##YextCollectionSubfieldSelector).
+
+### Features
+
+- Strongly typed helper for defining field configs
+- Support for standard Puck field types (`text`, `radio`, `select`, `array`, etc.)
+- Extended support for Yext-specific entity selectors
+- Intelligent handling of options from `@yext/visual-editor` theme options
+
+### Props
+
+#### `YextField`
+
+```ts
+YextField(label: string, config: YextFieldConfig): Field<any>
+```
+
+**Parameters:**
+
+- `label`: `string` — The name of the field shown in the visual editor.
+- `config`: `YextFieldConfig` — Configuration object describing the field type and its behavior.
+
+### Usage
+
+```tsx
+import { YextField } from "@yext/visual-editor";
+
+const myComponentFields: Fields<myComponentProps> = {
+  address: YextField<AddressType>("Address", {
+    type: "entity",
+    filter: { types: ["type.address"] },
+  }),
+  showGetDirections: YextField("Show Get Directions Link", {
+    type: "radio",
+    options: [
+      { label: "Yes", value: true },
+      { label: "No", value: false },
+    ],
+  }),
+};
+
+export const MyComponent: ComponentConfig<myComponentProps> = {
+  fields: myComponentFields,
+  render: (props) => <SomeComponent {...props} />,
+};
+```
+
+### Supported Field Types
+
+#### Text Field
+
+Creates a simple string input. Supports multi-line input.
+
+```tsx
+title: YextField("Title", {
+  type: "text",
+}),
+description: YextField("Description", {
+  type: "text",
+  isMultiline: true
+})
+```
+
+**Props:**
+
+- `type`: `"text"`
+- `isMultiline?`: `boolean` — if true, renders a `<textarea>` for the multiline input.
+
+---
+
+#### Select Field
+
+Creates a dropdown select input. Options can be passed directly or as a string key from `ThemeOptions`. Optional search behavior uses the [BasicSelector](##BasicSelector).
+
+```tsx
+variant: YextField("CTA Variant", {
+  type: "select",
+  options: "CTA_VARIANT",
+  hasSearch: true,
+}),
+aspectRatio: YextField("Aspect Ratio", {
+  type: "select",
+  options: [
+    { label: "1:1", value: 1 },
+    { label: "5:4", value: 1.25 },
+    { label: "4:3", value: 1.33 },
+  ],
+}),
+```
+
+**Props:**
+
+- `type`: `"select"`
+- `options`: `FieldOptions | keyof ThemeOptions`
+- `hasSearch?`: `boolean` — enables searchable dropdown
+
+---
+
+#### Radio Field
+
+Creates a radio button group. Options can be passed directly or via a `ThemeOptions` key.
+
+```tsx
+alignment: YextField("Alignment", {
+  type: "radio",
+  options: "ALIGNMENT",
+}),
+includeHyperlink: YextField("Include Hyperlink", {
+  type: "radio",
+  options: [
+    { label: "Yes", value: true },
+    { label: "No", value: false },
+  ],
+}),
+```
+
+**Props:**
+
+- `type`: `"radio"`
+- `options`: `FieldOptions | keyof ThemeOptions`
+
+---
+
+#### Number Field
+
+Creates a numeric input field with optional min and max values. [Additional documentation](https://puckeditor.com/docs/api-reference/fields/number)
+
+```tsx
+spacing: YextField("Spacing", { type: "number" });
+```
+
+**Props:**
+
+- `type`: `"number"`
+- `min?`: `number`
+- `max?`: `number`
+
+---
+
+#### Array Field
+
+Creates a repeatable field group (e.g., a list of items). Define inner fields using `arrayFields`. [Additional documentation](https://puckeditor.com/docs/api-reference/fields/array)
+
+```tsx
+items: YextField("Items", {
+  type: "array",
+  arrayFields: {
+    title: YextField("Title", { type: "text" }),
+    url: YextField("URL", { type: "text" }),
+  },
+});
+```
+
+**Props:**
+
+- `type`: `"array"`
+- `arrayFields`: `object`;
+- `defaultItemProps?`: `string`;
+- `getItemSummary?`: `function`;
+- `max?`: `number`;
+- `min?`: `number`;
+
+---
+
+#### Object Field
+
+Creates a nested object field with multiple subfields. [Additional documentation](https://puckeditor.com/docs/api-reference/fields/object)
+
+```tsx
+card: YextField("Card", {
+  type: "object",
+  objectFields: {
+    title: YextField("Title", { type: "text" }),
+    description: YextField("Description", {
+      type: "text",
+      isMultiline: true,
+    }),
+  },
+});
+```
+
+**Props:**
+
+- `type`: `"object"`
+- `objectFields`: `object`
+
+---
+
+#### Entity Selector Field
+
+Renders a Yext entity selector with filtering capabilities.
+
+```tsx
+linkedEntity: YextField("Linked Entity", {
+  type: "entity",
+  filter: { entityType: "faq" },
+});
+```
+
+**Props:**
+
+- `type`: `"entity"`
+- `filter`: `any` — passed to [YextEntityFieldSelector](##YextEntityFieldSelector)
+- `isCollection?`: `boolean` — used when creating collection subfields, specifically in cardComponents.
+
+---
+
+#### Optional Number Selector Field
+
+[Additional documentation](##OptionalNumberField)
+
+```tsx
+limit: YextField("Items Limit", {
+  type: "optionalNumber",
+  hideNumberFieldRadioLabel: "All",
+  showNumberFieldRadioLabel: "Limit",
+  defaultCustomValue: 3,
+}),
+```
+
+**Props:**
+
+- `type`: `"optionalNumber"`
+- `hideNumberFieldRadioLabel`: `boolean`
+- `showNumberFieldRadioLabel`: `boolean`
+- `defaultCustomValue `: `number`

--- a/packages/visual-editor/src/editor/YextField.tsx
+++ b/packages/visual-editor/src/editor/YextField.tsx
@@ -6,11 +6,14 @@ import {
   ObjectField,
 } from "@measured/puck";
 import {
-  YextEntityFieldSelector,
+  YextCollectionSubfieldSelector,
   ThemeOptions,
   BasicSelector,
 } from "@yext/visual-editor";
-import { YextEntityField } from "./YextEntityFieldSelector.tsx";
+import {
+  RenderYextEntityFieldSelectorProps,
+  YextEntityField,
+} from "./YextEntityFieldSelector.tsx";
 
 /** Copied from Puck, do not change */
 export type FieldOption = {
@@ -56,10 +59,12 @@ type YextTextField = YextBaseField & {
   isMultiline?: boolean;
 };
 
-type YextEntitySelectorField = YextBaseField & {
-  type: "entity";
-  filter: any;
-};
+export type YextEntitySelectorField<
+  T extends Record<string, any> = Record<string, any>,
+> = YextBaseField &
+  Omit<RenderYextEntityFieldSelectorProps<T>, "label"> & {
+    type: "entity";
+  };
 
 type YextFieldConfig =
   | YextArrayField
@@ -74,6 +79,7 @@ export function YextField<U>(
   fieldName: string,
   config: { type: "entity"; filter: any }
 ): Field<YextEntityField<U>>;
+
 export function YextField<T = any>(
   fieldName: string,
   config: YextFieldConfig
@@ -84,9 +90,10 @@ export function YextField<T, U>(
   config: YextFieldConfig
 ): Field<any> {
   if (config.type === "entity") {
-    return YextEntityFieldSelector<any, U>({
+    return YextCollectionSubfieldSelector<any, U>({
       label: fieldName,
       filter: config.filter,
+      isCollection: config.isCollection,
     });
   }
 

--- a/packages/visual-editor/src/editor/YextField.tsx
+++ b/packages/visual-editor/src/editor/YextField.tsx
@@ -9,6 +9,8 @@ import {
   YextCollectionSubfieldSelector,
   ThemeOptions,
   BasicSelector,
+  OptionalNumberFieldProps,
+  OptionalNumberField,
 } from "@yext/visual-editor";
 import {
   RenderYextEntityFieldSelectorProps,
@@ -37,29 +39,44 @@ type YextBaseField = {
   type: string;
 };
 
+// YextArrayField has same functionality as Puck's ArrayField
 type YextArrayField = YextBaseField & Omit<ArrayField, keyof BaseField>;
 
+// YextNumberField has same functionality as Puck's NumberField
 type YextNumberField = YextBaseField & Omit<NumberField, keyof BaseField>;
 
+// YextObjectField has same functionality as Puck's ObjectField
 type YextObjectField = YextBaseField & Omit<ObjectField, keyof BaseField>;
 
+// YextRadioField accepts normal FieldOptions or specific ThemeConfig options.
 type YextRadioField = YextBaseField & {
   type: "radio";
   options: FieldOptions | radioOptions;
 };
 
+// YextSelectField accepts normal FieldOptions or specific ThemeConfig options.
+// If hasSearch is true, uses the BasicSelector rather than Puck's SelectField.
 type YextSelectField = YextBaseField & {
   type: "select";
   hasSearch?: boolean;
   options: FieldOptions | selectOptions;
 };
 
+// YextTextField has same functionality as Puck's TextField
+// If isMultiline is true, uses Puck's TextAreaField
 type YextTextField = YextBaseField & {
   type: "text";
   isMultiline?: boolean;
 };
 
-export type YextEntitySelectorField<
+// YextOptionalNumberField has same functionality as OptionalNumberField
+type YextOptionalNumberField = YextBaseField &
+  Omit<OptionalNumberFieldProps, "fieldLabel"> & {
+    type: "optionalNumber";
+  };
+
+// YextEntitySelectorField has same functionality as YextCollectionSubfieldSelector
+type YextEntitySelectorField<
   T extends Record<string, any> = Record<string, any>,
 > = YextBaseField &
   Omit<RenderYextEntityFieldSelectorProps<T>, "label"> & {
@@ -73,7 +90,8 @@ type YextFieldConfig =
   | YextEntitySelectorField
   | YextSelectField
   | YextRadioField
-  | YextObjectField;
+  | YextObjectField
+  | YextOptionalNumberField;
 
 export function YextField<U>(
   fieldName: string,
@@ -89,6 +107,7 @@ export function YextField<T, U>(
   fieldName: string,
   config: YextFieldConfig
 ): Field<any> {
+  // use YextCollectionSubfieldSelector
   if (config.type === "entity") {
     return YextCollectionSubfieldSelector<any, U>({
       label: fieldName,
@@ -97,6 +116,16 @@ export function YextField<T, U>(
     });
   }
 
+  if (config.type === "optionalNumber") {
+    return OptionalNumberField({
+      fieldLabel: fieldName,
+      hideNumberFieldRadioLabel: config.hideNumberFieldRadioLabel,
+      showNumberFieldRadioLabel: config.showNumberFieldRadioLabel,
+      defaultCustomValue: config.defaultCustomValue,
+    });
+  }
+
+  // use BasicSelector functionality
   if (config.type === "select" && config.hasSearch) {
     const options =
       typeof config.options === "string"

--- a/packages/visual-editor/src/editor/YextField.tsx
+++ b/packages/visual-editor/src/editor/YextField.tsx
@@ -1,0 +1,123 @@
+import {
+  ArrayField,
+  BaseField,
+  Field,
+  NumberField,
+  ObjectField,
+} from "@measured/puck";
+import {
+  YextEntityFieldSelector,
+  ThemeOptions,
+  BasicSelector,
+} from "@yext/visual-editor";
+import { YextEntityField } from "./YextEntityFieldSelector.tsx";
+
+/** Copied from Puck, do not change */
+export type FieldOption = {
+  label: string;
+  value: string | number | boolean;
+};
+
+/** Copied from Puck, do not change */
+export type FieldOptions = Array<FieldOption> | ReadonlyArray<FieldOption>;
+
+type radioOptions =
+  | "PHONE_OPTIONS"
+  | "ALIGNMENT"
+  | "BODY_VARIANT"
+  | "JUSTIFY_CONTENT"
+  | "CTA_VARIANT";
+
+type selectOptions = keyof Omit<typeof ThemeOptions, radioOptions>;
+
+type YextBaseField = {
+  type: string;
+};
+
+type YextArrayField = YextBaseField & Omit<ArrayField, keyof BaseField>;
+
+type YextNumberField = YextBaseField & Omit<NumberField, keyof BaseField>;
+
+type YextObjectField = YextBaseField & Omit<ObjectField, keyof BaseField>;
+
+type YextRadioField = YextBaseField & {
+  type: "radio";
+  options: FieldOptions | radioOptions;
+};
+
+type YextSelectField = YextBaseField & {
+  type: "select";
+  hasSearch?: boolean;
+  options: FieldOptions | selectOptions;
+};
+
+type YextTextField = YextBaseField & {
+  type: "text";
+  isMultiline?: boolean;
+};
+
+type YextEntitySelectorField = YextBaseField & {
+  type: "entity";
+  filter: any;
+};
+
+type YextFieldConfig =
+  | YextArrayField
+  | YextNumberField
+  | YextTextField
+  | YextEntitySelectorField
+  | YextSelectField
+  | YextRadioField
+  | YextObjectField;
+
+export function YextField<U>(
+  fieldName: string,
+  config: { type: "entity"; filter: any }
+): Field<YextEntityField<U>>;
+export function YextField<T = any>(
+  fieldName: string,
+  config: YextFieldConfig
+): Field<T>;
+
+export function YextField<T, U>(
+  fieldName: string,
+  config: YextFieldConfig
+): Field<any> {
+  if (config.type === "entity") {
+    return YextEntityFieldSelector<any, U>({
+      label: fieldName,
+      filter: config.filter,
+    });
+  }
+
+  if (config.type === "select" && config.hasSearch) {
+    const options =
+      typeof config.options === "string"
+        ? ThemeOptions[config.options]
+        : config.options;
+    return BasicSelector(fieldName, options as any);
+  }
+
+  if (
+    (config.type === "select" || config.type === "radio") &&
+    typeof config.options === "string"
+  ) {
+    return {
+      label: fieldName,
+      type: config.type,
+      options: ThemeOptions[config.options] as FieldOptions,
+    };
+  }
+
+  if (config.type === "text") {
+    return {
+      label: fieldName,
+      type: config.isMultiline ? "textarea" : "text",
+    };
+  }
+
+  return {
+    label: fieldName,
+    ...config,
+  } as Field<T>;
+}

--- a/packages/visual-editor/src/editor/index.ts
+++ b/packages/visual-editor/src/editor/index.ts
@@ -15,3 +15,4 @@ export { FontSizeSelector } from "./FontSizeSelector.tsx";
 export { BorderRadiusSelector } from "./BorderRadiusSelector.tsx";
 export { SpacingSelector } from "./SpacingSelector.tsx";
 export { BasicSelector } from "./BasicSelector.tsx";
+export { YextField } from "./YextField.tsx";


### PR DESCRIPTION
`YextField` provides a unified utility for creating typed field configurations in a Puck and Yext Visual Editor integration context. It abstracts over common field types and includes special handling for Yext's BasicSelector OptionalNumberField, YextEntityFieldSelector, and YextCollectionSubfieldSelector.

```
const myComponentFields: Fields<myComponentProps> = {
  address: YextField<AddressType>("Address", {
    type: "entity",
    filter: { types: ["type.address"] },
  }),
  showGetDirections: YextField("Show Get Directions Link", {
    type: "radio",
    options: [
      { label: "Yes", value: true },
      { label: "No", value: false },
    ],
  }),
};
```