### PR TITLE
feat: add liveVisibility prop to Promo

### DIFF
--- a/packages/visual-editor/src/components/Directory.tsx
+++ b/packages/visual-editor/src/components/Directory.tsx
@@ -149,7 +149,7 @@ const DirectoryComponent = (props: DirectoryProps) => {
   return (
     <>
       <div className="flex justify-center">
-        <BreadcrumbsComponent separator={separator} />
+        <BreadcrumbsComponent separator={separator} liveVisibility={true} />
       </div>
       {document.dm_directoryChildren &&
         isDirectoryGrid(document.dm_directoryChildren) && (

--- a/packages/visual-editor/src/components/atoms/index.ts
+++ b/packages/visual-editor/src/components/atoms/index.ts
@@ -7,3 +7,4 @@ export { MaybeLink, type MaybeLinkProps } from "./maybeLink.tsx";
 export { PageSection, type PageSectionProps } from "./pageSection.tsx";
 export { PhoneAtom, type PhoneAtomProps } from "./phone.tsx";
 export { Background, type BackgroundProps } from "./background.tsx";
+export { VisibilityWrapper } from "./visibilityWrapper.tsx";

--- a/packages/visual-editor/src/components/atoms/visibilityWrapper.tsx
+++ b/packages/visual-editor/src/components/atoms/visibilityWrapper.tsx
@@ -41,7 +41,7 @@ export const VisibilityWrapper: React.FC<VisibilityWrapperProps> = ({
           <FaEyeSlash
             className={themeManagerCn(
               wrapperVariants({ size: iconSize }),
-              "fill-gray-600"
+              "fill-gray-500"
             )}
           />
         </div>

--- a/packages/visual-editor/src/components/atoms/visibilityWrapper.tsx
+++ b/packages/visual-editor/src/components/atoms/visibilityWrapper.tsx
@@ -1,0 +1,53 @@
+import { themeManagerCn } from "@yext/visual-editor";
+import { cva, VariantProps } from "class-variance-authority";
+import * as React from "react";
+import { FaEyeSlash } from "react-icons/fa";
+
+interface VisibilityWrapperProps {
+  liveVisibility: boolean;
+  isEditing: boolean;
+  iconSize?: VariantProps<typeof wrapperVariants>["size"];
+  children: React.ReactNode;
+}
+
+export const wrapperVariants = cva("components", {
+  variants: {
+    size: {
+      sm: "text-xl",
+      base: "text-3xl",
+      lg: "text-7xl",
+    },
+  },
+  defaultVariants: {
+    size: "lg",
+  },
+});
+
+export const VisibilityWrapper: React.FC<VisibilityWrapperProps> = ({
+  liveVisibility,
+  isEditing,
+  iconSize,
+  children,
+}) => {
+  if (!liveVisibility && !isEditing) {
+    return null;
+  }
+
+  if (!liveVisibility && isEditing) {
+    return (
+      <div className="relative">
+        <div className="opacity-30">{children}</div>
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+          <FaEyeSlash
+            className={themeManagerCn(
+              wrapperVariants({ size: iconSize }),
+              "fill-gray-600"
+            )}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+};

--- a/packages/visual-editor/src/components/atoms/visibilityWrapper.tsx
+++ b/packages/visual-editor/src/components/atoms/visibilityWrapper.tsx
@@ -13,8 +13,7 @@ interface VisibilityWrapperProps {
 export const wrapperVariants = cva("components", {
   variants: {
     size: {
-      sm: "text-xl",
-      base: "text-3xl",
+      md: "text-3xl",
       lg: "text-7xl",
     },
   },

--- a/packages/visual-editor/src/components/layoutBlocks/Collection.tsx
+++ b/packages/visual-editor/src/components/layoutBlocks/Collection.tsx
@@ -176,7 +176,7 @@ export const Collection: ComponentConfig<CollectionProps> = {
     <VisibilityWrapper
       liveVisibility={props.liveVisibility}
       isEditing={props.puck.isEditing}
-      iconSize="base"
+      iconSize="md"
     >
       <CollectionSectionWrapper {...props} />
     </VisibilityWrapper>

--- a/packages/visual-editor/src/components/layoutBlocks/Collection.tsx
+++ b/packages/visual-editor/src/components/layoutBlocks/Collection.tsx
@@ -13,6 +13,7 @@ import {
   CardCategory,
   themeManagerCn,
   YextField,
+  VisibilityWrapper,
 } from "@yext/visual-editor";
 
 export interface CollectionProps {
@@ -20,6 +21,7 @@ export interface CollectionProps {
   shouldClearDropZone?: boolean;
   layout?: "grid" | "flex";
   direction?: "flex-row" | "flex-col";
+  liveVisibility: boolean;
 }
 
 const collectionFields: Fields<CollectionProps> = {
@@ -40,6 +42,13 @@ const collectionFields: Fields<CollectionProps> = {
         defaultCustomValue: 3,
       }),
     },
+  }),
+  liveVisibility: YextField("Visible on Live Page", {
+    type: "radio",
+    options: [
+      { label: "Show", value: true },
+      { label: "Hide", value: false },
+    ],
   }),
 };
 
@@ -161,6 +170,15 @@ export const Collection: ComponentConfig<CollectionProps> = {
       },
       limit: 3,
     },
+    liveVisibility: true,
   },
-  render: (props) => <CollectionSectionWrapper {...props} />,
+  render: (props) => (
+    <VisibilityWrapper
+      liveVisibility={props.liveVisibility}
+      isEditing={props.puck.isEditing}
+      iconSize="base"
+    >
+      <CollectionSectionWrapper {...props} />
+    </VisibilityWrapper>
+  ),
 };

--- a/packages/visual-editor/src/components/layoutBlocks/Flex.tsx
+++ b/packages/visual-editor/src/components/layoutBlocks/Flex.tsx
@@ -113,7 +113,7 @@ export const Flex: ComponentConfig<FlexProps> = {
     <VisibilityWrapper
       liveVisibility={props.liveVisibility}
       isEditing={props.puck.isEditing}
-      iconSize="base"
+      iconSize="md"
     >
       <FlexContainer {...props} />
     </VisibilityWrapper>

--- a/packages/visual-editor/src/components/layoutBlocks/Flex.tsx
+++ b/packages/visual-editor/src/components/layoutBlocks/Flex.tsx
@@ -9,12 +9,14 @@ import {
   ContentBlockCategory,
   LayoutBlockCategory,
   YextField,
+  VisibilityWrapper,
 } from "@yext/visual-editor";
 
 export interface FlexProps extends layoutProps {
   justifyContent: "start" | "center" | "end";
   direction: "flex-row" | "flex-col";
   wrap: "wrap" | "nowrap";
+  liveVisibility: boolean;
 }
 
 const FlexContainer = React.forwardRef<HTMLDivElement, FlexProps>(
@@ -85,6 +87,13 @@ const flexContainerFields: Fields<FlexProps> = {
     ],
   }),
   ...layoutFields,
+  liveVisibility: YextField("Visible on Live Page", {
+    type: "radio",
+    options: [
+      { label: "Show", value: true },
+      { label: "Hide", value: false },
+    ],
+  }),
 };
 
 export const Flex: ComponentConfig<FlexProps> = {
@@ -98,6 +107,15 @@ export const Flex: ComponentConfig<FlexProps> = {
     verticalPadding: "0",
     horizontalPadding: "0",
     backgroundColor: backgroundColors.background1.value,
+    liveVisibility: true,
   },
-  render: (props) => <FlexContainer {...props} />,
+  render: (props) => (
+    <VisibilityWrapper
+      liveVisibility={props.liveVisibility}
+      isEditing={props.puck.isEditing}
+      iconSize="base"
+    >
+      <FlexContainer {...props} />
+    </VisibilityWrapper>
+  ),
 };

--- a/packages/visual-editor/src/components/layoutBlocks/Grid.tsx
+++ b/packages/visual-editor/src/components/layoutBlocks/Grid.tsx
@@ -106,7 +106,7 @@ export const Grid: ComponentConfig<GridProps> = {
     <VisibilityWrapper
       liveVisibility={props.liveVisibility}
       isEditing={props.puck.isEditing}
-      iconSize="base"
+      iconSize="md"
     >
       <GridSection {...props} />
     </VisibilityWrapper>

--- a/packages/visual-editor/src/components/layoutBlocks/Grid.tsx
+++ b/packages/visual-editor/src/components/layoutBlocks/Grid.tsx
@@ -8,11 +8,13 @@ import {
   CardCategory,
   LayoutBlockCategory,
   YextField,
+  VisibilityWrapper,
 } from "@yext/visual-editor";
 import { layoutFields, layoutProps, layoutVariants } from "../Layout.tsx";
 
 export interface GridProps extends layoutProps {
   columns: number;
+  liveVisibility: boolean;
 }
 
 const GridSection = React.forwardRef<HTMLDivElement, GridProps>(
@@ -79,6 +81,13 @@ const gridSectionFields: Fields<GridProps> = {
     max: 12,
   }),
   ...layoutFields,
+  liveVisibility: YextField("Visible on Live Page", {
+    type: "radio",
+    options: [
+      { label: "Show", value: true },
+      { label: "Hide", value: false },
+    ],
+  }),
 };
 
 export const Grid: ComponentConfig<GridProps> = {
@@ -91,6 +100,15 @@ export const Grid: ComponentConfig<GridProps> = {
     horizontalPadding: "0",
     backgroundColor: backgroundColors.background1.value,
     columnFormatting: "default",
+    liveVisibility: true,
   },
-  render: (props) => <GridSection {...props} />,
+  render: (props) => (
+    <VisibilityWrapper
+      liveVisibility={props.liveVisibility}
+      isEditing={props.puck.isEditing}
+      iconSize="base"
+    >
+      <GridSection {...props} />
+    </VisibilityWrapper>
+  ),
 };

--- a/packages/visual-editor/src/components/pageSections/Banner.tsx
+++ b/packages/visual-editor/src/components/pageSections/Banner.tsx
@@ -6,6 +6,7 @@ import {
   Body,
   PageSection,
   YextField,
+  VisibilityWrapper,
 } from "@yext/visual-editor";
 import { ComponentConfig, Fields } from "@measured/puck";
 import {
@@ -17,6 +18,7 @@ export type BannerSectionProps = {
   text: YextEntityField<string>;
   textAlignment: "left" | "right" | "center";
   backgroundColor?: BackgroundStyle;
+  liveVisibility: boolean;
 };
 
 const bannerSectionFields: Fields<BannerSectionProps> = {
@@ -34,6 +36,13 @@ const bannerSectionFields: Fields<BannerSectionProps> = {
     type: "select",
     hasSearch: true,
     options: "DARK_BACKGROUND_COLOR",
+  }),
+  liveVisibility: YextField("Visible on Live Page", {
+    type: "radio",
+    options: [
+      { label: "Show", value: true },
+      { label: "Hide", value: false },
+    ],
   }),
 };
 
@@ -73,6 +82,15 @@ export const BannerSection: ComponentConfig<BannerSectionProps> = {
     },
     textAlignment: "center",
     backgroundColor: backgroundColors.background6.value,
+    liveVisibility: true,
   },
-  render: (props) => <BannerComponent {...props} />,
+  render: (props) => (
+    <VisibilityWrapper
+      liveVisibility={props.liveVisibility}
+      isEditing={props.puck.isEditing}
+      iconSize="sm"
+    >
+      <BannerComponent {...props} />
+    </VisibilityWrapper>
+  ),
 };

--- a/packages/visual-editor/src/components/pageSections/Banner.tsx
+++ b/packages/visual-editor/src/components/pageSections/Banner.tsx
@@ -88,7 +88,7 @@ export const BannerSection: ComponentConfig<BannerSectionProps> = {
     <VisibilityWrapper
       liveVisibility={props.liveVisibility}
       isEditing={props.puck.isEditing}
-      iconSize="sm"
+      iconSize="md"
     >
       <BannerComponent {...props} />
     </VisibilityWrapper>

--- a/packages/visual-editor/src/components/pageSections/Breadcrumbs.tsx
+++ b/packages/visual-editor/src/components/pageSections/Breadcrumbs.tsx
@@ -3,13 +3,25 @@ import {
   useTemplateProps,
   MaybeLink,
   PageSection,
+  YextField,
+  VisibilityWrapper,
 } from "@yext/visual-editor";
-import { ComponentConfig } from "@measured/puck";
+import { ComponentConfig, Fields } from "@measured/puck";
 
 export type BreadcrumbsSectionProps = {
   separator?: string;
+  liveVisibility: boolean;
 };
 
+const breadcrumbsSectionFields: Fields<BreadcrumbsSectionProps> = {
+  liveVisibility: YextField("Visible on Live Page", {
+    type: "radio",
+    options: [
+      { label: "Show", value: true },
+      { label: "Hide", value: false },
+    ],
+  }),
+};
 // getDirectoryParents returns an array of objects. If no dm_directoryParents or children of
 // the directory parent are not the expected objects, returns an empty array.
 const getDirectoryParents = (
@@ -87,5 +99,17 @@ export const BreadcrumbsComponent = (props: BreadcrumbsSectionProps) => {
 
 export const BreadcrumbsSection: ComponentConfig<BreadcrumbsSectionProps> = {
   label: "Breadcrumbs",
-  render: (props) => <BreadcrumbsComponent {...props} />,
+  fields: breadcrumbsSectionFields,
+  defaultProps: {
+    liveVisibility: true,
+  },
+  render: (props) => (
+    <VisibilityWrapper
+      liveVisibility={props.liveVisibility}
+      isEditing={props.puck.isEditing}
+      iconSize="sm"
+    >
+      <BreadcrumbsComponent {...props} />
+    </VisibilityWrapper>
+  ),
 };

--- a/packages/visual-editor/src/components/pageSections/Breadcrumbs.tsx
+++ b/packages/visual-editor/src/components/pageSections/Breadcrumbs.tsx
@@ -107,7 +107,7 @@ export const BreadcrumbsSection: ComponentConfig<BreadcrumbsSectionProps> = {
     <VisibilityWrapper
       liveVisibility={props.liveVisibility}
       isEditing={props.puck.isEditing}
-      iconSize="sm"
+      iconSize="md"
     >
       <BreadcrumbsComponent {...props} />
     </VisibilityWrapper>

--- a/packages/visual-editor/src/components/pageSections/CoreInfoSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/CoreInfoSection.tsx
@@ -24,6 +24,7 @@ import {
   PhoneAtom,
   Background,
   YextField,
+  VisibilityWrapper,
 } from "@yext/visual-editor";
 
 export interface CoreInfoSectionProps {
@@ -56,6 +57,7 @@ export interface CoreInfoSectionProps {
     headingText: YextEntityField<string>;
     servicesList: YextEntityField<string[]>;
   };
+  liveVisibility: boolean;
 }
 
 const coreInfoSectionFields: Fields<CoreInfoSectionProps> = {
@@ -193,6 +195,13 @@ const coreInfoSectionFields: Fields<CoreInfoSectionProps> = {
         },
       }),
     },
+  }),
+  liveVisibility: YextField("Visible on Live Page", {
+    type: "radio",
+    options: [
+      { label: "Show", value: true },
+      { label: "Hide", value: false },
+    ],
   }),
 };
 
@@ -497,6 +506,14 @@ export const CoreInfoSection: ComponentConfig<CoreInfoSectionProps> = {
         constantValue: [],
       },
     },
+    liveVisibility: true,
   },
