### PR TITLE
feat: added Insurance providers Section for FINS

### DIFF
--- a/packages/visual-editor/src/components/_componentCategories.ts
+++ b/packages/visual-editor/src/components/_componentCategories.ts
@@ -75,7 +75,10 @@ import {
   StaticMapSection,
   StaticMapSectionProps,
 } from "./pageSections/StaticMapSection.tsx";
-
+import {
+  FINS_InsuranceSectionProps,
+  FINS_InsuranceProvidersSection,
+} from "./pageSections/FINS/FINS_InsuranceSection.tsx";
 export interface PageSectionCategoryProps {
   BreadcrumbsSection: BreadcrumbsSectionProps;
   HeroSection: HeroSectionProps;
@@ -91,6 +94,7 @@ export interface PageSectionCategoryProps {
   FAQSection: FAQSectionProps;
   StaticMapSection: StaticMapSectionProps;
   TestimonialSection: TestimonialSectionProps;
+  FINS_InsuranceProvidersSection: FINS_InsuranceSectionProps;
 }
 
 export const PageSectionCategoryComponents = {
@@ -108,6 +112,7 @@ export const PageSectionCategoryComponents = {
   PromoSection,
   TeamSection,
   TestimonialSection,
+  FINS_InsuranceProvidersSection,
 };
 
 export const PageSectionCategory = Object.keys(

--- a/packages/visual-editor/src/components/pageSections/FINS/FINS_InsuranceSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/FINS/FINS_InsuranceSection.tsx
@@ -96,7 +96,13 @@ const InsuranceProvidersSectionWrapper = ({
           fieldId={headingText.field}
           constantValueEnabled={headingText.constantValueEnabled}
         >
-          <Heading level={headingLevel} className="text-center">
+          <Heading
+            level={headingLevel}
+            semanticLevelOverride={
+              headingLevel < 6 ? ((headingLevel + 1) as HeadingLevel) : "span"
+            }
+            className="text-center"
+          >
             {resolvedHeading}
           </Heading>
         </EntityField>

--- a/packages/visual-editor/src/components/pageSections/FINS/FINS_InsuranceSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/FINS/FINS_InsuranceSection.tsx
@@ -96,13 +96,7 @@ const InsuranceProvidersSectionWrapper = ({
           fieldId={headingText.field}
           constantValueEnabled={headingText.constantValueEnabled}
         >
-          <Heading
-            level={headingLevel}
-            semanticLevelOverride={
-              headingLevel < 6 ? ((headingLevel + 1) as HeadingLevel) : "span"
-            }
-            className="text-center"
-          >
+          <Heading level={headingLevel} className="text-center">
             {resolvedHeading}
           </Heading>
         </EntityField>
@@ -121,13 +115,16 @@ const InsuranceProvidersSectionWrapper = ({
             {resolvedProviders.insuranceProviders.map((item, idx) => (
               <li key={idx} className="flex flex-col gap-2.5">
                 {item.image && (
-                  <Image
-                    image={item.image}
-                    layout="auto"
-                    aspectRatio={item.image.width / item.image.height}
-                  />
+                  <Image image={item.image} layout="auto" aspectRatio={2.5} />
                 )}
-                <Heading level={insuranceProviderNameLevel}>
+                <Heading
+                  semanticLevelOverride={
+                    headingLevel < 6
+                      ? ((headingLevel + 1) as HeadingLevel)
+                      : "span"
+                  }
+                  level={insuranceProviderNameLevel}
+                >
                   {item.title}
                 </Heading>
               </li>

--- a/packages/visual-editor/src/components/pageSections/FINS/FINS_InsuranceSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/FINS/FINS_InsuranceSection.tsx
@@ -1,0 +1,221 @@
+import { ComponentConfig, Fields } from "@measured/puck";
+import {
+  backgroundColors,
+  BackgroundStyle,
+  ComponentFields,
+  Heading,
+  InsuranceProvidersSectionType,
+  PageSection,
+  resolveYextEntityField,
+  useDocument,
+  YextEntityField,
+  YextField,
+  Image,
+  VisibilityWrapper,
+  HeadingLevel,
+  EntityField,
+} from "@yext/visual-editor";
+
+const PLACEHOLDER_IMAGE_URL = "https://placehold.co/260X105";
+
+export interface FINS_InsuranceSectionProps {
+  styles: {
+    backgroundColor: BackgroundStyle;
+    headingLevel: HeadingLevel;
+    insuranceProviderNameLevel: HeadingLevel;
+  };
+  data: {
+    headingText: YextEntityField<string>;
+    entityField: YextEntityField<InsuranceProvidersSectionType>;
+  };
+  liveVisibility: boolean;
+}
+
+const insuranceSectionFields: Fields<FINS_InsuranceSectionProps> = {
+  data: YextField("Data", {
+    type: "object",
+    objectFields: {
+      headingText: YextField<any, string>("Heading Text", {
+        type: "entityField",
+        filter: { types: ["type.string"] },
+      }),
+      entityField: YextField("Insurance", {
+        type: "entityField",
+        filter: {
+          types: [ComponentFields.InsuranceProviderSection.type],
+        },
+      }),
+    },
+  }),
+  styles: YextField("Styles", {
+    type: "object",
+    objectFields: {
+      backgroundColor: YextField("Background Color", {
+        type: "select",
+        hasSearch: true,
+        options: "BACKGROUND_COLOR",
+      }),
+      headingLevel: YextField("Heading Level", {
+        type: "select",
+        hasSearch: true,
+        options: "HEADING_LEVEL",
+      }),
+      insuranceProviderNameLevel: YextField("Provider Name Heading Level", {
+        type: "select",
+        hasSearch: true,
+        options: "HEADING_LEVEL",
+      }),
+    },
+  }),
+  liveVisibility: YextField("Visible on Live Page", {
+    type: "radio",
+    options: [
+      { label: "Show", value: true },
+      { label: "Hide", value: false },
+    ],
+  }),
+};
+
+const InsuranceProvidersSectionWrapper = ({
+  styles: { headingLevel, insuranceProviderNameLevel, backgroundColor },
+  data: { headingText, entityField },
+}: FINS_InsuranceSectionProps) => {
+  const document = useDocument();
+  const resolvedHeading = resolveYextEntityField(document, headingText);
+  const resolvedProviders = resolveYextEntityField(document, entityField);
+
+  return (
+    <PageSection
+      background={backgroundColor}
+      aria-label="Core Info Section"
+      className="flex flex-col flex-col gap-8"
+    >
+      {resolvedHeading && (
+        <EntityField
+          displayName="Heading Text"
+          fieldId={headingText.field}
+          constantValueEnabled={headingText.constantValueEnabled}
+        >
+          <Heading level={headingLevel} className="text-center">
+            {resolvedHeading}
+          </Heading>
+        </EntityField>
+      )}
+      {resolvedProviders?.insuranceProviders && (
+        <EntityField
+          displayName="Insurance Providers"
+          fieldId={entityField.field}
+          constantValueEnabled={entityField.constantValueEnabled}
+        >
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-6 md:gap-8">
+            {resolvedProviders?.insuranceProviders.map((item, idx) => (
+              <div key={idx} className="flex flex-col gap-2.5">
+                {item.image && (
+                  <Image
+                    image={item.image}
+                    layout={"auto"}
+                    aspectRatio={item.image.width / item.image.height}
+                  />
+                )}
+                <Heading level={insuranceProviderNameLevel}>
+                  {item.title}
+                </Heading>
+              </div>
+            ))}
+          </div>
+        </EntityField>
+      )}
+    </PageSection>
+  );
+};
+
+export const FINS_InsuranceProvidersSection: ComponentConfig<FINS_InsuranceSectionProps> =
+  {
+    label: "FINS - Insurance Providers Section",
+    fields: insuranceSectionFields,
+    defaultProps: {
+      styles: {
+        backgroundColor: backgroundColors.background1.value,
+        headingLevel: 2,
+        insuranceProviderNameLevel: 5,
+      },
+      data: {
+        headingText: {
+          field: "",
+          constantValue: "Find the best coverage for you",
+          constantValueEnabled: true,
+        },
+        entityField: {
+          field: "",
+          constantValue: {
+            insuranceProviders: [
+              {
+                title: "Insurance Name",
+                image: {
+                  alternateText: "Insurance Provider Logo",
+                  height: 105,
+                  url: PLACEHOLDER_IMAGE_URL,
+                  width: 260,
+                },
+              },
+              {
+                title: "Insurance Name",
+                image: {
+                  alternateText: "Insurance Provider Logo",
+                  height: 105,
+                  url: PLACEHOLDER_IMAGE_URL,
+                  width: 260,
+                },
+              },
+              {
+                title: "Insurance Name",
+                image: {
+                  alternateText: "Insurance Provider Logo",
+                  height: 105,
+                  url: PLACEHOLDER_IMAGE_URL,
+                  width: 260,
+                },
+              },
+              {
+                title: "Insurance Name",
+                image: {
+                  alternateText: "Insurance Provider Logo",
+                  height: 105,
+                  url: PLACEHOLDER_IMAGE_URL,
+                  width: 260,
+                },
+              },
+              {
+                title: "Insurance Name",
+                image: {
+                  alternateText: "Insurance Provider Logo",
+                  height: 105,
+                  url: PLACEHOLDER_IMAGE_URL,
+                  width: 260,
+                },
+              },
+              {
+                title: "Insurance Name",
+                image: {
+                  alternateText: "Insurance Provider Logo",
+                  height: 105,
+                  url: PLACEHOLDER_IMAGE_URL,
+                  width: 260,
+                },
+              },
+            ],
+          },
+          constantValueEnabled: true,
+        },
+      },
+      liveVisibility: true,
+    },
+    render: (props) => (
+      <VisibilityWrapper
+        liveVisibility={props.liveVisibility}
+        isEditing={props.puck.isEditing}
+      >
+        <InsuranceProvidersSectionWrapper {...props} />
+      </VisibilityWrapper>
+    ),
+  };

--- a/packages/visual-editor/src/components/pageSections/FINS/FINS_InsuranceSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/FINS/FINS_InsuranceSection.tsx
@@ -88,7 +88,7 @@ const InsuranceProvidersSectionWrapper = ({
     <PageSection
       background={backgroundColor}
       aria-label="Core Info Section"
-      className="flex flex-col flex-col gap-8"
+      className="flex flex-col gap-8"
     >
       {resolvedHeading && (
         <EntityField
@@ -101,28 +101,32 @@ const InsuranceProvidersSectionWrapper = ({
           </Heading>
         </EntityField>
       )}
+
       {resolvedProviders?.insuranceProviders && (
         <EntityField
           displayName="Insurance Providers"
           fieldId={entityField.field}
           constantValueEnabled={entityField.constantValueEnabled}
         >
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-6 md:gap-8">
-            {resolvedProviders?.insuranceProviders.map((item, idx) => (
-              <div key={idx} className="flex flex-col gap-2.5">
+          <ul
+            className="grid grid-cols-2 md:grid-cols-4 gap-6 md:gap-8"
+            aria-label="Insurance Providers List"
+          >
+            {resolvedProviders.insuranceProviders.map((item, idx) => (
+              <li key={idx} className="flex flex-col gap-2.5">
                 {item.image && (
                   <Image
                     image={item.image}
-                    layout={"auto"}
+                    layout="auto"
                     aspectRatio={item.image.width / item.image.height}
                   />
                 )}
                 <Heading level={insuranceProviderNameLevel}>
                   {item.title}
                 </Heading>
-              </div>
+              </li>
             ))}
-          </div>
+          </ul>
         </EntityField>
       )}
     </PageSection>

--- a/packages/visual-editor/src/components/registry/components.ts
+++ b/packages/visual-editor/src/components/registry/components.ts
@@ -186,6 +186,23 @@ export const ui: Registry["items"] = [
     files: [{ path: "pageSections/FAQsSection.tsx", type: "registry:ui" }],
   },
   {
+    name: "FINS_InsuranceSection",
+    type: "registry:ui",
+    registryDependencies: [
+      "pageSection",
+      "heading",
+      "image",
+      "background",
+      "visibilityWrapper",
+    ],
+    files: [
+      {
+        path: "pageSections/FINS/FINS_InsuranceSection.tsx",
+        type: "registry:ui",
+      },
+    ],
+  },
+  {
     name: "Flex",
     type: "registry:ui",
     registryDependencies: ["layout", "background", "visibilityWrapper"],

--- a/packages/visual-editor/src/editor/YextEntityFieldSelector.tsx
+++ b/packages/visual-editor/src/editor/YextEntityFieldSelector.tsx
@@ -30,6 +30,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "../internal/puck/ui/Tooltip.tsx";
+import { INSURANCE_PROVIDERS_SECTION_CONSTANT_CONFIG } from "../internal/puck/constant-value-fields/InsuranceProvidersSection.tsx";
 
 const devLogger = new DevLogger();
 
@@ -66,6 +67,8 @@ export const TYPE_TO_CONSTANT_CONFIG: Record<string, Field<any>> = {
   "type.faq_section": FAQ_SECTION_CONSTANT_CONFIG,
   "type.team_section": TEAM_SECTION_CONSTANT_CONFIG,
   "type.testimonials_section": TESTIMONIAL_SECTION_CONSTANT_CONFIG,
+  "type.insuranceProviders_section":
+    INSURANCE_PROVIDERS_SECTION_CONSTANT_CONFIG,
 };
 
 const LIST_TYPE_TO_CONSTANT_CONFIG: Record<string, Field<any>> = {

--- a/packages/visual-editor/src/internal/puck/constant-value-fields/InsuranceProvidersSection.tsx
+++ b/packages/visual-editor/src/internal/puck/constant-value-fields/InsuranceProvidersSection.tsx
@@ -18,12 +18,7 @@ export const INSURANCE_PROVIDERS_SECTION_CONSTANT_CONFIG: CustomField<InsuranceP
       ) => void;
     }) => {
       return (
-        <div
-          className={
-            "ve-mt-4" +
-            (value.insuranceProviders.length === 0 ? " empty-array-fix" : "")
-          }
-        >
+        <div className="ve-mt-4">
           <AutoField
             field={InsuranceProvidersStructArrayField}
             value={value.insuranceProviders}

--- a/packages/visual-editor/src/internal/puck/constant-value-fields/InsuranceProvidersSection.tsx
+++ b/packages/visual-editor/src/internal/puck/constant-value-fields/InsuranceProvidersSection.tsx
@@ -1,0 +1,62 @@
+import { ArrayField, CustomField, AutoField, UiState } from "@measured/puck";
+import {
+  InsuranceProvidersSectionType,
+  InsuranceProvidersStruct,
+} from "../../../types/types.ts";
+
+export const INSURANCE_PROVIDERS_SECTION_CONSTANT_CONFIG: CustomField<InsuranceProvidersSectionType> =
+  {
+    type: "custom",
+    render: ({
+      onChange,
+      value,
+    }: {
+      value: InsuranceProvidersSectionType;
+      onChange: (
+        value: InsuranceProvidersSectionType,
+        uiState?: Partial<UiState>
+      ) => void;
+    }) => {
+      return (
+        <div
+          className={
+            "ve-mt-4" +
+            (value.insuranceProviders.length === 0 ? " empty-array-fix" : "")
+          }
+        >
+          <AutoField
+            field={InsuranceProvidersStructArrayField}
+            value={value.insuranceProviders}
+            onChange={(newValue, uiState) =>
+              onChange({ insuranceProviders: newValue }, uiState)
+            }
+          />
+        </div>
+      );
+    },
+  };
+
+const InsuranceProvidersStructArrayField: ArrayField<
+  InsuranceProvidersStruct[]
+> = {
+  label: "Array Field",
+  type: "array",
+  arrayFields: {
+    title: {
+      type: "text",
+      label: "Name",
+    },
+    image: {
+      type: "object",
+      label: "Image",
+      objectFields: {
+        url: {
+          label: "URL",
+          type: "text",
+        },
+      },
+    },
+  },
+  getItemSummary: (item, i) =>
+    item.title ?? "Insurance Provider " + ((i ?? 0) + 1),
+};

--- a/packages/visual-editor/src/internal/utils/getFilteredEntityFields.ts
+++ b/packages/visual-editor/src/internal/utils/getFilteredEntityFields.ts
@@ -53,6 +53,7 @@ export type EntityFieldTypes =
   | "type.events_section"
   | "type.promo_section"
   | "type.hero_section"
+  | "type.insuranceProviders_section"
   | `c_${string}`;
 
 const DEFAULT_DISALLOWED_ENTITY_FIELDS = ["uid", "meta", "slug"];

--- a/packages/visual-editor/src/types/fields.ts
+++ b/packages/visual-editor/src/types/fields.ts
@@ -66,4 +66,11 @@ export const ComponentFields = {
     tooltipDescription: "",
     altLanguageBehavior: "LANGUAGE_SPECIFIC",
   },
+  InsuranceProviderSection: {
+    name: "Insurance Provider Section",
+    type: "type.insuranceProviders_section",
+    isList: false,
+    tooltipDescription: "",
+    altLanguageBehavior: "LANGUAGE_SPECIFIC",
+  },
 } as const satisfies Record<string, ComponentField>;

--- a/packages/visual-editor/src/types/types.ts
+++ b/packages/visual-editor/src/types/types.ts
@@ -73,6 +73,15 @@ export type TeamSectionType = {
   people: Array<PersonStruct>;
 };
 
+export type InsuranceProvidersSectionType = {
+  insuranceProviders: Array<InsuranceProvidersStruct>;
+};
+
+export type InsuranceProvidersStruct = {
+  title: string;
+  image?: ImageType;
+};
+
 export type PersonStruct = {
   headshot?: ImageType;
   name?: string;


### PR DESCRIPTION
Created Insurance Providers component for FINS.
Component is added under `components/pageSections/FINS`
Didn't add it to `/pageSections/index.ts`
Created a new Struct and Constant for `InsuranceProviders`
[Component Doc](https://docs.google.com/document/d/15JdCygk76PxQXL9z3OcFBDCdMWGYyrvyIWDMZA0U_18/edit?tab=t.ghh9n42jhwbs)

<img width="1892" alt="Screenshot 2025-05-29 at 3 18 00 AM" src="https://github.com/user-attachments/assets/e010ad42-59fa-448c-a0bd-6e0485248c74" />
<img width="1641" alt="Screenshot 2025-05-29 at 3 18 09 AM" src="https://github.com/user-attachments/assets/8a0a6a34-4d71-4ce1-88d9-1a5889ff082c" />
