### PR TITLE
fix: card heading levels

### DIFF
--- a/packages/visual-editor/src/components/Directory.tsx
+++ b/packages/visual-editor/src/components/Directory.tsx
@@ -58,7 +58,7 @@ const DirectoryCard = ({
               : profile.slug
           }
         >
-          <Heading level={4} semanticLevelOverride="h3">
+          <Heading level={4} semanticLevelOverride={3}>
             {profile.name}
           </Heading>
         </MaybeLink>

--- a/packages/visual-editor/src/components/atoms/heading.tsx
+++ b/packages/visual-editor/src/components/atoms/heading.tsx
@@ -70,7 +70,7 @@ export interface HeadingProps
   extends Omit<React.HTMLAttributes<HTMLHeadingElement>, "color">,
     VariantProps<typeof headingVariants> {
   level: HeadingLevel;
-  semanticLevelOverride?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "span";
+  semanticLevelOverride?: HeadingLevel | "span";
 }
 
 export const Heading = React.forwardRef<HTMLHeadingElement, HeadingProps>(
@@ -86,12 +86,16 @@ export const Heading = React.forwardRef<HTMLHeadingElement, HeadingProps>(
     },
     ref
   ) => {
-    const Tag =
-      semanticLevelOverride ??
-      (`h${level}` as keyof Pick<
-        JSX.IntrinsicElements,
-        "h1" | "h2" | "h3" | "h4" | "h5" | "h6"
-      >);
+    const Tag = (
+      semanticLevelOverride
+        ? typeof semanticLevelOverride === "string"
+          ? semanticLevelOverride
+          : `h${semanticLevelOverride}`
+        : `h${level}`
+    ) as keyof Pick<
+      JSX.IntrinsicElements,
+      "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "span"
+    >;
 
     return (
       <Tag

--- a/packages/visual-editor/src/components/pageSections/EventSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/EventSection.tsx
@@ -83,9 +83,11 @@ const eventSectionFields: Fields<EventSectionProps> = {
 const EventCard = ({
   event,
   backgroundColor,
+  sectionHeadingLevel,
 }: {
   event: EventStruct;
   backgroundColor?: BackgroundStyle;
+  sectionHeadingLevel: HeadingLevel;
 }) => {
   return (
     <Background
@@ -105,7 +107,14 @@ const EventCard = ({
       </div>
       <div className="flex flex-col gap-2 p-6 w-full md:w-[55%]">
         {event.title && (
-          <Heading level={6} semanticLevelOverride={3}>
+          <Heading
+            level={6}
+            semanticLevelOverride={
+              sectionHeadingLevel < 6
+                ? ((sectionHeadingLevel + 1) as HeadingLevel)
+                : "span"
+            }
+          >
             {event.title}
           </Heading>
         )}
@@ -164,6 +173,7 @@ const EventSectionWrapper: React.FC<EventSectionProps> = (props) => {
                 key={index}
                 event={event}
                 backgroundColor={styles.cardBackgroundColor}
+                sectionHeadingLevel={styles.headingLevel}
               />
             ))}
           </div>

--- a/packages/visual-editor/src/components/pageSections/EventSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/EventSection.tsx
@@ -105,7 +105,7 @@ const EventCard = ({
       </div>
       <div className="flex flex-col gap-2 p-6 w-full md:w-[55%]">
         {event.title && (
-          <Heading level={6} semanticLevelOverride="h3">
+          <Heading level={6} semanticLevelOverride={3}>
             {event.title}
           </Heading>
         )}

--- a/packages/visual-editor/src/components/pageSections/InsightSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/InsightSection.tsx
@@ -82,9 +82,11 @@ const insightSectionFields: Fields<InsightSectionProps> = {
 const InsightCard = ({
   insight,
   backgroundColor,
+  sectionHeadingLevel,
 }: {
   insight: InsightStruct;
   backgroundColor?: BackgroundStyle;
+  sectionHeadingLevel: HeadingLevel;
 }) => {
   return (
     <Background className="rounded-sm h-full" background={backgroundColor}>
@@ -108,7 +110,18 @@ const InsightCard = ({
               )}
             </div>
           )}
-          {insight.name && <Heading level={3}>{insight.name}</Heading>}
+          {insight.name && (
+            <Heading
+              level={3}
+              semanticLevelOverride={
+                sectionHeadingLevel < 6
+                  ? ((sectionHeadingLevel + 1) as HeadingLevel)
+                  : "span"
+              }
+            >
+              {insight.name}
+            </Heading>
+          )}
           <MaybeRTF data={insight.description} />
         </div>
         {insight.cta && (
@@ -157,6 +170,7 @@ const InsightSectionWrapper = ({ data, styles }: InsightSectionProps) => {
                 key={index}
                 insight={insight}
                 backgroundColor={styles.cardBackgroundColor}
+                sectionHeadingLevel={styles.headingLevel}
               />
             ))}
           </div>

--- a/packages/visual-editor/src/components/pageSections/ProductSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/ProductSection.tsx
@@ -81,9 +81,11 @@ const productSectionFields: Fields<ProductSectionProps> = {
 const ProductCard = ({
   product,
   backgroundColor,
+  sectionHeadingLevel,
 }: {
   product: ProductStruct;
   backgroundColor?: BackgroundStyle;
+  sectionHeadingLevel: HeadingLevel;
 }) => {
   return (
     <Background
@@ -100,7 +102,15 @@ const ProductCard = ({
       <div className="p-8 gap-8 flex flex-col">
         <div className="gap-4 flex flex-col">
           {product.name && (
-            <Heading level={3} className="mb-2">
+            <Heading
+              level={3}
+              semanticLevelOverride={
+                sectionHeadingLevel < 6
+                  ? ((sectionHeadingLevel + 1) as HeadingLevel)
+                  : "span"
+              }
+              className="mb-2"
+            >
               {product.name}
             </Heading>
           )}
@@ -160,6 +170,7 @@ const ProductSectionWrapper = ({ data, styles }: ProductSectionProps) => {
                 key={index}
                 product={product}
                 backgroundColor={styles.cardBackgroundColor}
+                sectionHeadingLevel={styles.headingLevel}
               />
             ))}
           </div>

--- a/packages/visual-editor/src/components/pageSections/TeamSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/TeamSection.tsx
@@ -82,9 +82,11 @@ const TeamSectionFields: Fields<TeamSectionProps> = {
 const PersonCard = ({
   person,
   backgroundColor,
+  sectionHeadingLevel,
 }: {
   person: PersonStruct;
   backgroundColor?: BackgroundStyle;
+  sectionHeadingLevel: HeadingLevel;
 }) => {
   return (
     <div className="flex flex-col rounded-lg overflow-hidden border bg-white h-full">
@@ -99,7 +101,18 @@ const PersonCard = ({
           )}
         </div>
         <div className="flex flex-col justify-center gap-1">
-          {person.name && <Heading level={3}>{person.name}</Heading>}
+          {person.name && (
+            <Heading
+              level={3}
+              semanticLevelOverride={
+                sectionHeadingLevel < 6
+                  ? ((sectionHeadingLevel + 1) as HeadingLevel)
+                  : "span"
+              }
+            >
+              {person.name}
+            </Heading>
+          )}
           {person.title && <Body variant="base">{person.title}</Body>}
         </div>
       </Background>
@@ -183,6 +196,7 @@ const TeamSectionWrapper = ({ data, styles }: TeamSectionProps) => {
                 key={index}
                 person={person}
                 backgroundColor={styles.cardBackgroundColor}
+                sectionHeadingLevel={styles.headingLevel}
               />
             ))}
           </div>

--- a/packages/visual-editor/src/components/pageSections/TestimonialSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/TestimonialSection.tsx
@@ -80,9 +80,11 @@ const testimonialSectionFields: Fields<TestimonialSectionProps> = {
 const TestimonialCard = ({
   testimonial,
   backgroundColor,
+  sectionHeadingLevel,
 }: {
   testimonial: TestimonialStruct;
   backgroundColor?: BackgroundStyle;
+  sectionHeadingLevel: HeadingLevel;
 }) => {
   return (
     <div className="flex flex-col rounded-lg overflow-hidden border h-full">
@@ -94,7 +96,16 @@ const TestimonialCard = ({
       </Background>
       <Background background={backgroundColor} className="p-8">
         {testimonial.contributorName && (
-          <Heading level={3}>{testimonial.contributorName}</Heading>
+          <Heading
+            level={3}
+            semanticLevelOverride={
+              sectionHeadingLevel < 6
+                ? ((sectionHeadingLevel + 1) as HeadingLevel)
+                : "span"
+            }
+          >
+            {testimonial.contributorName}
+          </Heading>
         )}
         {testimonial.contributionDate && (
           <Timestamp
@@ -147,6 +158,7 @@ const TestimonialSectionWrapper = ({
                 key={index}
                 testimonial={testimonial}
                 backgroundColor={styles.cardBackgroundColor}
+                sectionHeadingLevel={styles.headingLevel}
               />
             ))}
           </div>


### PR DESCRIPTION
For WCAG, the headers inside the cards that are in one of our list sections (Event, Insight, Product, Team, Testimonial) should be one heading level under than the Section Heading, regardless of their styling