### PR TITLE
fix: apply gap inside of grid columns

### DIFF
--- a/packages/visual-editor/src/components/layoutBlocks/Grid.tsx
+++ b/packages/visual-editor/src/components/layoutBlocks/Grid.tsx
@@ -56,7 +56,11 @@ const GridSection = React.forwardRef<HTMLDivElement, GridProps>(
           {Array.from({ length: columns }).map((_, idx) => (
             <div className="w-full" key={idx}>
               <DropZone
-                className="flex flex-col w-full"
+                className={themeManagerCn(
+                  layoutVariants({ gap }),
+                  `flex flex-col w-full`,
+                  className
+                )}
                 zone={`column-${idx}`}
                 allow={[
                   ...CardCategory,


### PR DESCRIPTION
The gap was only being applied to the space between columns.

According to the item, it seems that we expect to have the gap also applied between rows.

Unsure if we want this fix or not. Waiting on feedback.