### PR TITLE
feat: added Core Info Section for FINS

### DIFF
--- a/packages/visual-editor/src/components/_componentCategories.ts
+++ b/packages/visual-editor/src/components/_componentCategories.ts
@@ -75,7 +75,10 @@ import {
   StaticMapSection,
   StaticMapSectionProps,
 } from "./pageSections/StaticMapSection.tsx";
-
+import {
+  FINS_CoreInfoSectionProps,
+  FINS_CoreInfoSection,
+} from "./pageSections/FINS/FINS_CoreInfoSection.tsx";
 export interface PageSectionCategoryProps {
   BreadcrumbsSection: BreadcrumbsSectionProps;
   HeroSection: HeroSectionProps;
@@ -91,6 +94,7 @@ export interface PageSectionCategoryProps {
   FAQSection: FAQSectionProps;
   StaticMapSection: StaticMapSectionProps;
   TestimonialSection: TestimonialSectionProps;
+  FINS_CoreInfoSection: FINS_CoreInfoSectionProps;
 }
 
 export const PageSectionCategoryComponents = {
@@ -108,6 +112,7 @@ export const PageSectionCategoryComponents = {
   PromoSection,
   TeamSection,
   TestimonialSection,
+  FINS_CoreInfoSection,
 };
 
 export const PageSectionCategory = Object.keys(

--- a/packages/visual-editor/src/components/pageSections/FINS/FINS_CoreInfoSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/FINS/FINS_CoreInfoSection.tsx
@@ -1,0 +1,843 @@
+import { ComponentConfig, Fields } from "@measured/puck";
+
+import {
+  HoursType,
+  DayOfWeekNames,
+  HoursTable,
+  HoursStatus,
+} from "@yext/pages-components";
+import {
+  backgroundColors,
+  BackgroundStyle,
+  Body,
+  EntityField,
+  Heading,
+  HeadingLevel,
+  MaybeRTF,
+  PageSection,
+  RTF2,
+  useBackground,
+  useDocument,
+  resolveYextEntityField,
+  ComponentFields,
+  YextEntityField,
+  YextField,
+  Image,
+  VisibilityWrapper,
+  AwardSectionType,
+  AwardStruct,
+} from "@yext/visual-editor";
+import { FaInstagram } from "react-icons/fa";
+import { FaFacebookF, FaLinkedinIn, FaXTwitter } from "react-icons/fa6";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "../../atoms/accordion.js";
+
+export interface FINS_CoreInfoSectionProps {
+  data: {
+    biography: {
+      headingText: YextEntityField<string>;
+      entityField: YextEntityField<RTF2 | string>;
+    };
+    awards: {
+      headingText: YextEntityField<string>;
+      entityField: YextEntityField<AwardSectionType>;
+    };
+    hours: {
+      headingText: YextEntityField<string>;
+      hours: YextEntityField<HoursType>;
+    };
+    services: {
+      headingText: YextEntityField<string>;
+      entityField: YextEntityField<string[]>;
+    };
+    areasServed: {
+      headingText: YextEntityField<string>;
+      entityField: YextEntityField<string[]>;
+    };
+    languages: {
+      headingText: YextEntityField<string>;
+      entityField: YextEntityField<string[]>;
+    };
+    education: {
+      headingText: YextEntityField<string>;
+      entityField: YextEntityField<string[]>;
+    };
+    followUs: {
+      headingText: YextEntityField<string>;
+    };
+  };
+  styles: {
+    mainHeadingLevel: HeadingLevel;
+    subHeadingLevel: HeadingLevel;
+    backgroundColor?: BackgroundStyle;
+    hours: {
+      startOfWeek: keyof DayOfWeekNames | "today";
+      showAdditionalHoursText: boolean;
+    };
+  };
+  liveVisibility: boolean;
+}
+
+const coreInfoSectionFields: Fields<FINS_CoreInfoSectionProps> = {
+  data: YextField("Data", {
+    type: "object",
+    objectFields: {
+      biography: YextField("Biography", {
+        type: "object",
+        objectFields: {
+          headingText: YextField<any, string>("Heading Text", {
+            type: "entityField",
+            filter: {
+              types: ["type.string"],
+            },
+          }),
+          entityField: YextField("Description", {
+            type: "entityField",
+            filter: {
+              types: ["type.string"],
+            },
+          }),
+        },
+      }),
+      awards: YextField("Awards", {
+        type: "object",
+        objectFields: {
+          headingText: YextField<any, string>("Heading Text", {
+            type: "entityField",
+            filter: { types: ["type.string"] },
+          }),
+          entityField: YextField("Awards", {
+            type: "entityField",
+            filter: {
+              types: [ComponentFields.AwardSection.type],
+            },
+          }),
+        },
+      }),
+      hours: YextField("Hours", {
+        type: "object",
+        objectFields: {
+          headingText: YextField<any, string>("Heading Text", {
+            type: "entityField",
+            filter: {
+              types: ["type.string"],
+            },
+          }),
+          hours: YextField("Hours", {
+            type: "entityField",
+            filter: {
+              types: ["type.hours"],
+            },
+          }),
+        },
+      }),
+      services: YextField("Services Offered", {
+        type: "object",
+        objectFields: {
+          headingText: YextField<any, string>("Heading Text", {
+            type: "entityField",
+            filter: {
+              types: ["type.string"],
+            },
+          }),
+          entityField: YextField<any, string[]>("Services Offered", {
+            type: "entityField",
+            filter: {
+              types: ["type.string"],
+              includeListsOnly: true,
+            },
+          }),
+        },
+      }),
+      areasServed: YextField("Areas Served", {
+        type: "object",
+        objectFields: {
+          headingText: YextField<any, string>("Heading Text", {
+            type: "entityField",
+            filter: {
+              types: ["type.string"],
+            },
+          }),
+          entityField: YextField<any, string[]>("Areas Served", {
+            type: "entityField",
+            filter: {
+              types: ["type.string"],
+              includeListsOnly: true,
+            },
+          }),
+        },
+      }),
+      languages: YextField("Languages Spoken", {
+        type: "object",
+        objectFields: {
+          headingText: YextField<any, string>("Heading Text", {
+            type: "entityField",
+            filter: {
+              types: ["type.string"],
+            },
+          }),
+          entityField: YextField<any, string[]>("Languages Spoken", {
+            type: "entityField",
+            filter: {
+              types: ["type.string"],
+              includeListsOnly: true,
+            },
+          }),
+        },
+      }),
+      education: YextField("Education", {
+        type: "object",
+        objectFields: {
+          headingText: YextField<any, string>("Heading Text", {
+            type: "entityField",
+            filter: {
+              types: ["type.string"],
+            },
+          }),
+          entityField: YextField<any, string[]>("Education", {
+            type: "entityField",
+            filter: {
+              types: ["type.string"],
+              includeListsOnly: true,
+            },
+          }),
+        },
+      }),
+      followUs: YextField("Follow Us", {
+        type: "object",
+        objectFields: {
+          headingText: YextField<any, string>("Heading Text", {
+            type: "entityField",
+            filter: {
+              types: ["type.string"],
+            },
+          }),
+        },
+      }),
+    },
+  }),
+  styles: YextField("Styles", {
+    type: "object",
+    objectFields: {
+      backgroundColor: YextField("Background Color", {
+        type: "select",
+        hasSearch: true,
+        options: "BACKGROUND_COLOR",
+      }),
+      mainHeadingLevel: YextField("Heading Level", {
+        type: "select",
+        hasSearch: true,
+        options: "HEADING_LEVEL",
+      }),
+      subHeadingLevel: YextField("Sub Heading Level", {
+        type: "select",
+        hasSearch: true,
+        options: "HEADING_LEVEL",
+      }),
+      hours: YextField("Hours", {
+        type: "object",
+        objectFields: {
+          startOfWeek: YextField("Start of the Week", {
+            type: "select",
+            hasSearch: true,
+            options: "HOURS_OPTIONS",
+          }),
+          showAdditionalHoursText: YextField("Show additional hours text", {
+            type: "radio",
+            options: [
+              { label: "Yes", value: true },
+              { label: "No", value: false },
+            ],
+          }),
+        },
+      }),
+    },
+  }),
+  liveVisibility: YextField("Visible on Live Page", {
+    type: "radio",
+    options: [
+      { label: "Show", value: true },
+      { label: "Hide", value: false },
+    ],
+  }),
+};
+
+const AwardCard = ({ title, description, image }: AwardStruct) => {
+  return (
+    <section className="flex gap-2 md:gap-6 items-start md:items-center">
+      {image && (
+        <figure className="!w-1/3">
+          <Image
+            image={image}
+            layout={"auto"}
+            aspectRatio={image.width / image.height}
+          />
+        </figure>
+      )}
+      <div className="flex flex-col gap-1 w-2/3">
+        <Body className="text-base md:text-lg font-bold">{title}</Body>
+        <MaybeRTF className="text-xs md:text-sm" data={description}></MaybeRTF>
+      </div>
+    </section>
+  );
+};
+
+const CoreInfoSectionWrapper = ({
+  data: {
+    biography,
+    hours,
+    services,
+    areasServed,
+    languages,
+    education,
+    followUs,
+    awards,
+  },
+  styles: {
+    mainHeadingLevel,
+    subHeadingLevel,
+    backgroundColor,
+    hours: { startOfWeek, showAdditionalHoursText },
+  },
+}: FINS_CoreInfoSectionProps) => {
+  const document = useDocument();
+  const resolvedBiographyHeading = resolveYextEntityField<string>(
+    document,
+    biography.headingText
+  );
+  const resolvedHoursHeading = resolveYextEntityField<string>(
+    document,
+    hours.headingText
+  );
+  const resolvedServicesHeading = resolveYextEntityField<string>(
+    document,
+    services.headingText
+  );
+  const resolvedAwardsHeading = resolveYextEntityField<string>(
+    document,
+    awards.headingText
+  );
+  const resolvedAreasServedHeading = resolveYextEntityField<string>(
+    document,
+    areasServed.headingText
+  );
+  const resolvedLanguagesHeading = resolveYextEntityField<string>(
+    document,
+    languages.headingText
+  );
+  const resolvedEducationHeading = resolveYextEntityField<string>(
+    document,
+    education.headingText
+  );
+  const resolvedFollowUsHeading = resolveYextEntityField<string>(
+    document,
+    followUs.headingText
+  );
+  const resolvedBiography = resolveYextEntityField<string | RTF2>(
+    document,
+    biography.entityField
+  );
+  const resolvedHours = resolveYextEntityField<HoursType>(
+    document,
+    hours.hours
+  );
+  const resolvedServices = resolveYextEntityField<string[]>(
+    document,
+    services.entityField
+  );
+  const resolvedAreasServed = resolveYextEntityField<string[]>(
+    document,
+    areasServed.entityField
+  );
+  const resolvedLanguages = resolveYextEntityField<string[]>(
+    document,
+    languages.entityField
+  );
+  const resolvedEducation = resolveYextEntityField<string[]>(
+    document,
+    education.entityField
+  );
+  const resolvedAwards = resolveYextEntityField(document, awards.entityField);
+  const background = useBackground();
+  const hasDarkBackground = background?.textColor === "text-white";
+  const {
+    additionalHoursText,
+    twitterHandle,
+    facebookPageUrl,
+    instagramHandle,
+    linkedInUrl,
+    timezone,
+  } = document as {
+    additionalHoursText: string;
+    twitterHandle: string;
+    facebookPageUrl: string;
+    instagramHandle: string;
+    linkedInUrl: string;
+    timezone: string;
+  };
+
+  return (
+    <PageSection
+      background={backgroundColor}
+      aria-label="Core Info Section"
+      className="flex flex-col md:flex-row gap-8 divide-y-2 md:divide-y-0"
+    >
+      <div className="w-full md:w-2/3 flex flex-col gap-8">
+        <div className="flex flex-col gap-8 md:gap-16 divide-y-2 md:divide-y-0">
+          <div className="flex flex-col gap-8">
+            <EntityField
+              displayName="Heading Text"
+              fieldId={biography.headingText.field}
+              constantValueEnabled={biography.headingText.constantValueEnabled}
+            >
+              <Heading level={mainHeadingLevel}>
+                {resolvedBiographyHeading}
+              </Heading>
+            </EntityField>
+            <EntityField
+              displayName="Description"
+              fieldId={biography.entityField.field}
+              constantValueEnabled={biography.entityField.constantValueEnabled}
+            >
+              <Body>
+                <MaybeRTF data={resolvedBiography} />
+              </Body>
+            </EntityField>
+          </div>
+          <div className="flex flex-col gap-4 pt-4 md:pt-0">
+            <EntityField
+              displayName="Heading Text"
+              fieldId={awards.headingText.field}
+              constantValueEnabled={awards.headingText.constantValueEnabled}
+            >
+              <Heading level={subHeadingLevel}>{resolvedAwardsHeading}</Heading>
+            </EntityField>
+            {resolvedAwards?.awards && (
+              <EntityField
+                displayName="Award"
+                fieldId={awards.entityField.field}
+                constantValueEnabled={awards.entityField.constantValueEnabled}
+              >
+                <div className="flex flex-col gap-6">
+                  {resolvedAwards.awards.map((award, index) => (
+                    <AwardCard key={index} {...award} />
+                  ))}
+                </div>
+              </EntityField>
+            )}
+          </div>
+        </div>
+      </div>
+      <div className="w-full md:w-1/3 flex flex-col divide-y-2">
+        {resolvedHours && (
+          <section
+            aria-label="Hours Section"
+            className="flex flex-col gap-4 py-8 first:md:pt-0 last:md:pb-0"
+          >
+            {resolvedHoursHeading && (
+              <EntityField
+                displayName="Heading Text"
+                fieldId={hours.headingText.field}
+                constantValueEnabled={hours.headingText.constantValueEnabled}
+              >
+                <Heading level={subHeadingLevel}>
+                  {resolvedHoursHeading}
+                </Heading>
+              </EntityField>
+            )}
+            <Accordion type="single" collapsible>
+              <AccordionItem value="hoursAccordion" className="border-b-0">
+                <AccordionTrigger className="py-0 justify-start gap-3">
+                  <EntityField
+                    displayName="Hours"
+                    fieldId={hours.hours.field}
+                    constantValueEnabled={hours.hours.constantValueEnabled}
+                  >
+                    <HoursStatus hours={resolvedHours} timezone={timezone} />
+                  </EntityField>
+                </AccordionTrigger>
+                <AccordionContent>
+                  <HoursTable
+                    className="pt-4 -mb-4"
+                    hours={resolvedHours}
+                    startOfWeek={startOfWeek}
+                  />
+                </AccordionContent>
+              </AccordionItem>
+            </Accordion>
+            {additionalHoursText && showAdditionalHoursText && (
+              <EntityField
+                displayName="Hours Text"
+                fieldId="additionalHoursText"
+              >
+                <Body className="text-sm">{additionalHoursText}</Body>
+              </EntityField>
+            )}
+          </section>
+        )}
+        {resolvedServices && resolvedServices.length > 0 && (
+          <section
+            aria-label="Services Section"
+            className="flex flex-col gap-4 py-8 first:md:pt-0 last:md:pb-0"
+          >
+            {resolvedServicesHeading && (
+              <EntityField
+                displayName="Heading Text"
+                fieldId={services.headingText.field}
+                constantValueEnabled={services.headingText.constantValueEnabled}
+              >
+                <Heading level={subHeadingLevel}>
+                  {resolvedServicesHeading}
+                </Heading>
+              </EntityField>
+            )}
+            <EntityField
+              displayName="Text List"
+              fieldId={services.entityField.field}
+              constantValueEnabled={services.entityField.constantValueEnabled}
+            >
+              <ul className="list-disc list-inside">
+                {resolvedServices.map((text: any, index: any) => (
+                  <li key={index} className="mb-2">
+                    {text}
+                  </li>
+                ))}
+              </ul>
+            </EntityField>
+          </section>
+        )}
+        {resolvedAreasServed && resolvedAreasServed.length > 0 && (
+          <section
+            aria-label="Areas Served Section"
+            className="flex flex-col gap-4 py-8 first:md:pt-0 last:md:pb-0"
+          >
+            {resolvedAreasServedHeading && (
+              <EntityField
+                displayName="Heading Text"
+                fieldId={areasServed.headingText.field}
+                constantValueEnabled={
+                  areasServed.headingText.constantValueEnabled
+                }
+              >
+                <Heading level={subHeadingLevel}>
+                  {resolvedAreasServedHeading}
+                </Heading>
+              </EntityField>
+            )}
+            <EntityField
+              displayName="Text List"
+              fieldId={areasServed.entityField.field}
+              constantValueEnabled={
+                areasServed.entityField.constantValueEnabled
+              }
+            >
+              <ul className="list-disc list-inside">
+                {resolvedAreasServed.map((text: any, index: number) => (
+                  <li key={index} className="mb-2">
+                    {text}
+                  </li>
+                ))}
+              </ul>
+            </EntityField>
+          </section>
+        )}
+        {resolvedLanguages && resolvedLanguages.length > 0 && (
+          <section
+            aria-label="Languages Section"
+            className="flex flex-col gap-4 py-8 first:md:pt-0 last:md:pb-0"
+          >
+            {resolvedLanguagesHeading && (
+              <EntityField
+                displayName="Heading Text"
+                fieldId={languages.headingText.field}
+                constantValueEnabled={
+                  languages.headingText.constantValueEnabled
+                }
+              >
+                <Heading level={subHeadingLevel}>
+                  {resolvedLanguagesHeading}
+                </Heading>
+              </EntityField>
+            )}
+            <EntityField
+              displayName="Text List"
+              fieldId={languages.entityField.field}
+              constantValueEnabled={languages.entityField.constantValueEnabled}
+            >
+              <ul className="list-disc list-inside">
+                {resolvedLanguages.map((text: any, index: number) => (
+                  <li key={index} className="mb-2">
+                    {text}
+                  </li>
+                ))}
+              </ul>
+            </EntityField>
+          </section>
+        )}
+        {resolvedEducation && resolvedEducation.length > 0 && (
+          <section
+            aria-label="Education Section"
+            className="flex flex-col gap-4 py-8 first:md:pt-0 last:md:pb-0"
+          >
+            {resolvedEducationHeading && (
+              <EntityField
+                displayName="Heading Text"
+                fieldId={education.headingText.field}
+                constantValueEnabled={
+                  education.headingText.constantValueEnabled
+                }
+              >
+                <Heading level={subHeadingLevel}>
+                  {resolvedEducationHeading}
+                </Heading>
+              </EntityField>
+            )}
+            <EntityField
+              displayName="Text List"
+              fieldId={education.entityField.field}
+              constantValueEnabled={education.entityField.constantValueEnabled}
+            >
+              <ul className="list-disc list-inside">
+                {resolvedEducation.map((text: any, index: number) => (
+                  <li key={index} className="mb-2">
+                    {text}
+                  </li>
+                ))}
+              </ul>
+            </EntityField>
+          </section>
+        )}
+        {(twitterHandle ||
+          facebookPageUrl ||
+          instagramHandle ||
+          linkedInUrl) && (
+          <section
+            aria-label="Services Section"
+            className="flex flex-col gap-4 py-8 first:md:pt-0 last:md:pb-0"
+          >
+            {resolvedFollowUsHeading && (
+              <EntityField
+                displayName="Heading Text"
+                fieldId={followUs.headingText.field}
+                constantValueEnabled={followUs.headingText.constantValueEnabled}
+              >
+                <Heading level={subHeadingLevel}>
+                  {resolvedFollowUsHeading}
+                </Heading>
+              </EntityField>
+            )}
+            <EntityField displayName="Social">
+              <ul className="list-none flex gap-5">
+                {twitterHandle && (
+                  <li
+                    className={`h-12 w-12 flex items-center justify-center border rounded-full ${
+                      !hasDarkBackground
+                        ? "bg-palette-primary-dark text-white"
+                        : "bg-white text-palette-primary-dark"
+                    }`}
+                  >
+                    <a href={twitterHandle}>
+                      <FaXTwitter className="h-6 w-6" />
+                    </a>
+                  </li>
+                )}
+                {facebookPageUrl && (
+                  <li
+                    className={`h-12 w-12 flex items-center justify-center border rounded-full ${
+                      !hasDarkBackground
+                        ? "bg-palette-primary-dark text-white"
+                        : "bg-white text-palette-primary-dark"
+                    }`}
+                  >
+                    <a href={facebookPageUrl}>
+                      <FaFacebookF className="h-6 w-6" />
+                    </a>
+                  </li>
+                )}
+                {instagramHandle && (
+                  <li
+                    className={`h-12 w-12 flex items-center justify-center border rounded-full ${
+                      !hasDarkBackground
+                        ? "bg-palette-primary-dark text-white"
+                        : "bg-white text-palette-primary-dark"
+                    }`}
+                  >
+                    <a href={instagramHandle}>
+                      <FaInstagram className="h-6 w-6" />
+                    </a>
+                  </li>
+                )}
+                {linkedInUrl && (
+                  <li
+                    className={`h-12 w-12 flex items-center justify-center border rounded-full ${
+                      !hasDarkBackground
+                        ? "bg-palette-primary-dark text-white"
+                        : "bg-white text-palette-primary-dark"
+                    }`}
+                  >
+                    <a href={linkedInUrl}>
+                      <FaLinkedinIn className="h-6 w-6" />
+                    </a>
+                  </li>
+                )}
+              </ul>
+            </EntityField>
+          </section>
+        )}
+      </div>
+    </PageSection>
+  );
+};
+
+export const FINS_CoreInfoSection: ComponentConfig<FINS_CoreInfoSectionProps> =
+  {
+    label: "FINS - Core Info Section",
+    fields: coreInfoSectionFields,
+    defaultProps: {
+      data: {
+        hours: {
+          headingText: {
+            field: "",
+            constantValue: "Hours",
+            constantValueEnabled: true,
+          },
+          hours: {
+            field: "hours",
+            constantValue: {},
+          },
+        },
+        services: {
+          headingText: {
+            field: "",
+            constantValue: "Services Offered",
+            constantValueEnabled: true,
+          },
+          entityField: {
+            field: "services",
+            constantValue: [],
+          },
+        },
+        biography: {
+          headingText: {
+            field: "",
+            constantValue: "About",
+            constantValueEnabled: true,
+          },
+          entityField: {
+            field: "description",
+            constantValue: "",
+          },
+        },
+        areasServed: {
+          headingText: {
+            field: "",
+            constantValue: "Areas Served",
+            constantValueEnabled: true,
+          },
+          entityField: {
+            field: "",
+            constantValue: [
+              "Augue interdum velit euismod",
+              "Euismod lacinia at quis",
+              "Viverra ipsum nunc aliquet bib",
+              "Ultrices dui sapien",
+              "Deserunt mollit anim id est",
+            ],
+            constantValueEnabled: true,
+          },
+        },
+        languages: {
+          headingText: {
+            field: "",
+            constantValue: "Languages Spoken",
+            constantValueEnabled: true,
+          },
+          entityField: {
+            field: "languages",
+            constantValue: [],
+          },
+        },
+        education: {
+          headingText: {
+            field: "",
+            constantValue: "Education",
+            constantValueEnabled: true,
+          },
+          entityField: {
+            field: "",
+            constantValue: [
+              "Augue interdum velit euismod",
+              "Euismod lacinia at quis",
+            ],
+            constantValueEnabled: true,
+          },
+        },
+        followUs: {
+          headingText: {
+            field: "",
+            constantValue: "Follow Us",
+            constantValueEnabled: true,
+          },
+        },
+        awards: {
+          headingText: {
+            field: "",
+            constantValue: "Awards",
+            constantValueEnabled: true,
+          },
+          entityField: {
+            field: "",
+            constantValueEnabled: true,
+            constantValue: {
+              awards: [
+                {
+                  title: "Award title goes here",
+                  description:
+                    "Published annually Jan - April. Rankings based on data as of June 30 of prior year.",
+                  image: {
+                    alternateText: "The Galaxy Grill Logo",
+                    height: 90,
+                    url: "https://placehold.co/175x90",
+                    width: 175,
+                  },
+                },
+                {
+                  title: "Award title goes here",
+                  description:
+                    "Published annually Jan - April. Rankings based on data as of June 30 of prior year.",
+                  image: {
+                    alternateText: "The Galaxy Grill Logo",
+                    height: 90,
+                    url: "https://placehold.co/175x90",
+                    width: 175,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+      styles: {
+        mainHeadingLevel: 2,
+        subHeadingLevel: 4,
+        hours: {
+          startOfWeek: "today",
+          showAdditionalHoursText: true,
+        },
+        backgroundColor: backgroundColors.background2.value,
+      },
+      liveVisibility: true,
+    },
+    render: (props) => (
+      <VisibilityWrapper
+        liveVisibility={props.liveVisibility}
+        isEditing={props.puck.isEditing}
+      >
+        <CoreInfoSectionWrapper {...props} />
+      </VisibilityWrapper>
+    ),
+  };

--- a/packages/visual-editor/src/components/pageSections/FINS/FINS_CoreInfoSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/FINS/FINS_CoreInfoSection.tsx
@@ -388,35 +388,48 @@ const CoreInfoSectionWrapper = ({
     >
       <div className="w-full md:w-2/3 flex flex-col gap-8">
         <div className="flex flex-col gap-8 md:gap-16 divide-y-2 md:divide-y-0">
-          <div className="flex flex-col gap-8">
-            <EntityField
-              displayName="Heading Text"
-              fieldId={biography.headingText.field}
-              constantValueEnabled={biography.headingText.constantValueEnabled}
+          {resolvedBiography && (
+            <section aria-label="Biography" className="flex flex-col gap-8">
+              {resolvedBiographyHeading && (
+                <EntityField
+                  displayName="Heading Text"
+                  fieldId={biography.headingText.field}
+                  constantValueEnabled={
+                    biography.headingText.constantValueEnabled
+                  }
+                >
+                  <Heading level={mainHeadingLevel}>
+                    {resolvedBiographyHeading}
+                  </Heading>
+                </EntityField>
+              )}
+              <EntityField
+                displayName="Description"
+                fieldId={biography.entityField.field}
+                constantValueEnabled={
+                  biography.entityField.constantValueEnabled
+                }
+              >
+                <Body>
+                  <MaybeRTF data={resolvedBiography} />
+                </Body>
+              </EntityField>
+            </section>
+          )}
+          {resolvedAwards?.awards && (
+            <section
+              aria-label="Awards"
+              className="flex flex-col gap-4 pt-4 md:pt-0"
             >
-              <Heading level={mainHeadingLevel}>
-                {resolvedBiographyHeading}
-              </Heading>
-            </EntityField>
-            <EntityField
-              displayName="Description"
-              fieldId={biography.entityField.field}
-              constantValueEnabled={biography.entityField.constantValueEnabled}
-            >
-              <Body>
-                <MaybeRTF data={resolvedBiography} />
-              </Body>
-            </EntityField>
-          </div>
-          <div className="flex flex-col gap-4 pt-4 md:pt-0">
-            <EntityField
-              displayName="Heading Text"
-              fieldId={awards.headingText.field}
-              constantValueEnabled={awards.headingText.constantValueEnabled}
-            >
-              <Heading level={subHeadingLevel}>{resolvedAwardsHeading}</Heading>
-            </EntityField>
-            {resolvedAwards?.awards && (
+              <EntityField
+                displayName="Heading Text"
+                fieldId={awards.headingText.field}
+                constantValueEnabled={awards.headingText.constantValueEnabled}
+              >
+                <Heading level={subHeadingLevel}>
+                  {resolvedAwardsHeading}
+                </Heading>
+              </EntityField>
               <EntityField
                 displayName="Award"
                 fieldId={awards.entityField.field}
@@ -428,8 +441,8 @@ const CoreInfoSectionWrapper = ({
                   ))}
                 </div>
               </EntityField>
-            )}
-          </div>
+            </section>
+          )}
         </div>
       </div>
       <div className="w-full md:w-1/3 flex flex-col divide-y-2">
@@ -457,7 +470,11 @@ const CoreInfoSectionWrapper = ({
                     fieldId={hours.hours.field}
                     constantValueEnabled={hours.hours.constantValueEnabled}
                   >
-                    <HoursStatus hours={resolvedHours} timezone={timezone} />
+                    <HoursStatus
+                      hours={resolvedHours}
+                      timezone={timezone}
+                      dayOfWeekTemplate={() => null}
+                    />
                   </EntityField>
                 </AccordionTrigger>
                 <AccordionContent>
@@ -501,7 +518,7 @@ const CoreInfoSectionWrapper = ({
               constantValueEnabled={services.entityField.constantValueEnabled}
             >
               <ul className="list-disc list-inside">
-                {resolvedServices.map((text: any, index: any) => (
+                {resolvedServices.map((text, index) => (
                   <li key={index} className="mb-2">
                     {text}
                   </li>
@@ -536,7 +553,7 @@ const CoreInfoSectionWrapper = ({
               }
             >
               <ul className="list-disc list-inside">
-                {resolvedAreasServed.map((text: any, index: number) => (
+                {resolvedAreasServed.map((text, index) => (
                   <li key={index} className="mb-2">
                     {text}
                   </li>
@@ -569,7 +586,7 @@ const CoreInfoSectionWrapper = ({
               constantValueEnabled={languages.entityField.constantValueEnabled}
             >
               <ul className="list-disc list-inside">
-                {resolvedLanguages.map((text: any, index: number) => (
+                {resolvedLanguages.map((text, index) => (
                   <li key={index} className="mb-2">
                     {text}
                   </li>
@@ -602,7 +619,7 @@ const CoreInfoSectionWrapper = ({
               constantValueEnabled={education.entityField.constantValueEnabled}
             >
               <ul className="list-disc list-inside">
-                {resolvedEducation.map((text: any, index: number) => (
+                {resolvedEducation.map((text, index) => (
                   <li key={index} className="mb-2">
                     {text}
                   </li>
@@ -616,7 +633,7 @@ const CoreInfoSectionWrapper = ({
           instagramHandle ||
           linkedInUrl) && (
           <section
-            aria-label="Services Section"
+            aria-label="Social Section"
             className="flex flex-col gap-4 py-8 first:md:pt-0 last:md:pb-0"
           >
             {resolvedFollowUsHeading && (
@@ -634,53 +651,37 @@ const CoreInfoSectionWrapper = ({
               <ul className="list-none flex gap-5">
                 {twitterHandle && (
                   <li
-                    className={`h-12 w-12 flex items-center justify-center border rounded-full ${
-                      !hasDarkBackground
-                        ? "bg-palette-primary-dark text-white"
-                        : "bg-white text-palette-primary-dark"
-                    }`}
+                    className={`h-12 w-12 flex items-center justify-center border rounded-full ${!hasDarkBackground ? "bg-palette-primary-dark text-white" : "bg-white text-palette-primary-dark"}`}
                   >
-                    <a href={twitterHandle}>
-                      <FaXTwitter className="h-6 w-6" />
+                    <a href={twitterHandle} aria-label="Twitter">
+                      <FaXTwitter className="h-6 w-6" aria-hidden="true" />
                     </a>
                   </li>
                 )}
                 {facebookPageUrl && (
                   <li
-                    className={`h-12 w-12 flex items-center justify-center border rounded-full ${
-                      !hasDarkBackground
-                        ? "bg-palette-primary-dark text-white"
-                        : "bg-white text-palette-primary-dark"
-                    }`}
+                    className={`h-12 w-12 flex items-center justify-center border rounded-full ${!hasDarkBackground ? "bg-palette-primary-dark text-white" : "bg-white text-palette-primary-dark"}`}
                   >
-                    <a href={facebookPageUrl}>
-                      <FaFacebookF className="h-6 w-6" />
+                    <a href={facebookPageUrl} aria-label="Facebook">
+                      <FaFacebookF className="h-6 w-6" aria-hidden="true" />
                     </a>
                   </li>
                 )}
                 {instagramHandle && (
                   <li
-                    className={`h-12 w-12 flex items-center justify-center border rounded-full ${
-                      !hasDarkBackground
-                        ? "bg-palette-primary-dark text-white"
-                        : "bg-white text-palette-primary-dark"
-                    }`}
+                    className={`h-12 w-12 flex items-center justify-center border rounded-full ${!hasDarkBackground ? "bg-palette-primary-dark text-white" : "bg-white text-palette-primary-dark"}`}
                   >
-                    <a href={instagramHandle}>
-                      <FaInstagram className="h-6 w-6" />
+                    <a href={instagramHandle} aria-label="Instagram">
+                      <FaInstagram className="h-6 w-6" aria-hidden="true" />
                     </a>
                   </li>
                 )}
                 {linkedInUrl && (
                   <li
-                    className={`h-12 w-12 flex items-center justify-center border rounded-full ${
-                      !hasDarkBackground
-                        ? "bg-palette-primary-dark text-white"
-                        : "bg-white text-palette-primary-dark"
-                    }`}
+                    className={`h-12 w-12 flex items-center justify-center border rounded-full ${!hasDarkBackground ? "bg-palette-primary-dark text-white" : "bg-white text-palette-primary-dark"}`}
                   >
-                    <a href={linkedInUrl}>
-                      <FaLinkedinIn className="h-6 w-6" />
+                    <a href={linkedInUrl} aria-label="LinkedIn">
+                      <FaLinkedinIn className="h-6 w-6" aria-hidden="true" />
                     </a>
                   </li>
                 )}

--- a/packages/visual-editor/src/components/registry/components.ts
+++ b/packages/visual-editor/src/components/registry/components.ts
@@ -186,6 +186,26 @@ export const ui: Registry["items"] = [
     files: [{ path: "pageSections/FAQsSection.tsx", type: "registry:ui" }],
   },
   {
+    name: "FINS_CoreInfoSection",
+    type: "registry:ui",
+    registryDependencies: [
+      "pageSection",
+      "background",
+      "heading",
+      "body",
+      "accordion",
+      "maybeRTF",
+      "image",
+      "visibilityWrapper",
+    ],
+    files: [
+      {
+        path: "pageSections/FINS/FINS_CoreInfoSection.tsx",
+        type: "registry:ui",
+      },
+    ],
+  },
+  {
     name: "Flex",
     type: "registry:ui",
     registryDependencies: ["layout", "background", "visibilityWrapper"],

--- a/packages/visual-editor/src/editor/YextEntityFieldSelector.tsx
+++ b/packages/visual-editor/src/editor/YextEntityFieldSelector.tsx
@@ -30,6 +30,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "../internal/puck/ui/Tooltip.tsx";
+import { AWARDS_SECTION_CONSTANT_CONFIG } from "../internal/puck/constant-value-fields/AwardsSection.tsx";
 
 const devLogger = new DevLogger();
 
@@ -66,6 +67,7 @@ export const TYPE_TO_CONSTANT_CONFIG: Record<string, Field<any>> = {
   "type.faq_section": FAQ_SECTION_CONSTANT_CONFIG,
   "type.team_section": TEAM_SECTION_CONSTANT_CONFIG,
   "type.testimonials_section": TESTIMONIAL_SECTION_CONSTANT_CONFIG,
+  "type.awards_section": AWARDS_SECTION_CONSTANT_CONFIG,
 };
 
 const LIST_TYPE_TO_CONSTANT_CONFIG: Record<string, Field<any>> = {

--- a/packages/visual-editor/src/internal/puck/constant-value-fields/AwardsSection.tsx
+++ b/packages/visual-editor/src/internal/puck/constant-value-fields/AwardsSection.tsx
@@ -1,0 +1,54 @@
+import { ArrayField, CustomField, AutoField, UiState } from "@measured/puck";
+import { AwardSectionType, AwardStruct } from "../../../types/types.ts";
+
+export const AWARDS_SECTION_CONSTANT_CONFIG: CustomField<AwardSectionType> = {
+  type: "custom",
+  render: ({
+    onChange,
+    value,
+  }: {
+    value: AwardSectionType;
+    onChange: (value: AwardSectionType, uiState?: Partial<UiState>) => void;
+  }) => {
+    return (
+      <div
+        className={
+          "ve-mt-4" + (value.awards.length === 0 ? " empty-array-fix" : "")
+        }
+      >
+        <AutoField
+          field={AwardsStructArrayField}
+          value={value.awards}
+          onChange={(newValue, uiState) =>
+            onChange({ awards: newValue }, uiState)
+          }
+        />
+      </div>
+    );
+  },
+};
+const AwardsStructArrayField: ArrayField<AwardStruct[]> = {
+  label: "Array Field",
+  type: "array",
+  arrayFields: {
+    image: {
+      type: "object",
+      label: "Award Image",
+      objectFields: {
+        url: {
+          label: "URL",
+          type: "text",
+        },
+      },
+    },
+    title: {
+      type: "text",
+      label: "Award Title",
+    },
+    description: {
+      type: "textarea",
+      label: "Award Description",
+    },
+  },
+  getItemSummary: (item, i) => item.title ?? "Award " + ((i ?? 0) + 1),
+};

--- a/packages/visual-editor/src/internal/utils/getFilteredEntityFields.ts
+++ b/packages/visual-editor/src/internal/utils/getFilteredEntityFields.ts
@@ -53,6 +53,7 @@ export type EntityFieldTypes =
   | "type.events_section"
   | "type.promo_section"
   | "type.hero_section"
+  | "type.awards_section"
   | `c_${string}`;
 
 const DEFAULT_DISALLOWED_ENTITY_FIELDS = ["uid", "meta", "slug"];

--- a/packages/visual-editor/src/types/fields.ts
+++ b/packages/visual-editor/src/types/fields.ts
@@ -66,4 +66,11 @@ export const ComponentFields = {
     tooltipDescription: "",
     altLanguageBehavior: "LANGUAGE_SPECIFIC",
   },
+  AwardSection: {
+    name: "Award Section",
+    type: "type.awards_section",
+    isList: false,
+    tooltipDescription: "",
+    altLanguageBehavior: "LANGUAGE_SPECIFIC",
+  },
 } as const satisfies Record<string, ComponentField>;

--- a/packages/visual-editor/src/types/types.ts
+++ b/packages/visual-editor/src/types/types.ts
@@ -73,6 +73,16 @@ export type TeamSectionType = {
   people: Array<PersonStruct>;
 };
 
+export type AwardSectionType = {
+  awards: Array<AwardStruct>;
+};
+
+export type AwardStruct = {
+  title: string;
+  description: RTF2 | string;
+  image?: ImageType;
+};
+
 export type PersonStruct = {
   headshot?: ImageType;
   name?: string;


### PR DESCRIPTION
Created Core Info Section for FINS.
Component is added under `components/pageSections/FINS`
Didn't add it to `/pageSections/index.ts`
Used `FaFacebookF`, `FaLinkedinIn`, `FaXTwitter` from `react-icons/fa6`, since, the added icons aren't available in `react-icons/fa`
[Component Doc](https://docs.google.com/document/d/15JdCygk76PxQXL9z3OcFBDCdMWGYyrvyIWDMZA0U_18/edit?tab=t.ghh9n42jhwbs)

<img width="1666" alt="Screenshot 2025-05-29 at 3 24 59 AM" src="https://github.com/user-attachments/assets/7c21d336-6263-4b77-a230-8cc556e7d06d" />
<img width="1595" alt="Screenshot 2025-05-29 at 3 25 28 AM" src="https://github.com/user-attachments/assets/292135ce-4aba-4239-a710-8971182051e6" />
