### PR TITLE
feat: use document env vars to set up search headless

### DIFF
--- a/packages/visual-editor/THIRD-PARTY-NOTICES
+++ b/packages/visual-editor/THIRD-PARTY-NOTICES
@@ -4401,6 +4401,50 @@ Apache-2.0
 
 The following npm package may be included in this product:
 
+ - @yext/search-headless-react@2.5.0
+
+This package contains the following license:
+
+Contains information from the language-subtag-registry JSON Database (https://github.com/mattcg/language-subtag-registry/tree/master/data/json)
+which is made available under the ODC Attribution License (https://github.com/mattcg/language-subtag-registry/blob/master/LICENSE.md).
+
+The Search Headless React files listed in this repository are licensed under the below license. All other features and products are subject to 
+separate agreements and certain functionality requires paid subscriptions to Yext products.
+
+BSD 3-Clause License
+
+Copyright (c) 2022, Yext
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-----------
+
+The following npm package may be included in this product:
+
  - eslint@9.21.0
 
 This package contains the following license:

--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -75,7 +75,8 @@
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.4.0",
     "tsx": "^4.16.3",
-    "mapbox-gl": "^2.9.2"
+    "mapbox-gl": "^2.9.2",
+    "@yext/search-headless-react": "^2.5.0"
   },
   "engines": {
     "node": "^18 || ^20.2.0 || ^22"

--- a/packages/visual-editor/src/utils/index.ts
+++ b/packages/visual-editor/src/utils/index.ts
@@ -25,3 +25,4 @@ export {
 export { applyAnalytics } from "./applyAnalytics.ts";
 export { getPageMetadata } from "./getPageMetadata.ts";
 export { fetchNearbyLocations } from "./api/nearbyLocations.tsx";
+export { createSearchHeadlessConfig } from "./searchHeadlessConfig.ts";

--- a/packages/visual-editor/src/utils/searchHeadlessConfig.ts
+++ b/packages/visual-editor/src/utils/searchHeadlessConfig.ts
@@ -1,0 +1,71 @@
+import {
+  CloudChoice,
+  CloudRegion,
+  Environment,
+  HeadlessConfig,
+} from "@yext/search-headless-react";
+
+/**
+ * Builds the search headless config for the template. Returns undefined if the config is not valid.
+ * @param document the entity document
+ */
+export const createSearchHeadlessConfig = (document: any) => {
+  const warnings = [];
+  const searchApiKey = document?._env?.YEXT_SEARCH_API_KEY;
+  if (!searchApiKey) {
+    warnings.push("Missing YEXT_SEARCH_API_KEY! Unable to set up locator.");
+  }
+  const mapboxApiKey = document?._env?.YEXT_MAPBOX_API_KEY;
+  if (!mapboxApiKey) {
+    warnings.push("Missing YEXT_MAPBOX_API_KEY! Unable to set up locator.");
+  }
+  const cloudRegion = document?._env?.YEXT_CLOUD_REGION;
+  if (!cloudRegion || !isValidCloudRegion(cloudRegion)) {
+    warnings.push(
+      "Invalid or missing YEXT_CLOUD_REGION! Unable to set up locator."
+    );
+  }
+  const cloudChoice = document?._env?.YEXT_CLOUD_CHOICE;
+  if (!cloudChoice || !isValidCloudChoice(cloudChoice)) {
+    warnings.push(
+      "Invalid or missing YEXT_CLOUD_CHOICE! Unable to set up locator."
+    );
+  }
+  const environment = document?._env?.YEXT_ENVIRONMENT;
+  if (!environment || !isValidEnvironment(environment)) {
+    warnings.push(
+      "Invalid or missing YEXT_ENVIRONMENT! Unable to set up locator."
+    );
+  }
+  if (warnings.length > 0) {
+    warnings.forEach((msg) => console.warn(msg));
+    return;
+  }
+
+  // experienceKey will eventually be on the entity document, waiting on Spruce
+  // https://yext.slack.com/archives/C06A06BCUUF/p1745963801890889
+  const experienceKey = "jacob-test";
+  const headlessConfig: HeadlessConfig = {
+    apiKey: searchApiKey,
+    experienceKey: experienceKey,
+    locale: document.locale,
+    experienceVersion: "PRODUCTION",
+    verticalKey: "locations",
+    cloudRegion: cloudRegion,
+    cloudChoice: cloudChoice,
+    environment: environment,
+  };
+  return headlessConfig;
+};
+
+const isValidCloudRegion = (value: any): value is CloudRegion => {
+  return Object.values(CloudRegion).includes(value);
+};
+
+const isValidCloudChoice = (value: any): value is CloudChoice => {
+  return Object.values(CloudChoice).includes(value);
+};
+
+const isValidEnvironment = (value: any): value is Environment => {
+  return Object.values(Environment).includes(value);
+};

--- a/packages/visual-editor/src/vite-plugin/templates/edit.tsx
+++ b/packages/visual-editor/src/vite-plugin/templates/edit.tsx
@@ -5,6 +5,7 @@ import {
   usePlatformBridgeDocument,
   usePlatformBridgeEntityFields,
   VisualEditorProvider,
+  createSearchHeadlessConfig,
 } from "@yext/visual-editor";
 import { componentRegistry } from "../ve.config";
 import {
@@ -39,6 +40,13 @@ export const getHeadConfig: GetHeadConfig<TemplateRenderProps> = ({
 const Edit: () => JSX.Element = () => {
   const entityDocument = usePlatformBridgeDocument();
   const entityFields = usePlatformBridgeEntityFields();
+
+  // TODO (kgerner): move this to a Locator-specific template once we make one
+  // See this PR for example: https://github.com/yext/visual-editor/pull/409
+  // In the meantime, we can gate wrapping with SearchHeadlessProvider to only when
+  // the entity document has a locator config on it (waiting on Spruce):
+  // https://yexttest.atlassian.net/browse/SPR-6003
+  const searchHeadlessConfig = createSearchHeadlessConfig(entityDocument);
 
   return (
     <VisualEditorProvider

--- a/packages/visual-editor/src/vite-plugin/templates/main.tsx
+++ b/packages/visual-editor/src/vite-plugin/templates/main.tsx
@@ -19,7 +19,6 @@ import {
   applyAnalytics,
 } from "@yext/visual-editor";
 import { themeConfig } from "../../theme.config";
-import { buildSchema } from "../utils/buildSchema";
 import { AnalyticsProvider } from "@yext/pages-components";
 
 export const getHeadConfig: GetHeadConfig<TemplateRenderProps> = ({
@@ -64,11 +63,9 @@ export const getHeadConfig: GetHeadConfig<TemplateRenderProps> = ({
           ]
         : []),
     ],
-    other: [
-      applyAnalytics(document),
-      applyTheme(document, themeConfig),
-      buildSchema(document),
-    ].join("\n"),
+    other: [applyAnalytics(document), applyTheme(document, themeConfig)].join(
+      "\n"
+    ),
   };
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,9 @@ importers:
       "@yext/pages-components":
         specifier: ^1.1.4
         version: 1.1.4(@lexical/clipboard@0.12.6(lexical@0.12.6))(@lexical/selection@0.12.6(lexical@0.12.6))(@types/react@18.3.12)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(yjs@13.6.20)
+      "@yext/search-headless-react":
+        specifier: ^2.5.0
+        version: 2.5.0(encoding@0.1.13)(react@18.3.1)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0

--- a/starter/src/components/Locator.tsx
+++ b/starter/src/components/Locator.tsx
@@ -18,9 +18,15 @@ import {
   useSearchState,
 } from "@yext/search-headless-react";
 import * as React from "react";
-import { BasicSelector, Body, Button, CTA, Heading } from "@yext/visual-editor";
+import {
+  BasicSelector,
+  Body,
+  Button,
+  CTA,
+  Heading,
+  normalizeSlug,
+} from "@yext/visual-editor";
 import { LngLat, LngLatBounds } from "mapbox-gl";
-import { normalizeSlug } from "@yext/visual-editor";
 import { useEffect, useState } from "react";
 import { HoursStatus } from "@yext/pages-components";
 import { Address, Hours } from "../types/autogen.ts";

--- a/starter/src/templates/dev.tsx
+++ b/starter/src/templates/dev.tsx
@@ -15,15 +15,17 @@ import {
   VisualEditorProvider,
   YextSchemaField,
   defaultThemeConfig,
+  createSearchHeadlessConfig,
 } from "@yext/visual-editor";
 import { buildSchema } from "../utils/buildSchema.ts";
 import tailwindConfig from "../../tailwind.config";
 import { devTemplateStream } from "../dev.config";
 import React from "react";
 import {
-  CloudChoice,
-  CloudRegion,
-  Environment,
+  // CloudChoice,
+  // CloudRegion,
+  // Environment,
+  // HeadlessConfig,
   provideHeadless,
   SearchHeadlessProvider,
 } from "@yext/search-headless-react";
@@ -114,18 +116,26 @@ const Dev: Template<TemplateRenderProps> = (props) => {
   const { document } = props;
   const entityFields = devTemplateStream.stream.schema
     .fields as unknown as YextSchemaField[];
-  const config = {
-    apiKey: "",
-    experienceKey: "jacob-test",
-    locale: "en",
-    experienceVersion: "STAGING",
-    verticalKey: "locations",
-    businessId: document.businessId,
-    cloudRegion: CloudRegion.US,
-    cloudChoice: CloudChoice.GLOBAL_MULTI,
-    environment: Environment.PROD,
-  };
-  const searcher = provideHeadless(config);
+
+  const searchHeadlessConfig = createSearchHeadlessConfig(document);
+  if (!searchHeadlessConfig) {
+    return <></>;
+  }
+  const searcher = provideHeadless(searchHeadlessConfig);
+
+  // Uncomment this to use the config object directly while we're waiting for other work to be done
+  // const config = {
+  //   apiKey: "",
+  //   experienceKey: "jacob-test",
+  //   locale: "en",
+  //   experienceVersion: "STAGING",
+  //   verticalKey: "locations",
+  //   businessId: document.businessId,
+  //   cloudRegion: CloudRegion.US,
+  //   cloudChoice: CloudChoice.GLOBAL_MULTI,
+  //   environment: Environment.PROD,
+  // };
+  // const searcher = provideHeadless(config);
 
   return (
     <div>

--- a/starter/src/templates/dev.tsx
+++ b/starter/src/templates/dev.tsx
@@ -130,7 +130,6 @@ const Dev: Template<TemplateRenderProps> = (props) => {
   //   locale: "en",
   //   experienceVersion: "STAGING",
   //   verticalKey: "locations",
-  //   businessId: document.businessId,
   //   cloudRegion: CloudRegion.US,
   //   cloudChoice: CloudChoice.GLOBAL_MULTI,
   //   environment: Environment.PROD,


### PR DESCRIPTION
This will attempt to read the environment variables off of the entity document in order to get the values needed to set up Search Headless.

Remaining work to be done:
- read experience key from entity document (waiting on Spruce work)
- move logic to locator-specific template
- actually set the env vars in the site when creating the first locator page set

J=[WAT-4782](https://yexttest.atlassian.net/browse/WAT-4782?atlOrigin=eyJpIjoiZTRkYWYwMzNhZDUwNGExNGIwMDkzNTU5NDQ0OTNmNjUiLCJwIjoiaiJ9)
TEST=manual
Used dev account in development mode and saw us attempt to read from the env vars