### PR TITLE
fix: photoGallery returning zero

### DIFF
--- a/packages/visual-editor/src/components/pageSections/PhotoGallerySection.tsx
+++ b/packages/visual-editor/src/components/pageSections/PhotoGallerySection.tsx
@@ -170,7 +170,7 @@ const PhotoGallerySectionComponent = ({
           <Heading level={sectionHeading.level}>{sectionHeading.text}</Heading>
         </EntityField>
       )}
-      {images?.length && (
+      {images && images.length > 0 && (
         <CarouselProvider
           className="flex flex-col md:flex-row justify-center gap-8"
           naturalSlideWidth={100}


### PR DESCRIPTION
Ah so React is dumb and images?.length is falsy but it decides to render 0 like in screenshot. Google says if your condition is falsy, it doesn't return the second argument (<CarouselProvider/>), but instead will return images?.length, which is a number, so react will render it because React skips rendering for anything that is typeof boolean or undefined
<img width="1602" alt="Screenshot 2025-04-28 at 12 48 03 PM" src="https://github.com/user-attachments/assets/37902f3a-e2ba-43bc-add9-cb5c5bb10b8d" />


Fixed so now images && images.length > 0 is the conditional so its a boolean and React renders nothing. 
<img width="1602" alt="Screenshot 2025-04-28 at 12 47 49 PM" src="https://github.com/user-attachments/assets/ecf10ec1-1c0b-4d27-9ec3-0ad534a0a3f6" />
