### PR TITLE
feat: update heroSection

### DIFF
--- a/packages/visual-editor/src/components/pageSections/HeroSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/HeroSection.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { ComponentConfig, Fields } from "@measured/puck";
 import { HoursStatus, HoursType } from "@yext/pages-components";
 import {
+  HeroSection as HeroSectionType,
   useDocument,
   resolveYextEntityField,
   EntityField,
@@ -30,7 +31,7 @@ export interface HeroSectionProps {
     entityField: YextEntityField<HoursType>;
     showHours: boolean;
   };
-  hero: YextEntityField<HeroSection>;
+  hero: YextEntityField<HeroSectionType>;
   styles: {
     backgroundColor?: BackgroundStyle;
     imageOrientation: "left" | "right";

--- a/packages/visual-editor/src/components/pageSections/HeroSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/HeroSection.tsx
@@ -16,6 +16,7 @@ import {
   PageSection,
   YextField,
   VisibilityWrapper,
+  CTAProps,
 } from "@yext/visual-editor";
 
 const PLACEHOLDER_IMAGE_URL = "https://placehold.co/640x360";
@@ -34,6 +35,14 @@ export interface HeroSectionProps {
     showHours: boolean;
   };
   hero: YextEntityField<HeroSectionType>;
+  primaryCTA: {
+    showCTA: boolean;
+    variant: CTAProps["variant"];
+  };
+  secondaryCTA: {
+    showCTA: boolean;
+    variant: CTAProps["variant"];
+  };
   styles: {
     backgroundColor?: BackgroundStyle;
     imageOrientation: "left" | "right";
@@ -98,6 +107,38 @@ const heroSectionFields: Fields<HeroSectionProps> = {
       types: ["type.hero_section"],
     },
   }),
+  primaryCTA: YextField("Primary CTA", {
+    type: "object",
+    objectFields: {
+      showCTA: YextField("Show CTA", {
+        type: "radio",
+        options: [
+          { label: "Show", value: true },
+          { label: "Hide", value: false },
+        ],
+      }),
+      variant: YextField("Button Variant", {
+        type: "radio",
+        options: "CTA_VARIANT",
+      }),
+    },
+  }),
+  secondaryCTA: YextField("Secondary CTA", {
+    type: "object",
+    objectFields: {
+      showCTA: YextField("Show CTA", {
+        type: "radio",
+        options: [
+          { label: "Show", value: true },
+          { label: "Hide", value: false },
+        ],
+      }),
+      variant: YextField("Button Variant", {
+        type: "radio",
+        options: "CTA_VARIANT",
+      }),
+    },
+  }),
   styles: YextField("Styles", {
     type: "object",
     objectFields: {
@@ -129,6 +170,8 @@ const HeroSectionWrapper = ({
   localGeoModifier,
   hours,
   hero,
+  primaryCTA,
+  secondaryCTA,
   styles,
 }: HeroSectionProps) => {
   const document = useDocument() as any;
@@ -211,18 +254,18 @@ const HeroSectionWrapper = ({
             className="flex flex-col gap-y-4 md:flex-row md:gap-x-4"
             aria-label="Call to Actions"
           >
-            {resolvedHero?.primaryCta?.label && (
+            {resolvedHero?.primaryCta?.label && primaryCTA.showCTA && (
               <CTA
-                variant="primary"
+                variant={primaryCTA.variant}
                 label={resolvedHero.primaryCta.label}
                 link={resolvedHero.primaryCta.link}
                 linkType={resolvedHero.primaryCta.linkType}
                 className={"py-3"}
               />
             )}
-            {resolvedHero?.secondaryCta?.label && (
+            {resolvedHero?.secondaryCta?.label && secondaryCTA.showCTA && (
               <CTA
-                variant="secondary"
+                variant={secondaryCTA.variant}
                 label={resolvedHero.secondaryCta.label}
                 link={resolvedHero.secondaryCta.link}
                 linkType={resolvedHero.secondaryCta.linkType}
@@ -289,6 +332,14 @@ export const HeroSection: ComponentConfig<HeroSectionProps> = {
           linkType: "URL",
         },
       },
+    },
+    primaryCTA: {
+      showCTA: true,
+      variant: "primary",
+    },
+    secondaryCTA: {
+      showCTA: true,
+      variant: "secondary",
     },
     styles: {
       backgroundColor: backgroundColors.background1.value,

--- a/packages/visual-editor/src/components/pageSections/HeroSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/HeroSection.tsx
@@ -1,33 +1,35 @@
 import * as React from "react";
 import { ComponentConfig, Fields } from "@measured/puck";
-import { HoursStatus, HoursType } from "@yext/pages-components";
+import {
+  HoursStatus,
+  HoursType,
+  ImageType,
+  CTA as CTAType,
+} from "@yext/pages-components";
 import {
   useDocument,
   resolveYextEntityField,
   EntityField,
   YextEntityField,
   Image,
-  ImageProps,
-  ImageWrapperProps,
   backgroundColors,
   BackgroundStyle,
   HeadingLevel,
   CTA,
-  CTAProps,
   Heading,
   PageSection,
   YextField,
   VisibilityWrapper,
 } from "@yext/visual-editor";
-import {
-  ImageWrapperFields,
-  resolvedImageFields,
-} from "../contentBlocks/Image.js";
 
-const PLACEHOLDER_IMAGE_URL = "https://placehold.co/640x360";
+/** Hardcoded type */
+type HeroSection = {
+  image?: ImageType;
+  primaryCta?: CTAType;
+  secondaryCta?: CTAType;
+};
 
 export interface HeroSectionProps {
-  image: ImageWrapperProps;
   businessName: {
     entityField: YextEntityField<string>;
     level: HeadingLevel;
@@ -40,16 +42,7 @@ export interface HeroSectionProps {
     entityField: YextEntityField<HoursType>;
     showHours: boolean;
   };
-  primaryCta: {
-    entityField: YextEntityField<CTAProps>;
-    variant: CTAProps["variant"];
-    showCTA: boolean;
-  };
-  secondaryCta: {
-    entityField: YextEntityField<CTAProps>;
-    variant: CTAProps["variant"];
-    showCTA: boolean;
-  };
+  hero: YextEntityField<HeroSection>;
   styles: {
     backgroundColor?: BackgroundStyle;
     imageOrientation: "left" | "right";
@@ -58,16 +51,6 @@ export interface HeroSectionProps {
 }
 
 const heroSectionFields: Fields<HeroSectionProps> = {
-  image: YextField("Image", {
-    type: "object",
-    objectFields: {
-      ...ImageWrapperFields,
-      image: {
-        ...ImageWrapperFields.image,
-        label: "Value",
-      },
-    },
-  }),
   businessName: YextField("Business Name", {
     type: "object",
     objectFields: {
@@ -118,48 +101,10 @@ const heroSectionFields: Fields<HeroSectionProps> = {
       }),
     },
   }),
-  primaryCta: YextField("Primary CTA", {
-    type: "object",
-    objectFields: {
-      entityField: YextField("Value", {
-        type: "entityField",
-        filter: {
-          types: ["type.cta"],
-        },
-      }),
-      variant: YextField("Button Variant", {
-        type: "radio",
-        options: "CTA_VARIANT",
-      }),
-      showCTA: YextField("CTA", {
-        type: "radio",
-        options: [
-          { label: "Show", value: true },
-          { label: "Hide", value: false },
-        ],
-      }),
-    },
-  }),
-  secondaryCta: YextField("Secondary CTA", {
-    type: "object",
-    objectFields: {
-      entityField: YextField("Value", {
-        type: "entityField",
-        filter: {
-          types: ["type.cta"],
-        },
-      }),
-      variant: YextField("Button Variant", {
-        type: "radio",
-        options: "CTA_VARIANT",
-      }),
-      showCTA: YextField("CTA", {
-        type: "radio",
-        options: [
-          { label: "Show", value: true },
-          { label: "Hide", value: false },
-        ],
-      }),
+  hero: YextField("Hero", {
+    type: "entityField",
+    filter: {
+      types: ["type.hero_section"],
     },
   }),
   styles: YextField("Styles", {
@@ -189,39 +134,26 @@ const heroSectionFields: Fields<HeroSectionProps> = {
 };
 
 const HeroSectionWrapper = ({
-  businessName: businessNameField,
-  localGeoModifier: localGeoModifierField,
-  hours: hoursField,
-  primaryCta: primaryCtaField,
-  secondaryCta: secondaryCtaField,
-  image: imageField,
+  businessName,
+  localGeoModifier,
+  hours,
+  hero,
   styles,
 }: HeroSectionProps) => {
   const document = useDocument() as any;
-  const businessName = resolveYextEntityField<string>(
+  const resolvedBusinessName = resolveYextEntityField<string>(
     document,
-    businessNameField.entityField
+    businessName.entityField
   );
-  const localGeoModifier = resolveYextEntityField<string>(
+  const resolvedLocalGeoModifier = resolveYextEntityField<string>(
     document,
-    localGeoModifierField.entityField
+    localGeoModifier.entityField
   );
-  const hours = resolveYextEntityField<HoursType>(
+  const resolvedHours = resolveYextEntityField<HoursType>(
     document,
-    hoursField.entityField
+    hours.entityField
   );
-  const primaryCta = resolveYextEntityField<CTAProps>(
-    document,
-    primaryCtaField.entityField
-  );
-  const secondaryCta = resolveYextEntityField<CTAProps>(
-    document,
-    secondaryCtaField.entityField
-  );
-  const image = resolveYextEntityField<ImageProps["image"]>(
-    document,
-    imageField.image
-  );
+  const resolvedHero = resolveYextEntityField(document, hero);
 
   const { timezone } = document as {
     timezone: string;
@@ -246,101 +178,76 @@ const HeroSectionWrapper = ({
             className="flex flex-col gap-y-0"
             aria-label="Business Information"
           >
-            {businessName && (
+            {resolvedBusinessName && (
               <EntityField
                 displayName="Business Name"
-                fieldId={businessNameField.entityField.field}
+                fieldId={businessName.entityField.field}
                 constantValueEnabled={
-                  businessNameField.entityField.constantValueEnabled
+                  businessName.entityField.constantValueEnabled
                 }
               >
-                <Heading level={businessNameField.level}>
-                  {businessName}
+                <Heading level={businessName.level}>
+                  {resolvedBusinessName}
                 </Heading>
               </EntityField>
             )}
-            {localGeoModifier && (
+            {resolvedLocalGeoModifier && (
               <EntityField
                 displayName="Local GeoModifier"
-                fieldId={localGeoModifierField.entityField.field}
+                fieldId={localGeoModifier.entityField.field}
                 constantValueEnabled={
-                  localGeoModifierField.entityField.constantValueEnabled
+                  localGeoModifier.entityField.constantValueEnabled
                 }
               >
-                <Heading level={localGeoModifierField.level}>
-                  {localGeoModifier}
+                <Heading level={localGeoModifier.level}>
+                  {resolvedLocalGeoModifier}
                 </Heading>
               </EntityField>
             )}
           </section>
-          {hours && hoursField.showHours && (
+          {resolvedHours && hours.showHours && (
             <EntityField
               displayName="Hours"
-              fieldId={hoursField.entityField.field}
-              constantValueEnabled={hoursField.entityField.constantValueEnabled}
+              fieldId={hours.entityField.field}
+              constantValueEnabled={hours.entityField.constantValueEnabled}
             >
-              <HoursStatus hours={hours} timezone={timezone} />
+              <HoursStatus hours={resolvedHours} timezone={timezone} />
             </EntityField>
           )}
         </header>
-        {((primaryCta && primaryCtaField.showCTA) ||
-          (secondaryCta && secondaryCtaField.showCTA)) && (
+        {(resolvedHero?.primaryCta || resolvedHero?.secondaryCta) && (
           <div
             className="flex flex-col gap-y-4 md:flex-row md:gap-x-4"
             aria-label="Call to Actions"
           >
-            {primaryCta && primaryCtaField.showCTA && (
-              <EntityField
-                displayName="Primary CTA"
-                fieldId={primaryCtaField.entityField.field}
-                constantValueEnabled={
-                  primaryCtaField.entityField.constantValueEnabled
-                }
-              >
-                <CTA
-                  variant={primaryCtaField.variant}
-                  label={primaryCta.label}
-                  link={primaryCta.link}
-                  linkType={primaryCta.linkType}
-                  className={"py-3"}
-                />
-              </EntityField>
+            {resolvedHero?.primaryCta && (
+              <CTA
+                variant="primary"
+                label={resolvedHero.primaryCta.label}
+                link={resolvedHero.primaryCta.link}
+                linkType={resolvedHero.primaryCta.linkType}
+                className={"py-3"}
+              />
             )}
-            {secondaryCta && secondaryCtaField.showCTA && (
-              <EntityField
-                displayName="Secondary CTA"
-                fieldId={secondaryCtaField.entityField.field}
-                constantValueEnabled={
-                  secondaryCtaField.entityField.constantValueEnabled
-                }
-              >
-                <CTA
-                  variant={secondaryCtaField.variant}
-                  label={secondaryCta.label}
-                  link={secondaryCta.link}
-                  linkType={secondaryCta.linkType}
-                  className={"py-3"}
-                />
-              </EntityField>
+            {resolvedHero.secondaryCta && (
+              <CTA
+                variant="secondary"
+                label={resolvedHero.secondaryCta.label}
+                link={resolvedHero.secondaryCta.link}
+                linkType={resolvedHero.secondaryCta.linkType}
+                className={"py-3"}
+              />
             )}
           </div>
         )}
       </div>
-      {image && (
+      {resolvedHero?.image && (
         <div className="w-full" role="region" aria-label="Hero Image">
-          <EntityField
-            displayName="Image"
-            fieldId={imageField.image.field}
-            constantValueEnabled={imageField.image.constantValueEnabled}
-          >
-            <Image
-              image={image}
-              layout={imageField.layout}
-              width={imageField.width}
-              height={imageField.height}
-              aspectRatio={imageField.aspectRatio}
-            />
-          </EntityField>
+          <Image
+            image={resolvedHero?.image}
+            layout="auto"
+            aspectRatio={resolvedHero?.image.width / resolvedHero?.image.height}
+          />
         </div>
       )}
     </PageSection>
@@ -351,18 +258,6 @@ export const HeroSection: ComponentConfig<HeroSectionProps> = {
   label: "Hero Section",
   fields: heroSectionFields,
   defaultProps: {
-    image: {
-      image: {
-        field: "",
-        constantValue: {
-          height: 360,
-          width: 640,
-          url: PLACEHOLDER_IMAGE_URL,
-        },
-      },
-      layout: "auto",
-      aspectRatio: 1.78,
-    },
     businessName: {
       entityField: {
         field: "name",
@@ -384,46 +279,15 @@ export const HeroSection: ComponentConfig<HeroSectionProps> = {
       },
       showHours: true,
     },
-    primaryCta: {
-      entityField: {
-        field: "",
-        constantValue: {
-          label: "Call To Action",
-          link: "#",
-          linkType: "URL",
-        },
-        constantValueEnabled: true,
-      },
-      variant: "primary",
-      showCTA: true,
-    },
-    secondaryCta: {
-      entityField: {
-        field: "",
-        constantValue: {
-          label: "Call To Action",
-          link: "#",
-          linkType: "URL",
-        },
-        constantValueEnabled: true,
-      },
-      variant: "secondary",
-      showCTA: true,
+    hero: {
+      field: "",
+      constantValue: {},
     },
     styles: {
       backgroundColor: backgroundColors.background1.value,
       imageOrientation: "right",
     },
     liveVisibility: true,
-  },
-  resolveFields(data) {
-    return {
-      ...heroSectionFields,
-      image: {
-        ...heroSectionFields.image,
-        objectFields: resolvedImageFields(data.props.image.layout),
-      },
-    };
   },
   render: (props) => (
     <VisibilityWrapper

--- a/packages/visual-editor/src/components/pageSections/HeroSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/HeroSection.tsx
@@ -1,11 +1,6 @@
 import * as React from "react";
 import { ComponentConfig, Fields } from "@measured/puck";
-import {
-  HoursStatus,
-  HoursType,
-  ImageType,
-  CTA as CTAType,
-} from "@yext/pages-components";
+import { HoursStatus, HoursType } from "@yext/pages-components";
 import {
   useDocument,
   resolveYextEntityField,
@@ -21,13 +16,6 @@ import {
   YextField,
   VisibilityWrapper,
 } from "@yext/visual-editor";
-
-/** Hardcoded type */
-type HeroSection = {
-  image?: ImageType;
-  primaryCta?: CTAType;
-  secondaryCta?: CTAType;
-};
 
 export interface HeroSectionProps {
   businessName: {

--- a/packages/visual-editor/src/components/pageSections/HeroSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/HeroSection.tsx
@@ -18,6 +18,8 @@ import {
   VisibilityWrapper,
 } from "@yext/visual-editor";
 
+const PLACEHOLDER_IMAGE_URL = "https://placehold.co/640x360";
+
 export interface HeroSectionProps {
   businessName: {
     entityField: YextEntityField<string>;
@@ -209,7 +211,7 @@ const HeroSectionWrapper = ({
             className="flex flex-col gap-y-4 md:flex-row md:gap-x-4"
             aria-label="Call to Actions"
           >
-            {resolvedHero?.primaryCta && (
+            {resolvedHero?.primaryCta?.label && (
               <CTA
                 variant="primary"
                 label={resolvedHero.primaryCta.label}
@@ -218,7 +220,7 @@ const HeroSectionWrapper = ({
                 className={"py-3"}
               />
             )}
-            {resolvedHero.secondaryCta && (
+            {resolvedHero?.secondaryCta?.label && (
               <CTA
                 variant="secondary"
                 label={resolvedHero.secondaryCta.label}
@@ -270,7 +272,23 @@ export const HeroSection: ComponentConfig<HeroSectionProps> = {
     },
     hero: {
       field: "",
-      constantValue: {},
+      constantValue: {
+        image: {
+          height: 360,
+          width: 640,
+          url: PLACEHOLDER_IMAGE_URL,
+        },
+        primaryCta: {
+          label: "Call To Action",
+          link: "#",
+          linkType: "URL",
+        },
+        secondaryCta: {
+          label: "Call To Action",
+          link: "#",
+          linkType: "URL",
+        },
+      },
     },
     styles: {
       backgroundColor: backgroundColors.background1.value,

--- a/packages/visual-editor/src/components/pageSections/HeroSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/HeroSection.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { ComponentConfig, Fields } from "@measured/puck";
 import { HoursStatus, HoursType } from "@yext/pages-components";
 import {
-  HeroSection as HeroSectionType,
+  HeroSectionType,
   useDocument,
   resolveYextEntityField,
   EntityField,

--- a/packages/visual-editor/src/editor/YextEntityFieldSelector.tsx
+++ b/packages/visual-editor/src/editor/YextEntityFieldSelector.tsx
@@ -17,6 +17,7 @@ import { PHONE_CONSTANT_CONFIG } from "../internal/puck/constant-value-fields/Ph
 import { BasicSelector } from "./BasicSelector.tsx";
 import { useEntityFields } from "../hooks/useEntityFields.tsx";
 import { IMAGE_LIST_CONSTANT_CONFIG } from "../internal/puck/constant-value-fields/ImageList.tsx";
+import { HERO_CONSTANT_CONFIG } from "../internal/puck/constant-value-fields/HeroSection.tsx";
 
 const devLogger = new DevLogger();
 
@@ -47,6 +48,7 @@ const TYPE_TO_CONSTANT_CONFIG: Record<string, Field<any>> = {
   "type.image": IMAGE_CONSTANT_CONFIG,
   "type.address": ADDRESS_CONSTANT_CONFIG,
   "type.cta": CTA_CONSTANT_CONFIG,
+  "type.hero_section": HERO_CONSTANT_CONFIG,
 };
 
 const LIST_TYPE_TO_CONSTANT_CONFIG: Record<string, Field<any>> = {

--- a/packages/visual-editor/src/internal/puck/constant-value-fields/CallToAction.tsx
+++ b/packages/visual-editor/src/internal/puck/constant-value-fields/CallToAction.tsx
@@ -1,5 +1,33 @@
-import { CustomField } from "@measured/puck";
+import { CustomField, Field } from "@measured/puck";
 import { ConstantFields } from "./ConstantField.tsx";
+import { CTA } from "@yext/pages-components";
+
+const linkTypeOptions = [
+  {
+    label: "URL",
+    value: "URL",
+  },
+  {
+    label: "Email",
+    value: "EMAIL",
+  },
+  {
+    label: "Phone",
+    value: "PHONE",
+  },
+  {
+    label: "Click to Website",
+    value: "CLICK_TO_WEBSITE",
+  },
+  {
+    label: "Driving Directions",
+    value: "DRIVING_DIRECTIONS",
+  },
+  {
+    label: "Other",
+    value: "OTHER",
+  },
+];
 
 export const CTA_CONSTANT_CONFIG: CustomField<
   { label: string; link: string; linkType: string }[]
@@ -24,34 +52,29 @@ export const CTA_CONSTANT_CONFIG: CustomField<
           label: "Link Type",
           field: "linkType",
           fieldType: "select",
-          options: [
-            {
-              label: "URL",
-              value: "URL",
-            },
-            {
-              label: "Email",
-              value: "EMAIL",
-            },
-            {
-              label: "Phone",
-              value: "PHONE",
-            },
-            {
-              label: "Click to Website",
-              value: "CLICK_TO_WEBSITE",
-            },
-            {
-              label: "Driving Directions",
-              value: "DRIVING_DIRECTIONS",
-            },
-            {
-              label: "Other",
-              value: "OTHER",
-            },
-          ],
+          options: linkTypeOptions,
         },
       ],
     });
+  },
+};
+
+// Fields for CTA with labels
+export const ctaFields: Field<CTA> = {
+  type: "object",
+  objectFields: {
+    label: {
+      label: "Label",
+      type: "text",
+    },
+    link: {
+      label: "Link",
+      type: "text",
+    },
+    linkType: {
+      label: "Link Type",
+      type: "select",
+      options: linkTypeOptions,
+    },
   },
 };

--- a/packages/visual-editor/src/internal/puck/constant-value-fields/HeroSection.tsx
+++ b/packages/visual-editor/src/internal/puck/constant-value-fields/HeroSection.tsx
@@ -1,49 +1,6 @@
 import { Field } from "@measured/puck";
 import { CTA, ImageType } from "@yext/pages-components";
-
-const ctaFields: Field<CTA> = {
-  type: "object",
-  objectFields: {
-    label: {
-      label: "Label",
-      type: "text",
-    },
-    link: {
-      label: "Link",
-      type: "text",
-    },
-    linkType: {
-      label: "Link Type",
-      type: "select",
-      options: [
-        {
-          label: "URL",
-          value: "URL",
-        },
-        {
-          label: "Email",
-          value: "EMAIL",
-        },
-        {
-          label: "Phone",
-          value: "PHONE",
-        },
-        {
-          label: "Click to Website",
-          value: "CLICK_TO_WEBSITE",
-        },
-        {
-          label: "Driving Directions",
-          value: "DRIVING_DIRECTIONS",
-        },
-        {
-          label: "Other",
-          value: "OTHER",
-        },
-      ],
-    },
-  },
-};
+import { ctaFields } from "./CallToAction.tsx";
 
 export const HERO_CONSTANT_CONFIG: Field<{
   image: ImageType;

--- a/packages/visual-editor/src/internal/puck/constant-value-fields/HeroSection.tsx
+++ b/packages/visual-editor/src/internal/puck/constant-value-fields/HeroSection.tsx
@@ -1,0 +1,75 @@
+import { Field } from "@measured/puck";
+import { CTA, ImageType } from "@yext/pages-components";
+
+const ctaFields: Field<CTA> = {
+  type: "object",
+  objectFields: {
+    label: {
+      label: "Label",
+      type: "text",
+    },
+    link: {
+      label: "Link",
+      type: "text",
+    },
+    linkType: {
+      label: "Link Type",
+      type: "select",
+      options: [
+        {
+          label: "URL",
+          value: "URL",
+        },
+        {
+          label: "Email",
+          value: "EMAIL",
+        },
+        {
+          label: "Phone",
+          value: "PHONE",
+        },
+        {
+          label: "Click to Website",
+          value: "CLICK_TO_WEBSITE",
+        },
+        {
+          label: "Driving Directions",
+          value: "DRIVING_DIRECTIONS",
+        },
+        {
+          label: "Other",
+          value: "OTHER",
+        },
+      ],
+    },
+  },
+};
+
+export const HERO_CONSTANT_CONFIG: Field<{
+  image: ImageType;
+  primaryCta: CTA;
+  secondaryCta: CTA;
+}> = {
+  label: "",
+  type: "object",
+  objectFields: {
+    image: {
+      label: "Image",
+      type: "object",
+      objectFields: {
+        url: {
+          label: "URL",
+          type: "text",
+        },
+      },
+    } as Field<ImageType>,
+    primaryCta: {
+      label: "Primary CTA",
+      ...ctaFields,
+    },
+    secondaryCta: {
+      label: "Secondary CTA",
+      ...ctaFields,
+    },
+  },
+};

--- a/packages/visual-editor/src/internal/utils/getFilteredEntityFields.ts
+++ b/packages/visual-editor/src/internal/utils/getFilteredEntityFields.ts
@@ -42,6 +42,7 @@ export type EntityFieldTypes =
   | "type.phone"
   | "type.coordinate"
   | "type.cta"
+  | "type.hero_section"
   | "type.rich_text_v2"
   | `c_${string}`;
 

--- a/packages/visual-editor/src/types/entityFields.ts
+++ b/packages/visual-editor/src/types/entityFields.ts
@@ -1,3 +1,5 @@
+import { ImageType, CTA as CTAType } from "@yext/pages-components";
+
 export type YextSchemaField = {
   name: string;
   displayName?: string;
@@ -19,4 +21,10 @@ export type YextFieldDefinition = {
 export type StreamFields = {
   fields: YextSchemaField[];
   displayNames?: Record<string, string>;
+};
+
+export type HeroSection = {
+  image?: ImageType;
+  primaryCta?: CTAType;
+  secondaryCta?: CTAType;
 };

--- a/packages/visual-editor/src/types/entityFields.ts
+++ b/packages/visual-editor/src/types/entityFields.ts
@@ -1,5 +1,3 @@
-import { ImageType, CTA as CTAType } from "@yext/pages-components";
-
 export type YextSchemaField = {
   name: string;
   displayName?: string;
@@ -21,10 +19,4 @@ export type YextFieldDefinition = {
 export type StreamFields = {
   fields: YextSchemaField[];
   displayNames?: Record<string, string>;
-};
-
-export type HeroSection = {
-  image?: ImageType;
-  primaryCta?: CTAType;
-  secondaryCta?: CTAType;
 };

--- a/packages/visual-editor/src/types/index.ts
+++ b/packages/visual-editor/src/types/index.ts
@@ -2,4 +2,4 @@ export {
   type YextSchemaField,
   type YextFieldDefinition,
 } from "./entityFields.ts";
-export { type HeroSection } from "./types.ts";
+export { type HeroSectionType } from "./types.ts";

--- a/packages/visual-editor/src/types/index.ts
+++ b/packages/visual-editor/src/types/index.ts
@@ -2,3 +2,4 @@ export {
   type YextSchemaField,
   type YextFieldDefinition,
 } from "./entityFields.ts";
+export { type HeroSection } from "./types.ts";

--- a/packages/visual-editor/src/types/types.ts
+++ b/packages/visual-editor/src/types/types.ts
@@ -1,0 +1,7 @@
+import { ImageType, CTA as CTAType } from "@yext/pages-components";
+
+export type HeroSection = {
+  image?: ImageType;
+  primaryCta?: CTAType;
+  secondaryCta?: CTAType;
+};

--- a/packages/visual-editor/src/types/types.ts
+++ b/packages/visual-editor/src/types/types.ts
@@ -1,6 +1,6 @@
 import { ImageType, CTA as CTAType } from "@yext/pages-components";
 
-export type HeroSection = {
+export type HeroSectionType = {
   image?: ImageType;
   primaryCta?: CTAType;
   secondaryCta?: CTAType;


### PR DESCRIPTION
Updated HeroSection to no longer map to individual entityFields but instead map to one new built-in field we are adding which is `type.hero_section` which includes the image, primaryCta, and secondaryCta

[video](https://jam.dev/c/cf81cf87-3d89-47f0-abbb-33a92f65eb84)