-  render: (props) => <CoreInfoSectionWrapper {...props} />,
+  render: (props) => (
+    <VisibilityWrapper
+      liveVisibility={props.liveVisibility}
+      isEditing={props.puck.isEditing}
+    >
+      <CoreInfoSectionWrapper {...props} />
+    </VisibilityWrapper>
+  ),
 };

--- a/packages/visual-editor/src/components/pageSections/FAQs.tsx
+++ b/packages/visual-editor/src/components/pageSections/FAQs.tsx
@@ -11,6 +11,7 @@ import {
   Heading,
   backgroundColors,
   YextField,
+  VisibilityWrapper,
 } from "@yext/visual-editor";
 import {
   Accordion,
@@ -37,6 +38,7 @@ export interface FAQsSectionProps {
     question: string;
     answer: string;
   }>;
+  liveVisibility: boolean;
 }
 
 const FAQsSectionFields: Fields<FAQsSectionProps> = {
@@ -77,6 +79,13 @@ const FAQsSectionFields: Fields<FAQsSectionProps> = {
         isMultiline: true,
       }),
     },
+  }),
+  liveVisibility: YextField("Visible on Live Page", {
+    type: "radio",
+    options: [
+      { label: "Show", value: true },
+      { label: "Hide", value: false },
+    ],
   }),
 };
 
