### PR TITLE
fix: generate templates in plugin for dev server

### DIFF
--- a/packages/visual-editor/src/vite-plugin/plugin.ts
+++ b/packages/visual-editor/src/vite-plugin/plugin.ts
@@ -63,7 +63,6 @@ export const yextVisualEditorPlugin = (): Plugin => {
         return;
       }
       generateFiles();
-
       server.httpServer?.on("close", () => {
         cleanupFiles();
       });

--- a/packages/visual-editor/src/vite-plugin/plugin.ts
+++ b/packages/visual-editor/src/vite-plugin/plugin.ts
@@ -4,6 +4,7 @@ import { Plugin } from "vite";
 import mainTemplate from "./templates/main.tsx?raw";
 import editTemplate from "./templates/edit.tsx?raw";
 import directoryTemplate from "./templates/directory.tsx?raw";
+import { execSync } from "node:child_process";
 
 // files to generate
 const virtualFiles: Record<string, string> = {
@@ -17,6 +18,8 @@ export const yextVisualEditorPlugin = (): Plugin => {
   const filesToCleanup: string[] = [];
 
   const generateFiles = () => {
+    let newFilesWritten = false;
+
     Object.entries(virtualFiles).forEach(([fileName, content]) => {
       const filePath = path.join(process.cwd(), fileName);
       filesToCleanup.push(filePath);
@@ -25,7 +28,12 @@ export const yextVisualEditorPlugin = (): Plugin => {
         return;
       }
       fs.writeFileSync(filePath, content);
+      newFilesWritten = true;
     });
+
+    if (newFilesWritten) {
+      execSync("npx pages generate templates");
+    }
   };
 
   const cleanupFiles = () => {
@@ -55,6 +63,7 @@ export const yextVisualEditorPlugin = (): Plugin => {
         return;
       }
       generateFiles();
+
       server.httpServer?.on("close", () => {
         cleanupFiles();
       });

--- a/packages/visual-editor/vite.config.plugin.ts
+++ b/packages/visual-editor/vite.config.plugin.ts
@@ -15,7 +15,7 @@ export default defineConfig(() => ({
     target: "node18",
     tsconfig: path.resolve(__dirname, "tsconfig.plugin.json"),
     rollupOptions: {
-      external: ["node:path", "fs-extra"],
+      external: ["node:path", "node:child_process", "fs-extra"],
     },
   },
 }));


### PR DESCRIPTION
Runs the generate templates stage after writing the VE templates so that the edit static page is including in features.json. Alternative solution to https://github.com/yext/pages/pull/579.

The dev server should be run in the starter with the `--noGenFeatures` flag because the initial generate is run async and can complete after this one.