### PR TITLE
feat: add migration check

### DIFF
--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
-            const commentBody = "Warning: Component files have been updated but no migrations have been added.";
+            const commentBody = "Warning: Component files have been updated but no migrations have been added. See https://github.com/yext/visual-editor/blob/main/packages/visual-editor/src/components/migrations/README.md for more information.";
 
             await github.rest.issues.createComment({
               ...context.repo,

--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -1,0 +1,43 @@
+name: Check Migrations
+
+on:
+  pull_request:
+    paths:
+      # Trigger when files in components are updated
+      - "packages/visual-editor/src/components/**"
+
+jobs:
+  comment-on-pr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Get changed files
+        id: changes
+        run: |
+          # Get the list of files changed in this PR
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          git diff --name-only origin/${{ github.event.pull_request.base.ref }} > changed_files.txt
+
+          # Check for changes under components, excluding the migrations, testing, and registry subdirectories and .test. files
+          grep '^packages/visual-editor/src/components/' changed_files.txt | \
+            grep -vE '^packages/visual-editor/src/components/(migrations|testing|registry)' | \
+            grep -v -q '\.test\.' && echo "components_updated=true" >> $GITHUB_ENV || echo "components_updated=false" >> $GITHUB_ENV
+
+          grep -q '^packages/visual-editor/src/components/migrations/' changed_files.txt && echo "migrations_updated=true" >> $GITHUB_ENV || echo "migrations_updated=false" >> $GITHUB_ENV
+
+      - name: Comment on PR
+        if: env.components_updated == 'true' && env.migrations_updated == 'false'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const commentBody = "Warning: Component files have been updated but no migrations have been added.";
+
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: prNumber,
+              body: commentBody
+            });

--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -26,7 +26,7 @@ jobs:
             grep -vE '^packages/visual-editor/src/components/(migrations|testing|registry)' | \
             grep -v -q '\.test\.' && echo "components_updated=true" >> $GITHUB_ENV || echo "components_updated=false" >> $GITHUB_ENV
 
-          grep -q '^packages/visual-editor/src/components/migrations/' changed_files.txt && echo "migrations_updated=true" >> $GITHUB_ENV || echo "migrations_updated=false" >> $GITHUB_ENV
+          grep -q '^packages/visual-editor/src/components/migrations/migrationRegistry.ts' changed_files.txt && echo "migrations_updated=true" >> $GITHUB_ENV || echo "migrations_updated=false" >> $GITHUB_ENV
 
       - name: Comment on PR
         if: env.components_updated == 'true' && env.migrations_updated == 'false'

--- a/packages/visual-editor/src/components/migrations/README.md
+++ b/packages/visual-editor/src/components/migrations/README.md
@@ -1,8 +1,8 @@
 # Migrations
 
 Migrations ensure backwards compatibility for component updates. When a site is updated, it immediately begins
-using the new components however, the published and save state data is old. This data is run through
-`migrate` prior to being rendered so that any migrations will be applied and the data will match with the components.
+using the new components; however, the published and save state data may not reflect the schema of these component updates.
+This data is run through `migrate` prior to being rendered so that any migrations will be applied and the data will match with the components.
 
 ## When do I need to add a migrations?
 
@@ -21,8 +21,7 @@ If you update some fields, such as select, the new options may not match the old
 
 4. A component is removed (optional)
 
-A removed component will automatically disappear from the live page, however adding a
-removed migration will also remove the "No Configuration for" message from the editor.
+A removed component will automatically disappear from the live page as well as showing a "No Configuration for" message in the editor. Add a removed migration to handle this.
 
 ## How do I create a migration?
 
@@ -30,10 +29,11 @@ In the `migrations` directory, create a new file of the form `1234_example_migra
 the number increases sequentially and the rest of the name is a brief description of the migration.
 
 In that file, export an object of type `Migration`, which is object mapping component names to
-`MigrationActions`. The component name should be the name the component is registered as in
-`ve.config.ts` or `_componentCategories.ts`.
+`MigrationActions` (see [migrate.ts](https://github.com/yext/visual-editor/blob/main/packages/visual-editor/src/utils/migrate.ts)).
+The component name should be the name the component is registered as in
+`ve.config.ts` or [`_componentCategories.ts`](https://github.com/yext/visual-editor/blob/main/packages/visual-editor/src/components/_componentCategories.ts).
 
-There are three `MigrationActions`:
+There are three [`MigrationActions`](https://github.com/yext/visual-editor/blob/1210ee5bae73bff1456563b57506ff163fa59cb6/packages/visual-editor/src/utils/migrate.ts#L11):
 
 ### Removed
 
@@ -64,6 +64,13 @@ See https://puckeditor.com/docs/api-reference/functions/transform-props
   action: "updated";
   propTransformation: (oldProps: Record<string, any>) => Record<string, any>;
 }
+
+// Example
+// Renames a prop from "heading" to "title" while keeping all other props
+{
+  action: "updated";
+  propTransformation: ({ heading, ...props }) => ({ title: heading, ...props });
+}
 ```
 
 In `migrationRegistry.ts`, import your migration and append it to the array. Migrations are run in order.