@@ -133,6 +142,14 @@ export const FAQsSection: ComponentConfig<FAQsSectionProps> = {
       level: 2,
     },
     cards: [DEFAULT_FAQ, DEFAULT_FAQ, DEFAULT_FAQ],
+    liveVisibility: true,
   },
-  render: (props) => <FAQsSectionWrapper {...props} />,
+  render: (props) => (
+    <VisibilityWrapper
+      liveVisibility={props.liveVisibility}
+      isEditing={props.puck.isEditing}
+    >
+      <FAQsSectionWrapper {...props} />
+    </VisibilityWrapper>
+  ),
 };

--- a/packages/visual-editor/src/components/pageSections/HeroSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/HeroSection.tsx
@@ -17,6 +17,7 @@ import {
   Heading,
   PageSection,
   YextField,
+  VisibilityWrapper,
 } from "@yext/visual-editor";
 import {
   ImageWrapperFields,
@@ -53,6 +54,7 @@ export interface HeroSectionProps {
     backgroundColor?: BackgroundStyle;
     imageOrientation: "left" | "right";
   };
+  liveVisibility: boolean;
 }
 
 const heroSectionFields: Fields<HeroSectionProps> = {
@@ -176,6 +178,13 @@ const heroSectionFields: Fields<HeroSectionProps> = {
         ],
       }),
     },
