### PR TITLE
feat: support boolean and option with YextEntityField

### DIFF
--- a/packages/visual-editor/src/internal/utils/getFilteredEntityFields.ts
+++ b/packages/visual-editor/src/internal/utils/getFilteredEntityFields.ts
@@ -42,6 +42,7 @@ export type EntityFieldTypes =
   | "type.phone"
   | "type.coordinate"
   | "type.cta"
+  | "type.boolean"
   | "type.faq_section"
   | "type.testimonials_section"
   | "type.products_section"
@@ -115,11 +116,13 @@ const walkSubfields = (
 };
 
 const getTypeFromSchemaField = (schemaField: YextSchemaField) => {
-  return (
+  const type =
     schemaField.definition.typeName ||
     schemaField.definition.typeRegistryId ||
-    Object.entries(schemaField.definition.type)[0][1]
-  );
+    Object.entries(schemaField.definition.type)[0][1];
+
+  // type.option is a string from an enum
+  return type === "type.option" ? "type.string" : type;
 };
 
 function appendToMapList<K, V>(

--- a/packages/visual-editor/src/internal/utils/getFilteredEntityFields.ts
+++ b/packages/visual-editor/src/internal/utils/getFilteredEntityFields.ts
@@ -43,6 +43,7 @@ export type EntityFieldTypes =
   | "type.coordinate"
   | "type.cta"
   | "type.boolean"
+  | "type.option"
   | "type.faq_section"
   | "type.testimonials_section"
   | "type.products_section"
@@ -116,13 +117,11 @@ const walkSubfields = (
 };
 
 const getTypeFromSchemaField = (schemaField: YextSchemaField) => {
-  const type =
+  return (
     schemaField.definition.typeName ||
     schemaField.definition.typeRegistryId ||
-    Object.entries(schemaField.definition.type)[0][1];
-
-  // type.option is a string from an enum
-  return type === "type.option" ? "type.string" : type;
+    Object.entries(schemaField.definition.type)[0][1]
+  );
 };
 
 function appendToMapList<K, V>(
@@ -147,6 +146,14 @@ const getEntityTypeToFieldNames = (
       const typeName = getTypeFromSchemaField(fieldToSchema.schemaField);
       if (typeName) {
         prev = appendToMapList(prev, typeName, fieldToSchema.name);
+
+        // Also list type.option as type.string if not expanded
+        if (
+          typeName === "type.option" &&
+          fieldToSchema.schemaField.optionFormat !== "OPTION_FORMAT_EXPANDED"
+        ) {
+          prev = appendToMapList(prev, "type.string", fieldToSchema.name);
+        }
       }
     }
 

--- a/packages/visual-editor/src/types/entityFields.ts
+++ b/packages/visual-editor/src/types/entityFields.ts
@@ -5,6 +5,7 @@ export type YextSchemaField = {
   children?: {
     fields: YextSchemaField[];
   };
+  optionFormat?: "OPTION_FORMAT_EXPANDED";
 };
 
 export type YextFieldDefinition = {

--- a/starter/localData/dev-location-stream__en__8573da7e3961090ddb59214a1f01e59a.json
+++ b/starter/localData/dev-location-stream__en__8573da7e3961090ddb59214a1f01e59a.json
@@ -1346,6 +1346,8 @@
       "width": 600
     }
   },
+  "c_exampleOption": "Option 1",
+  "c_exampleMultiOption": ["Option 2", "Option 3"],
   "hours": {
     "friday": {
       "openIntervals": [

--- a/starter/localData/dev-location-stream__en__8573da7e3961090ddb59214a1f01e59a.json
+++ b/starter/localData/dev-location-stream__en__8573da7e3961090ddb59214a1f01e59a.json
@@ -1347,6 +1347,26 @@
     }
   },
   "c_exampleOption": "Option 1",
+  "c_exampleOptionExpanded": [
+    {
+      "displayName": "Option 1",
+      "numericValue": 504227,
+      "selected": false,
+      "value": "OPTION_1"
+    },
+    {
+      "displayName": "Option 2",
+      "numericValue": 504228,
+      "selected": true,
+      "value": "OPTION_2"
+    },
+    {
+      "displayName": "Option 3",
+      "numericValue": 504229,
+      "selected": false,
+      "value": "OPTION_3"
+    }
+  ],
   "c_exampleMultiOption": ["Option 2", "Option 3"],
   "hours": {
     "friday": {

--- a/starter/localData/dev-location-stream__en__a5ac5ff0d6330870779568c3bc865bc7.json
+++ b/starter/localData/dev-location-stream__en__a5ac5ff0d6330870779568c3bc865bc7.json
@@ -1340,6 +1340,26 @@
     }
   },
   "c_exampleOption": "Option 1",
+  "c_exampleOptionExpanded": [
+    {
+      "displayName": "Option 1",
+      "numericValue": 504227,
+      "selected": false,
+      "value": "OPTION_1"
+    },
+    {
+      "displayName": "Option 2",
+      "numericValue": 504228,
+      "selected": true,
+      "value": "OPTION_2"
+    },
+    {
+      "displayName": "Option 3",
+      "numericValue": 504229,
+      "selected": false,
+      "value": "OPTION_3"
+    }
+  ],
   "c_exampleMultiOption": ["Option 2", "Option 3"],
   "hours": {
     "friday": {

--- a/starter/localData/dev-location-stream__en__a5ac5ff0d6330870779568c3bc865bc7.json
+++ b/starter/localData/dev-location-stream__en__a5ac5ff0d6330870779568c3bc865bc7.json
@@ -1339,6 +1339,8 @@
       "width": 600
     }
   },
+  "c_exampleOption": "Option 1",
+  "c_exampleMultiOption": ["Option 2", "Option 3"],
   "hours": {
     "friday": {
       "openIntervals": [

--- a/starter/localData/dev-location-stream__en__aa6fc9407fdca53fc4133ee078b93231.json
+++ b/starter/localData/dev-location-stream__en__aa6fc9407fdca53fc4133ee078b93231.json
@@ -1337,6 +1337,8 @@
       "width": 600
     }
   },
+  "c_exampleOption": "Option 1",
+  "c_exampleMultiOption": ["Option 2", "Option 3"],
   "hours": {
     "friday": {
       "openIntervals": [

--- a/starter/localData/dev-location-stream__en__aa6fc9407fdca53fc4133ee078b93231.json
+++ b/starter/localData/dev-location-stream__en__aa6fc9407fdca53fc4133ee078b93231.json
@@ -1338,6 +1338,26 @@
     }
   },
   "c_exampleOption": "Option 1",
+  "c_exampleOptionExpanded": [
+    {
+      "displayName": "Option 1",
+      "numericValue": 504227,
+      "selected": false,
+      "value": "OPTION_1"
+    },
+    {
+      "displayName": "Option 2",
+      "numericValue": 504228,
+      "selected": true,
+      "value": "OPTION_2"
+    },
+    {
+      "displayName": "Option 3",
+      "numericValue": 504229,
+      "selected": false,
+      "value": "OPTION_3"
+    }
+  ],
   "c_exampleMultiOption": ["Option 2", "Option 3"],
   "hours": {
     "friday": {

--- a/starter/localData/dev-location-stream__en__cbafb9cd1c3e63d9814e236ba9181377.json
+++ b/starter/localData/dev-location-stream__en__cbafb9cd1c3e63d9814e236ba9181377.json
@@ -1340,6 +1340,8 @@
       "width": 600
     }
   },
+  "c_exampleOption": "Option 1",
+  "c_exampleMultiOption": ["Option 2", "Option 3"],
   "hours": {
     "friday": {
       "openIntervals": [

--- a/starter/localData/dev-location-stream__en__cbafb9cd1c3e63d9814e236ba9181377.json
+++ b/starter/localData/dev-location-stream__en__cbafb9cd1c3e63d9814e236ba9181377.json
@@ -1341,6 +1341,26 @@
     }
   },
   "c_exampleOption": "Option 1",
+  "c_exampleOptionExpanded": [
+    {
+      "displayName": "Option 1",
+      "numericValue": 504227,
+      "selected": false,
+      "value": "OPTION_1"
+    },
+    {
+      "displayName": "Option 2",
+      "numericValue": 504228,
+      "selected": true,
+      "value": "OPTION_2"
+    },
+    {
+      "displayName": "Option 3",
+      "numericValue": 504229,
+      "selected": false,
+      "value": "OPTION_3"
+    }
+  ],
   "c_exampleMultiOption": ["Option 2", "Option 3"],
   "hours": {
     "friday": {

--- a/starter/localData/dev-location-stream__en__d7f52f17aa2a321e60e8c1a8fae53637.json
+++ b/starter/localData/dev-location-stream__en__d7f52f17aa2a321e60e8c1a8fae53637.json
@@ -1325,6 +1325,26 @@
     }
   ],
   "c_exampleOption": "Option 1",
+  "c_exampleOptionExpanded": [
+    {
+      "displayName": "Option 1",
+      "numericValue": 504227,
+      "selected": false,
+      "value": "OPTION_1"
+    },
+    {
+      "displayName": "Option 2",
+      "numericValue": 504228,
+      "selected": true,
+      "value": "OPTION_2"
+    },
+    {
+      "displayName": "Option 3",
+      "numericValue": 504229,
+      "selected": false,
+      "value": "OPTION_3"
+    }
+  ],
   "c_exampleMultiOption": ["Option 2", "Option 3"],
   "hours": {
     "friday": {

--- a/starter/localData/dev-location-stream__en__d7f52f17aa2a321e60e8c1a8fae53637.json
+++ b/starter/localData/dev-location-stream__en__d7f52f17aa2a321e60e8c1a8fae53637.json
@@ -1324,6 +1324,8 @@
       }
     }
   ],
+  "c_exampleOption": "Option 1",
+  "c_exampleMultiOption": ["Option 2", "Option 3"],
   "hours": {
     "friday": {
       "openIntervals": [

--- a/starter/src/dev.config.ts
+++ b/starter/src/dev.config.ts
@@ -457,6 +457,14 @@ export const devTemplateStream = {
           fullObject: true,
         },
         {
+          name: "c_exampleOption",
+          fullObject: true,
+        },
+        {
+          name: "c_exampleMultiOption",
+          fullObject: true,
+        },
+        {
           name: "meta",
           children: {
             fields: [
@@ -1231,6 +1239,63 @@ export const devTemplateStream = {
                     },
                   ],
                 },
+              },
+            ],
+          },
+        },
+        {
+          name: "c_exampleOption",
+          definition: {
+            name: "c_exampleOption",
+            registryId: "location.custom.1000152098.exampleoption.0",
+            typeRegistryId: "type.option",
+            type: {
+              stringType: "STRING_TYPE_OPTION",
+            },
+            options: [
+              {
+                numericValue: 504227,
+                textValue: "OPTION_1",
+                displayName: "Option 1",
+              },
+              {
+                numericValue: 504228,
+                textValue: "OPTION_2",
+                displayName: "Option 2",
+              },
+              {
+                numericValue: 504229,
+                textValue: "OPTION_3",
+                displayName: "Option 3",
+              },
+            ],
+          },
+        },
+        {
+          name: "c_exampleMultiOption",
+          definition: {
+            name: "c_exampleMultiOption",
+            registryId: "location.custom.1000152098.examplemultioption.0",
+            typeRegistryId: "type.option",
+            type: {
+              stringType: "STRING_TYPE_OPTION",
+            },
+            isList: true,
+            options: [
+              {
+                numericValue: 504230,
+                textValue: "OPTION_1",
+                displayName: "Option 1",
+              },
+              {
+                numericValue: 504231,
+                textValue: "OPTION_2",
+                displayName: "Option 2",
+              },
+              {
+                numericValue: 504232,
+                textValue: "OPTION_3",
+                displayName: "Option 3",
               },
             ],
           },

--- a/starter/src/dev.config.ts
+++ b/starter/src/dev.config.ts
@@ -1272,6 +1272,35 @@ export const devTemplateStream = {
           },
         },
         {
+          name: "c_exampleOptionExpanded",
+          definition: {
+            name: "c_exampleOptionExpanded",
+            registryId: "location.custom.1000152098.exampleoption.0",
+            typeRegistryId: "type.option",
+            type: {
+              stringType: "STRING_TYPE_OPTION",
+            },
+            options: [
+              {
+                numericValue: 504227,
+                textValue: "OPTION_1",
+                displayName: "Option 1",
+              },
+              {
+                numericValue: 504228,
+                textValue: "OPTION_2",
+                displayName: "Option 2",
+              },
+              {
+                numericValue: 504229,
+                textValue: "OPTION_3",
+                displayName: "Option 3",
+              },
+            ],
+          },
+          optionFormat: "OPTION_FORMAT_EXPANDED",
+        },
+        {
           name: "c_exampleMultiOption",
           definition: {
             name: "c_exampleMultiOption",


### PR DESCRIPTION
Adds support for `type.boolean`

`type.option` returns for `type.option` and `type.string` unless the `expandOptionFields` has been applied, in which case it only returns for `type.option`

Multi-option has the same behavior but with `includeListsOnly:true`

https://github.com/user-attachments/assets/f785f5b5-0fa0-4272-b235-f49a8e663998


