### PR TITLE
fix: handle visibilityWrapper on older props

### DIFF
--- a/packages/visual-editor/src/components/atoms/visibilityWrapper.tsx
+++ b/packages/visual-editor/src/components/atoms/visibilityWrapper.tsx
@@ -28,6 +28,10 @@ export const VisibilityWrapper: React.FC<VisibilityWrapperProps> = ({
   iconSize,
   children,
 }) => {
+  if (liveVisibility === undefined) {
+    return <>{children}</>;
+  }
+
   if (!liveVisibility && !isEditing) {
     return null;
   }


### PR DESCRIPTION
When you have a site without visibilityWrapper and upgrade, the liveVisibility prop ends up undefined since default props are set on dragging into editor. 