+  }),
+  liveVisibility: YextField("Visible on Live Page", {
+    type: "radio",
+    options: [
+      { label: "Show", value: true },
+      { label: "Hide", value: false },
+    ],
   }),
 };
 
@@ -403,6 +412,7 @@ export const HeroSection: ComponentConfig<HeroSectionProps> = {
       backgroundColor: backgroundColors.background1.value,
       imageOrientation: "right",
     },
+    liveVisibility: true,
   },
   resolveFields(data) {
     return {
@@ -413,5 +423,12 @@ export const HeroSection: ComponentConfig<HeroSectionProps> = {
       },
     };
   },
-  render: (props) => <HeroSectionWrapper {...props} />,
+  render: (props) => (
+    <VisibilityWrapper
+      liveVisibility={props.liveVisibility}
+      isEditing={props.puck.isEditing}
+    >
+      <HeroSectionWrapper {...props} />
+    </VisibilityWrapper>
+  ),
 };

--- a/packages/visual-editor/src/components/pageSections/NearbyLocations.tsx
+++ b/packages/visual-editor/src/components/pageSections/NearbyLocations.tsx
@@ -12,6 +12,7 @@ import {
   fetchNearbyLocations,
   Background,
   YextField,
+  VisibilityWrapper,
 } from "@yext/visual-editor";
 import { useQuery } from "@tanstack/react-query";
 import { Address, Coordinate, HoursStatus } from "@yext/pages-components";
