### PR TITLE
fix: hide email list length when using constant value

### DIFF
--- a/packages/visual-editor/src/components/contentBlocks/Emails.tsx
+++ b/packages/visual-editor/src/components/contentBlocks/Emails.tsx
@@ -13,7 +13,7 @@ import {
 
 export interface EmailsProps {
   list: YextEntityField<string[]>;
-  listLength: number;
+  listLength?: number;
   includeHyperlink: boolean;
 }
 
@@ -32,11 +32,6 @@ const EmailsFields: Fields<EmailsProps> = {
       { label: "Yes", value: true },
       { label: "No", value: false },
     ],
-  }),
-  listLength: YextField("List Length", {
-    type: "number",
-    min: 1,
-    max: 100,
   }),
 };
 
@@ -61,7 +56,7 @@ const EmailsComponent: React.FC<EmailsProps> = ({
     >
       <ul className="components list-inside">
         {resolvedEmailList
-          .slice(0, Math.min(resolvedEmailList.length, listLength))
+          .slice(0, Math.min(resolvedEmailList.length, listLength ?? Infinity))
           ?.map((email, index) => (
             <li key={index} className={`mb-2 flex items-center`}>
               <FaEnvelope className={"mr-2 my-auto"} />
@@ -85,6 +80,20 @@ const EmailsComponent: React.FC<EmailsProps> = ({
 export const Emails: ComponentConfig<EmailsProps> = {
   label: "Emails",
   fields: EmailsFields,
+  resolveFields: (data, { fields }) => {
+    if (data.props.list.constantValueEnabled) {
+      return fields;
+    }
+
+    return {
+      ...fields,
+      listLength: YextField("List Length", {
+        type: "number",
+        min: 1,
+        max: 100,
+      }),
+    };
+  },
   defaultProps: {
     list: {
       field: "emails",

--- a/packages/visual-editor/src/components/pageSections/CoreInfoSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/CoreInfoSection.tsx
@@ -51,7 +51,7 @@ export interface CoreInfoSectionProps {
       showGetDirectionsLink: boolean;
       phoneFormat: "domestic" | "international";
       includePhoneHyperlink: boolean;
-      emailsListLength: number;
+      emailsListLength?: number;
     };
     hours: {
       startOfWeek: keyof DayOfWeekNames | "today";
@@ -173,11 +173,6 @@ const coreInfoSectionFields: Fields<CoreInfoSectionProps> = {
               { label: "Yes", value: true },
               { label: "No", value: false },
             ],
-          }),
-          emailsListLength: YextField("List Length", {
-            type: "number",
-            min: 0,
-            max: 3,
           }),
         },
       }),
@@ -350,7 +345,10 @@ const CoreInfoSectionWrapper = ({ data, styles }: CoreInfoSectionProps) => {
               {resolvedEmails
                 .slice(
                   0,
-                  Math.min(resolvedEmails.length, styles.info.emailsListLength)
+                  Math.min(
+                    resolvedEmails.length,
+                    styles.info.emailsListLength ?? Infinity
+                  )
                 )
                 .map((email, index) => (
                   <li key={index} className={`flex items-center gap-3`}>
@@ -443,6 +441,35 @@ const CoreInfoSectionWrapper = ({ data, styles }: CoreInfoSectionProps) => {
 export const CoreInfoSection: ComponentConfig<CoreInfoSectionProps> = {
   label: "Core Info Section",
   fields: coreInfoSectionFields,
+  resolveFields: (data, { fields }) => {
+    if (data.props.data.info.emails.constantValueEnabled) {
+      return fields;
+    }
+
+    return {
+      ...fields,
+      styles: {
+        ...fields.styles,
+        objectFields: {
+          // @ts-expect-error ts(2339) objectFields exists
+          ...fields.styles.objectFields,
+          info: {
+            // @ts-expect-error ts(2339) objectFields exists
+            ...fields.styles.objectFields.info,
+            objectFields: {
+              // @ts-expect-error ts(2339) objectFields exists
+              ...fields.styles.objectFields.info.objectFields,
+              emailsListLength: YextField("Emails List Length", {
+                type: "number",
+                min: 0,
+                max: 3,
+              }),
+            },
+          },
+        },
+      },
+    };
+  },
   defaultProps: {
     data: {
       info: {


### PR DESCRIPTION
This hides the email list length option when the field is set to a constant value since it is redundant.