### PR TITLE
feat: add timestamp atom

### DIFF
--- a/packages/visual-editor/src/components/atoms/timestamp.tsx
+++ b/packages/visual-editor/src/components/atoms/timestamp.tsx
@@ -1,0 +1,101 @@
+const format1: Intl.DateTimeFormatOptions = {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+};
+
+const format3: Intl.DateTimeFormatOptions = {
+  timeZoneName: "short",
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "numeric",
+};
+
+export enum TimestampOption {
+  DATE = "DATE",
+  DATE_TIME = "DATE_TIME",
+  DATE_RANGE = "DATE_RANGE",
+  DATE_TIME_RANGE = "DATE_TIME_RANGE",
+}
+
+export type TimestampProps = {
+  date: string; // ISO 8601 from KG like "YYYY-MM-DDTHH:MM"
+  option?: TimestampOption;
+  endDate?: string; // ISO 8601 from KG like "YYYY-MM-DDTHH:MM"
+  timeZone?: string;
+  hideTimeZone?: boolean;
+};
+
+type TimestampFormatterPropsType = {
+  date: Date;
+  option?: TimestampOption;
+  endDate?: Date;
+  timeZone?: string;
+  hideTimeZone?: boolean;
+};
+
+function timestampFormatter({
+  date,
+  option = TimestampOption.DATE,
+  endDate,
+  timeZone,
+  hideTimeZone,
+}: TimestampFormatterPropsType): string {
+  let format: Intl.DateTimeFormatOptions = (() => {
+    switch (option) {
+      case TimestampOption.DATE:
+        return format1;
+      case TimestampOption.DATE_TIME:
+        return format3;
+      case TimestampOption.DATE_RANGE:
+        return format1;
+      case TimestampOption.DATE_TIME_RANGE:
+        return format3;
+      default:
+        return format1;
+    }
+  })();
+
+  if (timeZone) {
+    format = { ...format, timeZone };
+  }
+
+  if (hideTimeZone) {
+    format = { ...format, timeZoneName: undefined };
+  }
+
+  if (
+    option === TimestampOption.DATE_TIME_RANGE ||
+    option === TimestampOption.DATE_RANGE
+  ) {
+    return new Intl.DateTimeFormat("en-US", format).formatRange(date, endDate!);
+  } else {
+    return new Intl.DateTimeFormat("en-US", format).format(date);
+  }
+}
+
+export function Timestamp({
+  date,
+  option = TimestampOption.DATE,
+  endDate = "",
+  timeZone,
+  hideTimeZone = false,
+}: TimestampProps): JSX.Element {
+  const startDate = new Date(date);
+  const formattedEndDate = new Date(endDate);
+  const timestamp = timestampFormatter({
+    date: startDate,
+    option,
+    endDate: formattedEndDate,
+    timeZone,
+    hideTimeZone,
+  });
+
+  return (
+    <div className="components font-body-fontFamily font-body-fontWeight text-body-fontSize inline-block">
+      {timestamp}
+    </div>
+  );
+}


### PR DESCRIPTION
Was just a quick component. The formats + options align with mana-ui's. Will be used in EventSection, TestimonialSection, InsightSection, etc so it seemed easier to toss together an atom to use than to rewrite same logic in each component. 

<img width="1840" alt="Screenshot 2025-05-01 at 4 29 12 PM" src="https://github.com/user-attachments/assets/d8ea861a-8ff9-4d96-a063-7532759685b7" />