@@ -40,6 +41,7 @@ export interface NearbyLocationsSectionProps {
   coordinate: YextEntityField<Coordinate>;
   radius: number;
   limit: number;
+  liveVisibility: boolean;
 }
 
 const nearbyLocationsSectionFields: Fields<NearbyLocationsSectionProps> = {
@@ -140,6 +142,13 @@ const nearbyLocationsSectionFields: Fields<NearbyLocationsSectionProps> = {
     type: "number",
     min: 0,
     max: 50,
+  }),
+  liveVisibility: YextField("Visible on Live Page", {
+    type: "radio",
+    options: [
+      { label: "Show", value: true },
+      { label: "Hide", value: false },
+    ],
   }),
 };
 
@@ -343,6 +352,14 @@ export const NearbyLocationsSection: ComponentConfig<NearbyLocationsSectionProps
           longitude: 0,
         },
       },
+      liveVisibility: true,
     },
-    render: (props) => <NearbyLocationsComponent {...props} />,
+    render: (props) => (
+      <VisibilityWrapper
+        liveVisibility={props.liveVisibility}
+        isEditing={props.puck.isEditing}
+      >
+        <NearbyLocationsComponent {...props} />
+      </VisibilityWrapper>
+    ),
   };

--- a/packages/visual-editor/src/components/pageSections/PhotoGallerySection.tsx
+++ b/packages/visual-editor/src/components/pageSections/PhotoGallerySection.tsx
@@ -25,6 +25,7 @@ import {
   useDocument,
   YextEntityField,
   YextField,
+  VisibilityWrapper,
 } from "@yext/visual-editor";
 import {
   resolvedImageFields,
@@ -43,6 +44,7 @@ export interface PhotoGallerySectionProps {
     level: HeadingLevel;
   };
   images: Array<ImageWrapperProps>;
+  liveVisibility: boolean;
 }
 
 interface DynamicChildColorsProps {
@@ -101,6 +103,13 @@ const photoGallerySectionFields: Fields<PhotoGallerySectionProps> = {
   images: YextField("Images", {
     type: "array",
     arrayFields: { ...ImageWrapperFields },
+  }),
+  liveVisibility: YextField("Visible on Live Page", {
+    type: "radio",
+    options: [
+      { label: "Show", value: true },
+      { label: "Hide", value: false },
+    ],
   }),
 };
 
@@ -258,6 +267,7 @@ export const PhotoGallerySection: ComponentConfig<PhotoGallerySectionProps> = {
         aspectRatio: 1.78,
       },
     ],
