### PR TITLE
fix: adjust address in NearbyLocations 

### DIFF
--- a/packages/visual-editor/src/components/NearbyLocations.tsx
+++ b/packages/visual-editor/src/components/NearbyLocations.tsx
@@ -200,7 +200,14 @@ const LocationCard = ({
       )}
       {address && (
         <div className="font-body-fontFamily font-body-fontWeight text-body-fontSize-sm">
-          <Address address={address} lines={[["line1"]]} />
+          <Address
+            address={address}
+            lines={[
+              ["line1"],
+              ["line2"],
+              ["city", ",", "region", "postalCode"],
+            ]}
+          />
         </div>
       )}
     </Background>


### PR DESCRIPTION
<img width="1765" alt="Screenshot 2025-04-17 at 11 27 48 AM" src="https://github.com/user-attachments/assets/3a8e1cbd-0e6c-40bf-bf2a-97976aedac0f" />

Show full address on cards instead of just line1