### PR TITLE
fix: remove text-body-fontSize-sm

### DIFF
--- a/packages/visual-editor/src/components/Directory.tsx
+++ b/packages/visual-editor/src/components/Directory.tsx
@@ -86,7 +86,7 @@ const DirectoryCard = ({
         />
       )}
       {profile.address && (
-        <div className="font-body-fontFamily font-body-fontWeight text-body-fontSize-sm">
+        <div className="font-body-fontFamily font-body-fontWeight text-body-fontSize">
           <Address
             address={profile.address}
             lines={[["line1"], ["line2"], ["city", "region", "postalCode"]]}

--- a/packages/visual-editor/src/components/pageSections/NearbyLocations.tsx
+++ b/packages/visual-editor/src/components/pageSections/NearbyLocations.tsx
@@ -209,7 +209,7 @@ const LocationCard = ({
         />
       )}
       {address && (
-        <div className="font-body-fontFamily font-body-fontWeight text-body-fontSize-sm">
+        <div className="font-body-fontFamily font-body-fontWeight text-body-fontSize">
           <Address
             address={address}
             lines={[


### PR DESCRIPTION
`text-body-fontSize-sm` isn't a valid class name (`text-body-sm-fontSize` is). These two components aren't using the `sm` variant in the mocks anyway