### PR TITLE
POC for component filtering

### DIFF
--- a/starter/package.json
+++ b/starter/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "scripts": {
     "dev": "cd .. && pnpm build && cd ./starter && pages dev --local --no-prod-url --noInit",
+    "dev:local": "pages dev --local --no-prod-url --noInit",
     "prod": "pages prod",
     "build": "pages build",
     "components": "REGISTRY_URL=https://reliably-numerous-kit.pgsdemo.com/components npx shadcn add"

--- a/starter/src/templates/dev.tsx
+++ b/starter/src/templates/dev.tsx
@@ -8,7 +8,7 @@ import {
   TemplateProps,
   TemplateRenderProps,
 } from "@yext/pages";
-import { componentRegistry } from "../ve.config";
+import { componentRegistry, filterComponentsFromRegistry } from "../ve.config";
 import {
   applyTheme,
   Editor,
@@ -102,6 +102,12 @@ export const getPath: GetPath<TemplateProps> = ({ document }) => {
     : `${localePath}${document.id.toString()}`;
 };
 
+const filteredRegistry = filterComponentsFromRegistry(
+  componentRegistry,
+  "dev",
+  ["BreadcrumbsSection", "HeroSection", "CoreInfoSection"]
+);
+
 const Dev: Template<TemplateRenderProps> = (props) => {
   const [themeMode, setThemeMode] = React.useState<boolean>(false);
   const { document } = props;
@@ -128,7 +134,7 @@ const Dev: Template<TemplateRenderProps> = (props) => {
         >
           <Editor
             document={document}
-            componentRegistry={componentRegistry}
+            componentRegistry={filteredRegistry}
             themeConfig={defaultThemeConfig}
             localDev={true}
             forceThemeMode={themeMode}

--- a/starter/src/ve.config.tsx
+++ b/starter/src/ve.config.tsx
@@ -1,4 +1,4 @@
-import { DropZone, type Config } from "@measured/puck";
+import { DefaultComponentProps, DropZone, type Config } from "@measured/puck";
 import "@yext/visual-editor/style.css";
 import "./index.css";
 import {
@@ -83,3 +83,52 @@ export const mainConfig: Config<MainProps> = {
 export const componentRegistry = new Map<string, Config<any>>([
   ["dev", mainConfig],
 ]);
+
+const filterComponentsFromConfig = <T extends DefaultComponentProps>(
+  config: Config<T>,
+  componentNamesToExclude: string[]
+): Config<T> => {
+  // Filter components object
+  const filteredComponents = Object.fromEntries(
+    Object.entries(config.components).filter(
+      ([key]) => !componentNamesToExclude.includes(key)
+    )
+  ) as Config<T>["components"];
+
+  // Filter categories by removing specified components from their components arrays
+  const filteredCategories = Object.fromEntries(
+    Object.entries(config.categories || {}).map(([categoryKey, category]) => [
+      categoryKey,
+      {
+        ...category,
+        components: (category.components || []).filter(
+          (componentName) =>
+            !componentNamesToExclude.includes(componentName as string)
+        ),
+      },
+    ])
+  );
+
+  return {
+    ...config,
+    components: filteredComponents,
+    categories: filteredCategories,
+  };
+};
+
+// Utility to filter components from a registry
+export const filterComponentsFromRegistry = (
+  registry: Map<string, Config<any>>,
+  registryKey: string,
+  componentNamesToExclude: string[]
+): Map<string, Config<any>> => {
+  const newRegistry = new Map(registry);
+  const config = newRegistry.get(registryKey);
+  if (config) {
+    newRegistry.set(
+      registryKey,
+      filterComponentsFromConfig(config, componentNamesToExclude)
+    );
+  }
+  return newRegistry;
+};


### PR DESCRIPTION
This is a POC/WIP to prove that components can be filtered dynamically, even though they are React code. The idea would be for some sort of config in the UI or hardcode set of components available to a particular vertical. The ve.config.tx would still maintain the full set of available components but then we'd filter at runtime based on some available/unavailable list passed through the document.

Doing this allows us to not have a different template (main.tsx, professional.tsx, etc) per vertical. It also allows us to do some crazy things in the future where someone brings their own library of components that only show up for a particular business.