### PR TITLE
feat: adjust paths in main template

### DIFF
--- a/packages/visual-editor/src/vite-plugin/templates/main.tsx
+++ b/packages/visual-editor/src/vite-plugin/templates/main.tsx
@@ -82,7 +82,7 @@ export const getPath: GetPath<TemplateProps> = ({ document }) => {
 
   const localePath = document.locale !== "en" ? `${document.locale}/` : "";
   const path = document.address
-    ? `${localePath}${document.address.region}/${document.address.city}/${document.address.line1}`
+    ? `${localePath}${document.address.region}/${document.address.city}/${document.address.line1}-${document.id}`
     : `${localePath}${document.id}`;
 
   return normalizeSlug(path);


### PR DESCRIPTION
This appends `-{entityId}` on the path built from address. Was requested from aaron so there aren't as many path conflicts when entities have the same address (and no slug)