@@ -73,3 +80,20 @@ In `migrationRegistry.ts`, import your migration and append it to the array. Mig
 In the local dev starter, create a layout with the existing components. Log the layout data
 and save it somewhere. Then, make your component updates. In the editor, set the layout data
 to your previously saved data. Confirm the old data is migrated to the new version successfully.
+
+### Adding Test Cases
+
+When updating a component requires a migration, new test cases should be added.
+Each component has a `Component.test.tsx` file with an array of
+[ComponentTests](https://github.com/yext/visual-editor/blob/1210ee5bae73bff1456563b57506ff163fa59cb6/packages/visual-editor/src/components/testing/componentTests.setup.ts#L32).
+
+The first two ComponentTests test the default props of the current version of the component.
+The `expect` cases should be updated to match the new version.
+
+The rest of the ComponentTests test specific component versions. These should not be
+updated unless making an intentional breaking change to existing component usages.
+
+For the new version, two test cases should be added: one using all Entity Values
+possible for the component and another using all Constant Values.
+It is recommended to configure the component in the `localDev` editor, log
+the component data, and copy it into the test file.

--- a/packages/visual-editor/src/components/migrations/README.md
+++ b/packages/visual-editor/src/components/migrations/README.md
@@ -1,0 +1,75 @@
+# Migrations
+
+Migrations ensure backwards compatibility for component updates. When a site is updated, it immediately begins
+using the new components however, the published and save state data is old. This data is run through
+`migrate` prior to being rendered so that any migrations will be applied and the data will match with the components.
+
+## When do I need to add a migrations?
+
+1. A component is renamed.
+
+Without a migration, old usages of the component will disappear from the live page and the user will be
+required to add the component to the layout again.
+
+2. Component props are updated
+
+Without a migration, new props will not have any data and data contained in old props will not be used.
+
+3. Component fields are updated
+
+If you update some fields, such as select, the new options may not match the old data.
+
+4. A component is removed (optional)
+
+A removed component will automatically disappear from the live page, however adding a
+removed migration will also remove the "No Configuration for" message from the editor.
+
+## How do I create a migration?
+
+In the `migrations` directory, create a new file of the form `1234_example_migration.ts` where
+the number increases sequentially and the rest of the name is a brief description of the migration.
+
+In that file, export an object of type `Migration`, which is object mapping component names to
+`MigrationActions`. The component name should be the name the component is registered as in
+`ve.config.ts` or `_componentCategories.ts`.
+
+There are three `MigrationActions`:
+
+### Removed
+
+Removes a component from all layouts.
+
+```ts
+{
+  action: "removed";
+}
+```
+
+### Renamed
+
+Renames all existing usages of a component to `newName`.
+This name should be the name of the component as it is registered as in `ve.config.ts` or `_componentCategories.ts`.
+
+```ts
+{ action: "renamed", newName: string }
+```
+
+### Updated
+
+Transforms the existing props to the new set of props.
+See https://puckeditor.com/docs/api-reference/functions/transform-props
+
+```ts
+{
+  action: "updated";
+  propTransformation: (oldProps: Record<string, any>) => Record<string, any>;
+}
+```
+
+In `migrationRegistry.ts`, import your migration and append it to the array. Migrations are run in order.
+
+## How do I test a migration?
+
+In the local dev starter, create a layout with the existing components. Log the layout data
+and save it somewhere. Then, make your component updates. In the editor, set the layout data
+to your previously saved data. Confirm the old data is migrated to the new version successfully.


### PR DESCRIPTION
Adds a github action that checks if component files have been updated. If they have and migrations have not, a comment is added to the PR with a warning. Doesn't actually check for anything other than files being updated so it's far from comprehensive but may be a helpful nudge?

See example here: #461 (the first commit had component changes but no migration, the second commit component+migration changes, and the third no component changes)