### PR TITLE
fix: adjust PhotoGallery to supports constant

### DIFF
--- a/packages/visual-editor/src/editor/YextEntityFieldSelector.tsx
+++ b/packages/visual-editor/src/editor/YextEntityFieldSelector.tsx
@@ -16,6 +16,7 @@ import { CTA_CONSTANT_CONFIG } from "../internal/puck/constant-value-fields/Call
 import { PHONE_CONSTANT_CONFIG } from "../internal/puck/constant-value-fields/Phone.tsx";
 import { BasicSelector } from "./BasicSelector.tsx";
 import { useEntityFields } from "../hooks/useEntityFields.tsx";
+import { IMAGE_LIST_CONSTANT_CONFIG } from "../internal/puck/constant-value-fields/ImageList.tsx";
 
 const devLogger = new DevLogger();
 
@@ -49,6 +50,7 @@ const TYPE_TO_CONSTANT_CONFIG: Record<string, Field<any>> = {
 
 const LIST_TYPE_TO_CONSTANT_CONFIG: Record<string, Field<any>> = {
   "type.string": TEXT_LIST_CONSTANT_CONFIG,
+  "type.image": IMAGE_LIST_CONSTANT_CONFIG,
 };
 
 const getConstantConfigFromType = (

--- a/packages/visual-editor/src/internal/puck/constant-value-fields/ImageList.tsx
+++ b/packages/visual-editor/src/internal/puck/constant-value-fields/ImageList.tsx
@@ -1,0 +1,18 @@
+import { ArrayField } from "@measured/puck";
+import { ImageType } from "@yext/pages-components";
+
+export const IMAGE_LIST_CONSTANT_CONFIG: ArrayField<ImageType[]> = {
+  label: "",
+  type: "array",
+  arrayFields: {
+    url: {
+      type: "text",
+    },
+    height: {
+      type: "text",
+    },
+    width: {
+      type: "text",
+    },
+  },
+};


### PR DESCRIPTION
No clue how I missed this, but now when you select const, you can actual adjust the array of const images. 

<img width="1840" alt="Screenshot 2025-04-24 at 12 59 40 PM" src="https://github.com/user-attachments/assets/28f54514-eddc-44fa-a47a-9c4e298f1e29" />
