### PR TITLE
feat: resize tooltips based on viewport

### DIFF
--- a/packages/visual-editor/src/editor/EntityField.tsx
+++ b/packages/visual-editor/src/editor/EntityField.tsx
@@ -65,6 +65,7 @@ export const EntityField = ({
             </div>
           </TooltipTrigger>
           <TooltipContent
+            zoomWithViewport
             className={!constantValueEnabled ? "ve-bg-primary" : ""}
           >
             <p>{tooltipContent}</p>

--- a/packages/visual-editor/src/internal/puck/ui/Tooltip.tsx
+++ b/packages/visual-editor/src/internal/puck/ui/Tooltip.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import { cn } from "../../../utils/cn.ts";
+import { usePuck } from "@measured/puck";
 
 const TooltipProvider = TooltipPrimitive.Provider;
 
@@ -10,21 +11,80 @@ const TooltipTrigger = TooltipPrimitive.Trigger;
 
 const TooltipArrow = TooltipPrimitive.Arrow;
 
+interface TooltipContentProps
+  extends React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content> {
+  zoomWithViewport?: boolean;
+}
+
 const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
-  <TooltipPrimitive.Content
-    ref={ref}
-    sideOffset={sideOffset}
-    className={cn(
-      "ve-z-50 ve-overflow-hidden ve-rounded-md ve-bg-popover ve-px-3 ve-py-1.5 ve-text-sm" +
-        " ve-text-popover-foreground",
-      className
-    )}
-    {...props}
-  />
-));
+  TooltipContentProps
+>(({ className, sideOffset = 4, zoomWithViewport, ...props }, ref) => {
+  const [scaleFactor, setScaleFactor] = React.useState<number>(1);
+  const [iframeWidth, setIFrameWidth] = React.useState<number | undefined>();
+  const { appState } = usePuck();
+
+  React.useEffect(() => {
+    if (!zoomWithViewport) {
+      return;
+    }
+
+    const viewportElement = document.getElementById(
+      "puck-canvas-root"
+    ) as HTMLDivElement;
+    const iFrameElement = document.getElementById(
+      "preview-frame"
+    ) as HTMLIFrameElement;
+
+    if (!viewportElement || !iFrameElement) {
+      return;
+    }
+
+    // Set initial width
+    setIFrameWidth(iFrameElement.getBoundingClientRect().width);
+
+    // Update the width when the puck viewport changes
+    // Puck updates the canvas's scale rather than the iframe's width
+    // Puck also has a transition animation so we have to introduce a small delay
+    const observer = new MutationObserver(() => {
+      setTimeout(() => {
+        setIFrameWidth(iFrameElement.getBoundingClientRect().width);
+      }, 150);
+    });
+    observer.observe(viewportElement, { attributes: true });
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [zoomWithViewport]);
+
+  React.useEffect(() => {
+    // Scale the tooltip using on Puck's zoom factor
+    // Based on https://github.com/puckeditor/puck/blob/af1dc89139e0311b1dc014e328f431b1ebab0067/packages/core/components/DraggableComponent/index.tsx#L608
+    // and https://github.com/puckeditor/puck/blob/af1dc89139e0311b1dc014e328f431b1ebab0067/packages/core/lib/get-zoom-config.ts#L6
+    if (
+      iframeWidth &&
+      appState.ui.viewports.current.width &&
+      zoomWithViewport
+    ) {
+      setScaleFactor(1 / (iframeWidth / appState.ui.viewports.current.width));
+    }
+  }, [appState.ui.viewports.current.width, iframeWidth, zoomWithViewport]);
+
+  return (
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      style={{ transform: `scale(${scaleFactor})` }}
+      className={cn(
+        "ve-z-50 ve-overflow-hidden ve-rounded-md ve-bg-popover ve-px-3 ve-py-1.5 ve-text-xs " +
+          "ve-text-popover-foreground ve-transform",
+        className
+      )}
+      {...props}
+    />
+  );
+});
 
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 


### PR DESCRIPTION
Updates the entity field tooltip size based on the viewport size/zoom. Uses similar logic to how puck scales the component name in the action bar.

https://github.com/user-attachments/assets/8b1a1b11-0c3c-4018-9a0c-55bf9e09d329



 