### PR TITLE
refactor: handle missing data in Insights and Products

### DIFF
--- a/packages/visual-editor/src/components/atoms/image.tsx
+++ b/packages/visual-editor/src/components/atoms/image.tsx
@@ -30,7 +30,7 @@ export const Image: React.FC<ImageProps> = ({
           image={image}
           layout={"aspect"}
           aspectRatio={aspectRatio}
-          className="object-cover w-full"
+          className="object-cover w-full h-full"
         />
       ) : !!width && !!height ? (
         <ImageComponent

--- a/packages/visual-editor/src/components/pageSections/InsightSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/InsightSection.tsx
@@ -90,16 +90,21 @@ const InsightCard = ({
   sectionHeadingLevel: HeadingLevel;
 }) => {
   return (
-    <Background className="rounded h-full" background={backgroundColor}>
-      {insight.image && (
+    <Background
+      className="rounded h-full flex flex-col"
+      background={backgroundColor}
+    >
+      {insight.image ? (
         <Image
           image={insight.image}
           layout="auto"
           aspectRatio={1.778} // 16:9
-          className="rounded-t-[inherit]"
+          className="rounded-t-[inherit] h-[200px]"
         />
+      ) : (
+        <div className="sm:h-[200px]" />
       )}
-      <div className="flex flex-col gap-8 p-8">
+      <div className="flex flex-col gap-8 p-8 flex-grow">
         <div className="flex flex-col gap-4">
           {(insight.category || insight.publishTime) && (
             <div
@@ -132,6 +137,7 @@ const InsightCard = ({
             label={insight.cta.label}
             link={insight.cta.link}
             linkType={insight.cta.linkType ?? "URL"}
+            className="mt-auto"
           />
         )}
       </div>

--- a/packages/visual-editor/src/components/pageSections/ProductSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/ProductSection.tsx
@@ -90,17 +90,20 @@ const ProductCard = ({
 }) => {
   return (
     <Background
-      className="flex flex-col justify-between rounded-lg overflow-hidden border h-full"
+      className="flex flex-col rounded-lg overflow-hidden border h-full"
       background={backgroundColor}
     >
-      {product.image && (
+      {product.image ? (
         <Image
           image={product.image}
           layout={"auto"}
-          aspectRatio={product.image.width / product.image.height}
+          aspectRatio={1.778} // 16:9
+          className="h-[200px]"
         />
+      ) : (
+        <div className="sm:h-[200px]" />
       )}
-      <div className="p-8 gap-8 flex flex-col">
+      <div className="p-8 gap-8 flex flex-col flex-grow">
         <div className="gap-4 flex flex-col">
           {product.name && (
             <Heading
@@ -131,6 +134,7 @@ const ProductCard = ({
             label={product.cta.label}
             link={product.cta.link}
             linkType={product.cta.linkType}
+            className="mt-auto"
           />
         )}
       </div>


### PR DESCRIPTION
Thread: https://yext.slack.com/archives/C06A06BCUUF/p1747766568494449?thread_ts=1747680405.497999&cid=C06A06BCUUF

- Standardizes image size and adds a placeholder if the image doesn't exist on desktop
- Pushes the CTA to the end of the card 

This isn't perfect / I'm sure there will be more changes at some point, but I think this handles it better

https://github.com/user-attachments/assets/54835842-2d4c-455c-8aba-ab0ef9d88f0d

