### PR TITLE
fix: fix Collection "grid" mode applying in entity mode

### DIFF
--- a/packages/visual-editor/src/components/layoutBlocks/Collection.tsx
+++ b/packages/visual-editor/src/components/layoutBlocks/Collection.tsx
@@ -170,6 +170,8 @@ export const Collection: ComponentConfig<CollectionProps> = {
       },
       limit: 3,
     },
+    layout: "flex",
+    direction: "flex-row",
     liveVisibility: true,
   },
   render: (props) => (

--- a/packages/visual-editor/src/components/layoutBlocks/Collection.tsx
+++ b/packages/visual-editor/src/components/layoutBlocks/Collection.tsx
@@ -90,7 +90,7 @@ const CollectionSectionWrapper: React.FC<
       zone="collection-dropzone"
       className={themeManagerCn(
         "max-w-pageSection-contentWidth mx-auto gap-8",
-        layout === "grid"
+        layout === "grid" && props.collection.items.constantValueEnabled
           ? "grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3"
           : "flex flex-wrap justify-center",
         direction


### PR DESCRIPTION
When the Collections component is set to "Entity" instead of Constant Value, we hide the options for Grid and Flex.

However they were still being applied.

We only want the Flex behavior while in entity mode.

Using Grid layout in entity mode causes the cards to all get squished.