### PR TITLE
fix: cta undefined 

### DIFF
--- a/packages/visual-editor/src/components/atoms/cta.tsx
+++ b/packages/visual-editor/src/components/atoms/cta.tsx
@@ -42,7 +42,7 @@ export const CTA = ({
     >
       <Link
         cta={{
-          link: link ?? "#",
+          link: link || "#",
           linkType: linkType ?? "URL",
         }}
         eventName={eventName}

--- a/packages/visual-editor/src/components/atoms/cta.tsx
+++ b/packages/visual-editor/src/components/atoms/cta.tsx
@@ -49,7 +49,7 @@ export const CTA = ({
         target={target}
         aria-label={ariaLabel}
       >
-        {label}
+        {label ?? ""}
         <FaAngleRight
           size={"12px"}
           // For directoryLink, the theme value for caret is ignored

--- a/packages/visual-editor/src/components/cards/EventCard.tsx
+++ b/packages/visual-editor/src/components/cards/EventCard.tsx
@@ -98,16 +98,16 @@ const EventCardItem = ({
             </Body>
           </EntityField>
         )}
-        {resolvedCTA && (
+        {resolvedCTA?.link && (
           <EntityField
             displayName="CTA"
             fieldId={card?.cta?.field}
             constantValueEnabled={card?.cta?.constantValueEnabled}
           >
             <CTA
-              label={resolvedCTA?.label}
-              link={resolvedCTA?.link || "#"}
-              linkType={resolvedCTA?.linkType}
+              label={resolvedCTA.label}
+              link={resolvedCTA.link}
+              linkType={resolvedCTA.linkType}
               variant="link"
               className="text-palette-primary-dark"
             />

--- a/packages/visual-editor/src/components/cards/InsightCard.tsx
+++ b/packages/visual-editor/src/components/cards/InsightCard.tsx
@@ -114,7 +114,7 @@ const InsightCardItem = ({
             </EntityField>
           )}
         </div>
-        {resolvedCTA && (
+        {resolvedCTA?.link && (
           <EntityField
             displayName="CTA"
             fieldId={card?.cta.field}
@@ -122,8 +122,8 @@ const InsightCardItem = ({
           >
             <CTA
               variant={"link"}
-              label={resolvedCTA.label ?? ""}
-              link={resolvedCTA.link ?? "#"}
+              label={resolvedCTA.label}
+              link={resolvedCTA.link}
               linkType={resolvedCTA.linkType ?? "URL"}
             />
           </EntityField>

--- a/packages/visual-editor/src/components/cards/PersonCard.tsx
+++ b/packages/visual-editor/src/components/cards/PersonCard.tsx
@@ -149,7 +149,7 @@ const PersonCardItem = ({
               </div>
             </EntityField>
           )}
-          {resolvedCTA && (
+          {resolvedCTA?.link && (
             <EntityField
               displayName="CTA"
               fieldId={card?.cta?.field}
@@ -157,9 +157,9 @@ const PersonCardItem = ({
             >
               <div className="flex justify-start gap-2">
                 <CTA
-                  label={resolvedCTA?.label}
-                  link={resolvedCTA?.link || "#"}
-                  linkType={resolvedCTA?.linkType}
+                  label={resolvedCTA.label}
+                  link={resolvedCTA.link}
+                  linkType={resolvedCTA.linkType}
                   variant="link"
                 />
               </div>

--- a/packages/visual-editor/src/components/contentBlocks/CtaWrapper.tsx
+++ b/packages/visual-editor/src/components/contentBlocks/CtaWrapper.tsx
@@ -45,7 +45,7 @@ const CTAWrapperComponent: React.FC<CTAWrapperProps> = ({
     >
       <CTA
         label={cta?.label}
-        link={cta?.link || "#"}
+        link={cta?.link}
         linkType={cta?.linkType}
         variant={variant}
         className={className}

--- a/packages/visual-editor/src/components/contentBlocks/GetDirections.tsx
+++ b/packages/visual-editor/src/components/contentBlocks/GetDirections.tsx
@@ -57,7 +57,7 @@ const GetDirectionsComponent = ({
     >
       <CTA
         label={"Get Directions"}
-        link={searchQuery || "#"}
+        link={searchQuery}
         linkType={"DRIVING_DIRECTIONS"}
         variant={variant}
       />

--- a/packages/visual-editor/src/components/pageSections/HeroSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/HeroSection.tsx
@@ -290,9 +290,9 @@ const HeroSectionWrapper = ({
               >
                 <CTA
                   variant={primaryCtaField.variant}
-                  label={primaryCta?.label ?? ""}
-                  link={primaryCta?.link || "#"}
-                  linkType={primaryCta?.linkType}
+                  label={primaryCta.label}
+                  link={primaryCta.link}
+                  linkType={primaryCta.linkType}
                 />
               </EntityField>
             )}
@@ -306,9 +306,9 @@ const HeroSectionWrapper = ({
               >
                 <CTA
                   variant={secondaryCtaField.variant}
-                  label={secondaryCta?.label ?? ""}
-                  link={secondaryCta?.link || "#"}
-                  linkType={secondaryCta?.linkType}
+                  label={secondaryCta.label}
+                  link={secondaryCta.link}
+                  linkType={secondaryCta.linkType}
                 />
               </EntityField>
             )}

--- a/packages/visual-editor/src/components/pageSections/Promo.tsx
+++ b/packages/visual-editor/src/components/pageSections/Promo.tsx
@@ -181,8 +181,8 @@ const PromoWrapper: React.FC<PromoSectionProps> = ({
         {resolvedCTA && cta.visible && (
           <CTA
             variant={cta.variant}
-            label={resolvedCTA.label ?? ""}
-            link={resolvedCTA.link || "#"}
+            label={resolvedCTA.label}
+            link={resolvedCTA.link}
             linkType={resolvedCTA.linkType}
           />
         )}


### PR DESCRIPTION
`"" ?? "#"` is `""`
`"" || "#"` is `"#"`

`<Link/> `from pages-components requires link for CTAs and empty strings do not count. Fixed and removed unneeded code. 