+    liveVisibility: true,
   },
   resolveFields(data) {
     const layout = data.props.images?.[0]?.layout ?? "auto";
@@ -269,5 +279,12 @@ export const PhotoGallerySection: ComponentConfig<PhotoGallerySectionProps> = {
       },
     };
   },
-  render: (props) => <PhotoGallerySectionWrapper {...props} />,
+  render: (props) => (
+    <VisibilityWrapper
+      liveVisibility={props.liveVisibility}
+      isEditing={props.puck.isEditing}
+    >
+      <PhotoGallerySectionWrapper {...props} />
+    </VisibilityWrapper>
+  ),
 };

--- a/packages/visual-editor/src/components/pageSections/SectionContainer.tsx
+++ b/packages/visual-editor/src/components/pageSections/SectionContainer.tsx
@@ -12,6 +12,7 @@ import {
   PageSectionCategory,
   useDocument,
   YextField,
+  VisibilityWrapper,
 } from "@yext/visual-editor";
 import {
   ComponentConfig,
@@ -28,6 +29,7 @@ export type SectionContainerProps = {
     level: HeadingProps["level"];
     alignment: "left" | "right" | "center";
   };
+  liveVisibility: boolean;
 };
 
 const sectionContainerFields: Fields<SectionContainerProps> = {
@@ -55,6 +57,13 @@ const sectionContainerFields: Fields<SectionContainerProps> = {
         options: ThemeOptions.ALIGNMENT,
       }),
     },
+  }),
+  liveVisibility: YextField("Visible on Live Page", {
+    type: "radio",
+    options: [
+      { label: "Show", value: true },
+      { label: "Hide", value: false },
+    ],
   }),
 };
 
