### PR TITLE
fix: adjust YextEntityFieldSelector

### DIFF
--- a/packages/visual-editor/src/editor/YextEntityFieldSelector.tsx
+++ b/packages/visual-editor/src/editor/YextEntityFieldSelector.tsx
@@ -274,8 +274,6 @@ const ConstantValueInput = <T extends Record<string, any>>({
     return;
   }
 
-  console.log("onChange", onChange);
-
   return constantFieldConfig.type === "custom" ? (
     <AutoField
       onChange={(newConstantValue, uiState) =>

--- a/packages/visual-editor/src/editor/YextEntityFieldSelector.tsx
+++ b/packages/visual-editor/src/editor/YextEntityFieldSelector.tsx
@@ -256,7 +256,7 @@ const ConstantValueModeToggler = ({
 
 type InputProps<T extends Record<string, any>> = {
   filter: RenderEntityFieldFilter<T>;
-  onChange: (value: any) => void;
+  onChange: (value: any, uiState: any) => void;
   value: any;
 };
 
@@ -274,14 +274,19 @@ const ConstantValueInput = <T extends Record<string, any>>({
     return;
   }
 
+  console.log("onChange", onChange);
+
   return constantFieldConfig.type === "custom" ? (
     <AutoField
-      onChange={(newConstantValue) =>
-        onChange({
-          field: value?.field ?? "",
-          constantValue: newConstantValue,
-          constantValueEnabled: true,
-        })
+      onChange={(newConstantValue, uiState) =>
+        onChange(
+          {
+            field: value?.field ?? "",
+            constantValue: newConstantValue,
+            constantValueEnabled: true,
+          },
+          uiState
+        )
       }
       value={value?.constantValue}
       field={constantFieldConfig}
@@ -292,12 +297,15 @@ const ConstantValueInput = <T extends Record<string, any>>({
       className={`ve-inline-block w-full ${constantFieldConfig.label ? "ve-pt-4" : ""}`}
     >
       <AutoField
-        onChange={(newConstantValue) =>
-          onChange({
-            field: value?.field ?? "",
-            constantValue: newConstantValue,
-            constantValueEnabled: true,
-          })
+        onChange={(newConstantValue, uiState) =>
+          onChange(
+            {
+              field: value?.field ?? "",
+              constantValue: newConstantValue,
+              constantValueEnabled: true,
+            },
+            uiState
+          )
         }
         value={value?.constantValue}
         field={constantFieldConfig}
@@ -348,12 +356,15 @@ const EntityFieldInput = <T extends Record<string, any>>({
     <div className={"ve-inline-block ve-w-full ve-pt-4"}>
       <AutoField
         field={basicSelectorField}
-        onChange={(selectedEntityField) => {
-          onChange({
-            field: selectedEntityField,
-            constantValue: value?.constantValue ?? "",
-            constantValueEnabled: false,
-          });
+        onChange={(selectedEntityField, uiState) => {
+          onChange(
+            {
+              field: selectedEntityField,
+              constantValue: value?.constantValue ?? "",
+              constantValueEnabled: false,
+            },
+            uiState
+          );
         }}
         value={value?.field}
       />


### PR DESCRIPTION
When I was playing around with PhotoGallery, I noticed puck's array field (available when const value is toggled) wasn't updating the ui properly. Now fixed. 