### PR TITLE
fix: small component updates

### DIFF
--- a/packages/visual-editor/src/components/cards/ProductCard.tsx
+++ b/packages/visual-editor/src/components/cards/ProductCard.tsx
@@ -88,7 +88,7 @@ const ProductCardItem = ({
           {resolvedCategory && (
             <Background
               background={backgroundColors.background5.value}
-              className="py-2 px-4 rounded-sm w-fit"
+              className="py-2 px-4 rounded w-fit"
             >
               <Body>{resolvedCategory}</Body>
             </Background>

--- a/packages/visual-editor/src/components/pageSections/InsightSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/InsightSection.tsx
@@ -90,12 +90,13 @@ const InsightCard = ({
   sectionHeadingLevel: HeadingLevel;
 }) => {
   return (
-    <Background className="rounded-sm h-full" background={backgroundColor}>
+    <Background className="rounded h-full" background={backgroundColor}>
       {insight.image && (
         <Image
           image={insight.image}
           layout="auto"
-          className="rounded-[inherit]"
+          aspectRatio={1.778} // 16:9
+          className="rounded-t-[inherit]"
         />
       )}
       <div className="flex flex-col gap-8 p-8">

--- a/packages/visual-editor/src/components/pageSections/ProductSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/ProductSection.tsx
@@ -118,7 +118,7 @@ const ProductCard = ({
           {product.category && (
             <Background
               background={backgroundColors.background5.value}
-              className="py-2 px-4 rounded-sm w-fit"
+              className="py-2 px-4 rounded w-fit"
             >
               <Body>{product.category}</Body>
             </Background>

--- a/packages/visual-editor/src/components/pageSections/TestimonialSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/TestimonialSection.tsx
@@ -91,7 +91,7 @@ const TestimonialCard = ({
     <div className="flex flex-col rounded-lg overflow-hidden border h-full">
       <Background
         background={backgroundColors.background1.value}
-        className="p-8"
+        className="p-8 grow"
       >
         <MaybeRTF data={testimonial.description} />
       </Background>


### PR DESCRIPTION
1. Set an aspect ratio so Insights don't get really tall
2. Add grow to Testimonial so the card fills the border height
3. Update border radii to match mocks

Before

<img width="1054" alt="Screenshot 2025-05-14 at 1 40 35 PM" src="https://github.com/user-attachments/assets/a257f2d4-7587-4814-bd40-92ef3d5f6488" />
<img width="1075" alt="Screenshot 2025-05-14 at 1 36 08 PM" src="https://github.com/user-attachments/assets/263aba2c-7f44-48a3-9dac-d6b58ef1a307" />

After

<img width="1034" alt="Screenshot 2025-05-19 at 2 55 47 PM" src="https://github.com/user-attachments/assets/b8e76028-eb2c-40cb-9484-47c3ee259c2d" />
<img width="1050" alt="Screenshot 2025-05-19 at 3 07 19 PM" src="https://github.com/user-attachments/assets/d6b02cb4-3225-4ddc-800f-363e9b33e9f8" />