@@ -96,7 +105,6 @@ const SectionContainerComponent = (
 export const SectionContainer: ComponentConfig<SectionContainerProps> = {
   label: "Section Container",
   fields: sectionContainerFields,
-  render: (props) => <SectionContainerComponent {...props} />,
   defaultProps: {
     background: backgroundColors.background1.value,
     sectionHeading: {
@@ -108,5 +116,14 @@ export const SectionContainer: ComponentConfig<SectionContainerProps> = {
       level: 2,
       alignment: "left",
     },
+    liveVisibility: true,
   },
+  render: (props) => (
+    <VisibilityWrapper
+      liveVisibility={props.liveVisibility}
+      isEditing={props.puck.isEditing}
+    >
+      <SectionContainerComponent {...props} />
+    </VisibilityWrapper>
+  ),
 };

--- a/packages/visual-editor/src/components/registry/components.ts
+++ b/packages/visual-editor/src/components/registry/components.ts
@@ -53,8 +53,15 @@ export const ui: Registry["items"] = [
   {
     name: "phone",
     type: "registry:component",
-    files: [{ path: "atoms/phone.tsx", type: "registry:component" }],
     registryDependencies: ["body", "cta"],
+    files: [{ path: "atoms/phone.tsx", type: "registry:component" }],
+  },
+  {
+    name: "visibilityWrapper",
+    type: "registry:component",
+    files: [
+      { path: "atoms/visibilityWrapper.tsx", type: "registry:component" },
+    ],
   },
   {
     name: "layout",
@@ -70,7 +77,7 @@ export const ui: Registry["items"] = [
   {
     name: "Banner",
     type: "registry:ui",
-    registryDependencies: ["body", "pageSection"],
+    registryDependencies: ["body", "pageSection", "visibilityWrapper"],
     files: [{ path: "pageSections/Banner.tsx", type: "registry:ui" }],
   },
   {
@@ -82,12 +89,18 @@ export const ui: Registry["items"] = [
   {
     name: "Breadcrumbs",
     type: "registry:ui",
-    registryDependencies: ["maybeLink", "body", "pageSection"],
+    registryDependencies: [
+      "maybeLink",
+      "body",
+      "pageSection",
+      "visibilityWrapper",
+    ],
     files: [{ path: "pageSections/Breadcrumbs.tsx", type: "registry:ui" }],
   },
   {
     name: "Collection",
     type: "registry:ui",
+    registryDependencies: ["visibilityWrapper"],
     files: [{ path: "layoutBlocks/Collection.tsx", type: "registry:ui" }],
   },
   {
@@ -100,6 +113,7 @@ export const ui: Registry["items"] = [
       "body",
       "cta",
       "phone",
+      "visibilityWrapper",
     ],
     files: [{ path: "pageSections/CoreInfoSection.tsx", type: "registry:ui" }],
   },
@@ -136,13 +150,19 @@ export const ui: Registry["items"] = [
   {
     name: "FAQsSection",
     type: "registry:ui",
-    registryDependencies: ["body", "heading", "pageSection", "accordion"],
+    registryDependencies: [
+      "body",
+      "heading",
+      "pageSection",
+      "accordion",
+      "visibilityWrapper",
+    ],
     files: [{ path: "pageSections/FAQs.tsx", type: "registry:ui" }],
   },
   {
     name: "Flex",
     type: "registry:ui",
-    registryDependencies: ["layout", "background"],
+    registryDependencies: ["layout", "background", "visibilityWrapper"],
     files: [{ path: "layoutBlocks/Flex.tsx", type: "registry:ui" }],
   },
   {
@@ -160,7 +180,12 @@ export const ui: Registry["items"] = [
   {
     name: "Grid",
     type: "registry:ui",
-    registryDependencies: ["section", "background", "layout"],
+    registryDependencies: [
+      "section",
+      "background",
+      "layout",
+      "visibilityWrapper",
+    ],
     files: [{ path: "layoutBlocks/Grid.tsx", type: "registry:ui" }],
   },
   {
@@ -178,7 +203,13 @@ export const ui: Registry["items"] = [
   {
     name: "HeroSection",
     type: "registry:ui",
-    registryDependencies: ["pageSection", "heading", "cta", "image"],
+    registryDependencies: [
+      "pageSection",
+      "heading",
+      "cta",
+      "image",
+      "visibilityWrapper",
+    ],
     files: [{ path: "pageSections/HeroSection.tsx", type: "registry:ui" }],
   },
   {
@@ -221,6 +252,7 @@ export const ui: Registry["items"] = [
       "body",
       "cta",
       "phone",
+      "visibilityWrapper",
     ],
     files: [{ path: "pageSections/NearbyLocations.tsx", type: "registry:ui" }],
   },
@@ -244,7 +276,12 @@ export const ui: Registry["items"] = [
   {
     name: "PhotoGallerySection",
     type: "registry:ui",
-    registryDependencies: ["pageSection", "heading", "image"],
+    registryDependencies: [
+      "pageSection",
+      "heading",
+      "image",
+      "visibilityWrapper",
+    ],
     files: [
       { path: "pageSections/PhotoGallerySection.tsx", type: "registry:ui" },
     ],
@@ -264,7 +301,7 @@ export const ui: Registry["items"] = [
   {
     name: "SectionContainer",
     type: "registry:ui",
-    registryDependencies: ["pageSection", "heading"],
+    registryDependencies: ["pageSection", "heading", "visibilityWrapper"],
     files: [{ path: "pageSections/SectionContainer.tsx", type: "registry:ui" }],
   },
   {


### PR DESCRIPTION
On show, no changes from normal. On hide, in live page and preview it won't show up at all and in editor it has opacity-30 with an slashed eyeball icon floating.

<img width="1580" alt="Screenshot 2025-04-18 at 1 57 10 PM" src="https://github.com/user-attachments/assets/25479439-ecea-439a-8876-ed8a7cf2c2b4" />

