### PR TITLE
feat: use YEXT_EDIT_LAYOUT_MODE_MAPBOX_API_KEY when in VLE if present

### DIFF
--- a/packages/visual-editor/src/components/Locator.tsx
+++ b/packages/visual-editor/src/components/Locator.tsx
@@ -432,8 +432,6 @@ const Map: React.FC<MapProps> = ({
     typeof document === "undefined"
       ? undefined
       : (document.getElementById("preview-frame") as HTMLIFrameElement);
-  const entityDocument: any = useDocument();
-  const mapboxApiKey = entityDocument._env?.YEXT_MAPBOX_API_KEY;
   //@ts-expect-error MapboxGL is not loaded in the iframe content window
   if (iframe?.contentDocument && !iframe.contentWindow?.mapboxgl) {
     // We are in an iframe, and mapboxgl is not loaded in yet
@@ -446,6 +444,16 @@ const Map: React.FC<MapProps> = ({
         </div>
       </div>
     );
+  }
+
+  const entityDocument: any = useDocument();
+  let mapboxApiKey = entityDocument._env?.YEXT_MAPBOX_API_KEY;
+  if (
+    iframe?.contentDocument &&
+    entityDocument._env?.YEXT_EDIT_LAYOUT_MODE_MAPBOX_API_KEY
+  ) {
+    // If we are in the layout editor, use the non-URL-restricted Mapbox API key
+    mapboxApiKey = entityDocument._env.YEXT_EDIT_LAYOUT_MODE_MAPBOX_API_KEY;
   }
 
   return (

--- a/packages/visual-editor/src/utils/searchHeadlessConfig.ts
+++ b/packages/visual-editor/src/utils/searchHeadlessConfig.ts
@@ -48,6 +48,17 @@ export const createSearchHeadlessConfig = (document: any) => {
     return;
   }
 
+  // The iframe'd locator will need a non-URL-restricted Mapbox API key in order to display the map
+  // properly. Without this key, we will fall back to the site-specific Mapbox API key, which is not
+  // guaranteed to work in the iframe.
+  const iframeMapboxApiKey =
+    document?._env?.YEXT_EDIT_LAYOUT_MODE_MAPBOX_API_KEY;
+  if (!iframeMapboxApiKey) {
+    console.warn(
+      "Missing YEXT_EDIT_LAYOUT_MODE_MAPBOX_API_KEY! Some map behavior may be unavailable in the layout editor."
+    );
+  }
+
   const headlessConfig: HeadlessConfig = {
     apiKey: searchApiKey,
     experienceKey: experienceKey,


### PR DESCRIPTION
We will use an environment-wide Mapbox key (in the `YEXT_EDIT_LAYOUT_MODE_MAPBOX_API_KEY` env var) when in the VLE iframe in order to get around the URL restrictions by the site-specific API key. If this key is not present for some reason, we will fall back to the site-specific API key. 

J=[WAT-4873](https://yexttest.atlassian.net/browse/WAT-4873)
TEST=manual