### PR TITLE
feat: added Disclosure Section for FINS

### DIFF
--- a/packages/visual-editor/src/components/_componentCategories.ts
+++ b/packages/visual-editor/src/components/_componentCategories.ts
@@ -75,6 +75,10 @@ import {
   StaticMapSection,
   StaticMapSectionProps,
 } from "./pageSections/StaticMapSection.tsx";
+import {
+  FINS_DisclosureSection,
+  FINS_DisclosureSectionProps,
+} from "./pageSections/FINS/FINS_DisclosureSection.tsx";
 
 export interface PageSectionCategoryProps {
   BreadcrumbsSection: BreadcrumbsSectionProps;
@@ -91,6 +95,7 @@ export interface PageSectionCategoryProps {
   FAQSection: FAQSectionProps;
   StaticMapSection: StaticMapSectionProps;
   TestimonialSection: TestimonialSectionProps;
+  FINS_DisclosureSection: FINS_DisclosureSectionProps;
 }
 
 export const PageSectionCategoryComponents = {
@@ -108,6 +113,7 @@ export const PageSectionCategoryComponents = {
   PromoSection,
   TeamSection,
   TestimonialSection,
+  FINS_DisclosureSection,
 };
 
 export const PageSectionCategory = Object.keys(

--- a/packages/visual-editor/src/components/pageSections/FINS/FINS_DisclosureSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/FINS/FINS_DisclosureSection.tsx
@@ -1,0 +1,143 @@
+import { ComponentConfig, Fields } from "@measured/puck";
+import {
+  backgroundColors,
+  BackgroundStyle,
+  EntityField,
+  Heading,
+  HeadingLevel,
+  MaybeRTF,
+  PageSection,
+  resolveYextEntityField,
+  RTF2,
+  useDocument,
+  VisibilityWrapper,
+  YextEntityField,
+  YextField,
+} from "@yext/visual-editor";
+
+export interface FINS_DisclosureSectionProps {
+  data: {
+    headingText: YextEntityField<string>;
+    description: YextEntityField<RTF2 | string>;
+  };
+  styles: {
+    headingLevel: HeadingLevel;
+    backgroundColor?: BackgroundStyle;
+  };
+  liveVisibility: boolean;
+}
+
+const disclosureSectionFields: Fields<FINS_DisclosureSectionProps> = {
+  data: YextField("Data", {
+    type: "object",
+    objectFields: {
+      headingText: YextField("Heading Text", {
+        type: "entityField",
+        filter: {
+          types: ["type.string"],
+        },
+      }),
+      description: YextField("Description", {
+        type: "entityField",
+        filter: {
+          types: ["type.string"],
+        },
+      }),
+    },
+  }),
+  styles: YextField("Styles", {
+    type: "object",
+    objectFields: {
+      headingLevel: YextField("Heading Level", {
+        type: "select",
+        hasSearch: true,
+        options: "HEADING_LEVEL",
+      }),
+      backgroundColor: YextField("Background Color", {
+        type: "select",
+        hasSearch: true,
+        options: "BACKGROUND_COLOR",
+      }),
+    },
+  }),
+  liveVisibility: YextField("Visible on Live Page", {
+    type: "radio",
+    options: [
+      { label: "Show", value: true },
+      { label: "Hide", value: false },
+    ],
+  }),
+};
+
+const DisclosureSectionWrapper = ({
+  data: { headingText, description },
+  styles: { backgroundColor, headingLevel },
+}: FINS_DisclosureSectionProps) => {
+  const document = useDocument();
+  const resolvedHeadingText = resolveYextEntityField(document, headingText);
+  const resolvedDisclosureText = resolveYextEntityField(document, description);
+
+  return (
+    <PageSection
+      background={backgroundColor}
+      aria-label="Disclosure"
+      className="flex flex-col gap-4 w-full"
+    >
+      {resolvedHeadingText && (
+        <EntityField
+          displayName="Heading Text"
+          fieldId={headingText.field}
+          constantValueEnabled={headingText.constantValueEnabled}
+        >
+          <Heading level={headingLevel}>{resolvedHeadingText}</Heading>
+        </EntityField>
+      )}
+      {resolvedDisclosureText && (
+        <EntityField
+          displayName="Disclosure Text"
+          fieldId={description.field}
+          constantValueEnabled={description.constantValueEnabled}
+        >
+          <MaybeRTF
+            className="text-xs"
+            data={resolvedDisclosureText}
+          ></MaybeRTF>
+        </EntityField>
+      )}
+    </PageSection>
+  );
+};
+
+export const FINS_DisclosureSection: ComponentConfig<FINS_DisclosureSectionProps> =
+  {
+    label: "FINS - Disclosure Section",
+    fields: disclosureSectionFields,
+    defaultProps: {
+      data: {
+        headingText: {
+          field: "",
+          constantValue: "Disclosure",
+          constantValueEnabled: true,
+        },
+        description: {
+          field: "",
+          constantValue:
+            "Lorem ipsum, dolor sit amet consectetur adipisicing elit. Nisi, modi asperiores, suscipit delectus eos expedita vero iste iure vel facere sed recusandae temporibus, fugiat natus. Dolore cumque blanditiis eligendi adipisci?",
+          constantValueEnabled: true,
+        },
+      },
+      styles: {
+        headingLevel: 4,
+        backgroundColor: backgroundColors.background3.value,
+      },
+      liveVisibility: true,
+    },
+    render: (props) => (
+      <VisibilityWrapper
+        liveVisibility={props.liveVisibility}
+        isEditing={props.puck.isEditing}
+      >
+        <DisclosureSectionWrapper {...props} />
+      </VisibilityWrapper>
+    ),
+  };

--- a/packages/visual-editor/src/components/registry/components.ts
+++ b/packages/visual-editor/src/components/registry/components.ts
@@ -186,6 +186,23 @@ export const ui: Registry["items"] = [
     files: [{ path: "pageSections/FAQsSection.tsx", type: "registry:ui" }],
   },
   {
+    name: "FINS_DisclosureSection",
+    type: "registry:ui",
+    registryDependencies: [
+      "pageSection",
+      "heading",
+      "maybeRTF",
+      "image",
+      "visibilityWrapper",
+    ],
+    files: [
+      {
+        path: "pageSections/FINS/FINS_DisclosureSection.tsx",
+        type: "registry:ui",
+      },
+    ],
+  },
+  {
     name: "Flex",
     type: "registry:ui",
     registryDependencies: ["layout", "background", "visibilityWrapper"],


### PR DESCRIPTION
Created Disclosure component for FINS.
Component is added under `components/pageSections/FINS`
Didn't add it to `/pageSections/index.ts`
[Component Doc](https://docs.google.com/document/d/15JdCygk76PxQXL9z3OcFBDCdMWGYyrvyIWDMZA0U_18/edit?tab=t.ghh9n42jhwbs)

<img width="1781" alt="Screenshot 2025-05-29 at 3 06 01 AM" src="https://github.com/user-attachments/assets/6388b34f-eca8-4bad-ac89-daffbeee2677" />

<img width="1887" alt="Screenshot 2025-05-29 at 3 05 35 AM" src="https://github.com/user-attachments/assets/a5af301f-7717-4c21-a7d6-d2213a06c313" />
