### PR TITLE
feat: update colors for entity field tooltips

### DIFF
--- a/packages/visual-editor/src/editor/EntityField.tsx
+++ b/packages/visual-editor/src/editor/EntityField.tsx
@@ -31,14 +31,16 @@ export const EntityField = ({
 }: EntityFieldProps) => {
   const tooltipsContext = useEntityTooltips();
 
-  if (!tooltipsContext || constantValueEnabled) {
+  if (!tooltipsContext) {
     return children;
   }
 
   const { tooltipsVisible } = tooltipsContext;
 
   let tooltipContent = "";
-  if (displayName && fieldId) {
+  if (constantValueEnabled) {
+    tooltipContent = "Static content";
+  } else if (displayName && fieldId) {
     tooltipContent = `${displayName} (${fieldId})`;
   } else if (fieldId) {
     tooltipContent = `${fieldId}`;
@@ -54,16 +56,22 @@ export const EntityField = ({
             <div
               className={
                 tooltipsVisible
-                  ? "ve-outline-2 ve-outline-dotted ve-outline-[#5A58F2]"
+                  ? "ve-outline-2 ve-outline-dotted" +
+                    (!constantValueEnabled ? " ve-outline-primary" : "")
                   : ""
               }
             >
               <MemoizedChildren>{children}</MemoizedChildren>
             </div>
           </TooltipTrigger>
-          <TooltipContent>
+          <TooltipContent
+            className={!constantValueEnabled ? "ve-bg-primary" : ""}
+          >
             <p>{tooltipContent}</p>
-            <TooltipArrow fill="bg-popover" />
+            <TooltipArrow
+              fill="bg-popover"
+              className={!constantValueEnabled ? "ve-fill-primary" : ""}
+            />
           </TooltipContent>
         </Tooltip>
       </TooltipProvider>


### PR DESCRIPTION
This updates the entity field tooltips such that entity-mapped fields show purple tooltips and outlines, and constant value-mapped fields show black tooltips and outlines.

![Screenshot 2025-06-02 at 2 28 35 PM](https://github.com/user-attachments/assets/0d94a163-4606-4e1b-adbb-f455dcb48ee4)
