### PR TITLE
feat: use app API key for analytics

### DIFF
--- a/packages/visual-editor/src/vite-plugin/templates/directory.tsx
+++ b/packages/visual-editor/src/vite-plugin/templates/directory.tsx
@@ -91,7 +91,7 @@ const Directory: Template<TemplateRenderProps> = (props) => {
 
   return (
     <AnalyticsProvider
-      apiKey={document?._env?.YEXT_PUBLIC_EVENTS_API_KEY}
+      apiKey={document?._env?.YEXT_PUBLIC_VISUAL_EDITOR_APP_API_KEY}
       templateData={props}
       currency="USD"
     >

--- a/packages/visual-editor/src/vite-plugin/templates/main.tsx
+++ b/packages/visual-editor/src/vite-plugin/templates/main.tsx
@@ -93,7 +93,7 @@ const Location: Template<TemplateRenderProps> = (props) => {
 
   return (
     <AnalyticsProvider
-      apiKey={document?._env?.YEXT_PUBLIC_EVENTS_API_KEY}
+      apiKey={document?._env?.YEXT_PUBLIC_VISUAL_EDITOR_APP_API_KEY}
       templateData={props}
       currency="USD"
     >


### PR DESCRIPTION
Uses YEXT_PUBLIC_VISUAL_EDITOR_APP_API_KEY instead of YEXT_PUBLIC_EVENTS_API_KEY

Both keys just point to the app which has all permissions needed for VE.