### PR TITLE
feat: use string constant value for RTF

### DIFF
--- a/packages/visual-editor/src/editor/YextEntityFieldSelector.tsx
+++ b/packages/visual-editor/src/editor/YextEntityFieldSelector.tsx
@@ -56,6 +56,7 @@ export type RenderYextEntityFieldSelectorProps<T extends Record<string, any>> =
 
 export const TYPE_TO_CONSTANT_CONFIG: Record<string, Field<any>> = {
   "type.string": TEXT_CONSTANT_CONFIG,
+  "type.rich_text_v2": TEXT_CONSTANT_CONFIG,
   "type.phone": PHONE_CONSTANT_CONFIG,
   "type.image": IMAGE_CONSTANT_CONFIG,
   "type.address": ADDRESS_CONSTANT_CONFIG,


### PR DESCRIPTION
The current components only use RTF as part of a section but the FINS components use RTF directly. To enable constant values for that field, we should map RTF to the normal string constant value input. MaybeRTF can handle a plain string so the output should be type safe.