### PR TITLE
wip: add constant value i18n support

### DIFF
--- a/packages/visual-editor/src/components/pageSections/Banner.tsx
+++ b/packages/visual-editor/src/components/pageSections/Banner.tsx
@@ -9,6 +9,8 @@ import {
   YextField,
   VisibilityWrapper,
   EntityField,
+  TranslatableString,
+  resolveTranslatableString,
 } from "@yext/visual-editor";
 import { ComponentConfig, Fields } from "@measured/puck";
 import {
@@ -22,7 +24,7 @@ export type BannerSectionProps = {
     textAlignment: "left" | "right" | "center";
   };
   data: {
-    text: YextEntityField<string>;
+    text: YextEntityField<TranslatableString>;
   };
   liveVisibility: boolean;
 };
@@ -31,7 +33,7 @@ const bannerSectionFields: Fields<BannerSectionProps> = {
   data: YextField("Data", {
     type: "object",
     objectFields: {
-      text: YextField<any, string>("Text", {
+      text: YextField<any, TranslatableString>("Text", {
         type: "entityField",
         filter: {
           types: ["type.string"],
@@ -65,7 +67,9 @@ const bannerSectionFields: Fields<BannerSectionProps> = {
 const BannerComponent = ({ data, styles }: BannerSectionProps) => {
   const { t } = useTranslation();
   const document = useDocument();
-  const resolvedText = resolveYextEntityField<string>(document, data.text);
+  const resolvedText = resolveTranslatableString(
+    resolveYextEntityField<TranslatableString>(document, data.text)
+  );
 
   const justifyClass = {
     left: "justify-start",

--- a/packages/visual-editor/src/components/pageSections/CoreInfoSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/CoreInfoSection.tsx
@@ -27,23 +27,25 @@ import {
   Background,
   YextField,
   VisibilityWrapper,
+  TranslatableString,
+  resolveTranslatableString,
 } from "@yext/visual-editor";
 
 export interface CoreInfoSectionProps {
   data: {
     info: {
-      headingText: YextEntityField<string>;
+      headingText: YextEntityField<TranslatableString>;
       address: YextEntityField<AddressType>;
       phoneNumbers: Array<{ number: YextEntityField<string>; label: string }>;
       emails: YextEntityField<string[]>;
     };
     hours: {
-      headingText: YextEntityField<string>;
+      headingText: YextEntityField<TranslatableString>;
       hours: YextEntityField<HoursType>;
     };
     services: {
-      headingText: YextEntityField<string>;
-      servicesList: YextEntityField<string[]>;
+      headingText: YextEntityField<TranslatableString>;
+      servicesList: YextEntityField<TranslatableString[]>;
     };
   };
   styles: {
@@ -74,7 +76,7 @@ const coreInfoSectionFields: Fields<CoreInfoSectionProps> = {
       info: YextField("Info Column", {
         type: "object",
         objectFields: {
-          headingText: YextField<any, string>("Heading Text", {
+          headingText: YextField<any, TranslatableString>("Heading Text", {
             type: "entityField",
             filter: { types: ["type.string"] },
           }),
@@ -110,7 +112,7 @@ const coreInfoSectionFields: Fields<CoreInfoSectionProps> = {
       hours: YextField("Hours Column", {
         type: "object",
         objectFields: {
-          headingText: YextField<any, string>("Heading Text", {
+          headingText: YextField<any, TranslatableString>("Heading Text", {
             type: "entityField",
             filter: {
               types: ["type.string"],
@@ -127,13 +129,13 @@ const coreInfoSectionFields: Fields<CoreInfoSectionProps> = {
       services: YextField("Services Column", {
         type: "object",
         objectFields: {
-          headingText: YextField<any, string>("Heading Text", {
+          headingText: YextField<any, TranslatableString>("Heading Text", {
             type: "entityField",
             filter: {
               types: ["type.string"],
             },
           }),
-          servicesList: YextField<any, string[]>("Services List", {
+          servicesList: YextField<any, TranslatableString[]>("Services List", {
             type: "entityField",
             filter: {
               types: ["type.string"],
@@ -219,9 +221,8 @@ const coreInfoSectionFields: Fields<CoreInfoSectionProps> = {
 const CoreInfoSectionWrapper = ({ data, styles }: CoreInfoSectionProps) => {
   const { t } = useTranslation();
   const document = useDocument();
-  const addressHeadingText = resolveYextEntityField<string>(
-    document,
-    data.info.headingText
+  const addressHeadingText = resolveTranslatableString(
+    resolveYextEntityField<TranslatableString>(document, data.info.headingText)
   );
   const resolvedAddress = resolveYextEntityField<AddressType>(
     document,
@@ -231,22 +232,23 @@ const CoreInfoSectionWrapper = ({ data, styles }: CoreInfoSectionProps) => {
     document,
     data.info.emails
   );
-  const hoursHeadingText = resolveYextEntityField<string>(
-    document,
-    data.hours.headingText
+  const hoursHeadingText = resolveTranslatableString(
+    resolveYextEntityField<TranslatableString>(document, data.hours.headingText)
   );
   const resolvedHours = resolveYextEntityField<HoursType>(
     document,
     data.hours.hours
   );
-  const servicesHeadingText = resolveYextEntityField<string>(
-    document,
-    data.services.headingText
+  const servicesHeadingText = resolveTranslatableString(
+    resolveYextEntityField<TranslatableString>(
+      document,
+      data.services.headingText
+    )
   );
-  const servicesList = resolveYextEntityField<string[]>(
+  const servicesList = resolveYextEntityField<TranslatableString[]>(
     document,
     data.services.servicesList
-  );
+  )?.map((t: TranslatableString) => resolveTranslatableString(t));
   const coordinates = getDirections(
     resolvedAddress as AddressType,
     undefined,

--- a/packages/visual-editor/src/components/pageSections/InsightSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/InsightSection.tsx
@@ -20,13 +20,15 @@ import {
   Timestamp,
   ComponentFields,
   MaybeRTF,
+  resolveTranslatableString,
 } from "@yext/visual-editor";
 import { ComponentConfig, Fields } from "@measured/puck";
 import { AnalyticsScopeProvider } from "@yext/pages-components";
+import { TranslatableString } from "../../editor/YextEntityFieldSelector.tsx";
 
 export interface InsightSectionProps {
   data: {
-    heading: YextEntityField<string>;
+    heading: YextEntityField<TranslatableString>;
     insights: YextEntityField<InsightSectionType>;
   };
   styles: {
@@ -44,7 +46,7 @@ const insightSectionFields: Fields<InsightSectionProps> = {
   data: YextField("Data", {
     type: "object",
     objectFields: {
-      heading: YextField<any, string>("Section Heading", {
+      heading: YextField<any, TranslatableString>("Section Heading", {
         type: "entityField",
         filter: { types: ["type.string"] },
       }),
@@ -157,7 +159,9 @@ const InsightSectionWrapper = ({ data, styles }: InsightSectionProps) => {
   const { t } = useTranslation();
   const document = useDocument();
   const resolvedInsights = resolveYextEntityField(document, data.insights);
-  const resolvedHeading = resolveYextEntityField(document, data.heading);
+  const resolvedHeading = resolveTranslatableString(
+    resolveYextEntityField(document, data.heading)
+  );
 
   return (
     <PageSection

--- a/packages/visual-editor/src/components/pageSections/NearbyLocations.tsx
+++ b/packages/visual-editor/src/components/pageSections/NearbyLocations.tsx
@@ -14,6 +14,8 @@ import {
   YextField,
   VisibilityWrapper,
   HoursStatusAtom,
+  TranslatableString,
+  resolveTranslatableString,
 } from "@yext/visual-editor";
 import { useQuery } from "@tanstack/react-query";
 import {
@@ -27,7 +29,7 @@ import { TFunction } from "i18next";
 
 export interface NearbyLocationsSectionProps {
   data: {
-    heading: YextEntityField<string>;
+    heading: YextEntityField<TranslatableString>;
     coordinate: YextEntityField<Coordinate>;
     radius: number;
     limit: number;
@@ -57,7 +59,7 @@ const nearbyLocationsSectionFields: Fields<NearbyLocationsSectionProps> = {
   data: YextField("Data", {
     type: "object",
     objectFields: {
-      heading: YextField<any, string>("Heading", {
+      heading: YextField<any, TranslatableString>("Heading", {
         type: "entityField",
         filter: {
           types: ["type.string"],
@@ -235,7 +237,9 @@ const NearbyLocationsComponent: React.FC<NearbyLocationsSectionProps> = ({
     document,
     data?.coordinate
   );
-  const headingText = resolveYextEntityField<string>(document, data?.heading);
+  const headingText = resolveTranslatableString(
+    resolveYextEntityField<TranslatableString>(document, data?.heading)
+  );
 
   // parse variables from document
   const { businessId, apiKey, contentEndpointId, contentDeliveryAPIDomain } =

--- a/packages/visual-editor/src/components/pageSections/PhotoGallerySection.tsx
+++ b/packages/visual-editor/src/components/pageSections/PhotoGallerySection.tsx
@@ -27,6 +27,7 @@ import {
   YextEntityField,
   YextField,
   VisibilityWrapper,
+  resolveTranslatableString,
 } from "@yext/visual-editor";
 import {
   resolvedImageFields,
@@ -34,6 +35,7 @@ import {
 } from "../contentBlocks/Image.js";
 import { FaArrowLeft, FaArrowRight } from "react-icons/fa";
 import { ComplexImageType, ImageType } from "@yext/pages-components";
+import { TranslatableString } from "../../editor/YextEntityFieldSelector.tsx";
 
 const PLACEHOLDER_IMAGE_URL = "https://placehold.co/1000x570/png";
 
@@ -45,7 +47,7 @@ const DEFAULT_IMAGE = {
 
 export interface PhotoGallerySectionProps {
   data: {
-    heading: YextEntityField<string>;
+    heading: YextEntityField<TranslatableString>;
     images: YextEntityField<ImageType[] | ComplexImageType[]>;
   };
   styles: {
@@ -110,7 +112,7 @@ const photoGallerySectionFields: Fields<PhotoGallerySectionProps> = {
   data: YextField("Data", {
     type: "object",
     objectFields: {
-      heading: YextField<any, string>("Heading", {
+      heading: YextField<any, TranslatableString>("Heading", {
         type: "entityField",
         filter: {
           types: ["type.string"],
@@ -140,7 +142,9 @@ const PhotoGallerySectionComponent = ({
 }: PhotoGallerySectionProps) => {
   const { t } = useTranslation();
   const document = useDocument();
-  const sectionHeading = resolveYextEntityField(document, data.heading);
+  const sectionHeading = resolveTranslatableString(
+    resolveYextEntityField(document, data.heading)
+  );
 
   const resolvedImages = resolveYextEntityField(document, data.images);
 

--- a/packages/visual-editor/src/components/pageSections/ProductSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/ProductSection.tsx
@@ -19,13 +19,15 @@ import {
   ProductStruct,
   ComponentFields,
   MaybeRTF,
+  TranslatableString,
+  resolveTranslatableString,
 } from "@yext/visual-editor";
 import { ComponentConfig, Fields } from "@measured/puck";
 import { AnalyticsScopeProvider } from "@yext/pages-components";
 
 export interface ProductSectionProps {
   data: {
-    heading: YextEntityField<string>;
+    heading: YextEntityField<TranslatableString>;
     products: YextEntityField<ProductSectionType>;
   };
   styles: {
@@ -43,7 +45,7 @@ const productSectionFields: Fields<ProductSectionProps> = {
   data: YextField("Data", {
     type: "object",
     objectFields: {
-      heading: YextField<any, string>("Section Heading", {
+      heading: YextField<any, TranslatableString>("Section Heading", {
         type: "entityField",
         filter: { types: ["type.string"] },
       }),
@@ -154,7 +156,9 @@ const ProductSectionWrapper = ({ data, styles }: ProductSectionProps) => {
   const { t } = useTranslation();
   const document = useDocument();
   const resolvedProducts = resolveYextEntityField(document, data.products);
-  const resolvedHeading = resolveYextEntityField(document, data.heading);
+  const resolvedHeading = resolveTranslatableString(
+    resolveYextEntityField(document, data.heading)
+  );
 
   return (
     <PageSection

--- a/packages/visual-editor/src/components/pageSections/SectionContainer.tsx
+++ b/packages/visual-editor/src/components/pageSections/SectionContainer.tsx
@@ -21,11 +21,13 @@ import {
   WithId,
   WithPuckProps,
 } from "@measured/puck";
+import { TranslatableString } from "../../editor/YextEntityFieldSelector.tsx";
+import { resolveTranslatableString } from "../../utils/resolveYextEntityField.ts";
 
 export type SectionContainerProps = {
   background?: BackgroundStyle;
   sectionHeading: {
-    text: YextEntityField<string>;
+    text: YextEntityField<TranslatableString>;
     level: HeadingProps["level"];
     alignment: "left" | "right" | "center";
   };
@@ -41,7 +43,7 @@ const sectionContainerFields: Fields<SectionContainerProps> = {
   sectionHeading: YextField("Section Heading", {
     type: "object",
     objectFields: {
-      text: YextField<any, string>("Section Heading Text", {
+      text: YextField<any, TranslatableString>("Section Heading Text", {
         type: "entityField",
         filter: {
           types: ["type.string"],
@@ -73,9 +75,8 @@ const SectionContainerComponent = (
   const { background, sectionHeading } = props;
   const document = useDocument();
 
-  const resolvedHeadingText = resolveYextEntityField<string>(
-    document,
-    sectionHeading.text
+  const resolvedHeadingText = resolveTranslatableString(
+    resolveYextEntityField<TranslatableString>(document, sectionHeading.text)
   );
 
   const justifyClass = {

--- a/packages/visual-editor/src/editor/YextEntityFieldSelector.tsx
+++ b/packages/visual-editor/src/editor/YextEntityFieldSelector.tsx
@@ -8,7 +8,7 @@ import {
 } from "../internal/utils/getFilteredEntityFields.ts";
 import { DevLogger } from "../utils/devLogger.ts";
 import { IMAGE_CONSTANT_CONFIG } from "../internal/puck/constant-value-fields/Image.tsx";
-import { TEXT_CONSTANT_CONFIG } from "../internal/puck/constant-value-fields/Text.tsx";
+import { TRANSLATABLE_TEXT_CONSTANT_CONFIG } from "../internal/puck/constant-value-fields/Text.tsx";
 import { ADDRESS_CONSTANT_CONFIG } from "../internal/puck/constant-value-fields/Address.tsx";
 import { TEXT_LIST_CONSTANT_CONFIG } from "../internal/puck/constant-value-fields/TextList.tsx";
 import { CTA_CONSTANT_CONFIG } from "../internal/puck/constant-value-fields/CallToAction.tsx";
@@ -37,6 +37,8 @@ const devLogger = new DevLogger();
 
 type RenderProps = Parameters<CustomField<any>["render"]>[0];
 
+export type TranslatableString = string | Record<string, string>;
+
 export type YextEntityField<T> = {
   field: string;
   constantValue: T;
@@ -57,8 +59,8 @@ export type RenderYextEntityFieldSelectorProps<T extends Record<string, any>> =
   };
 
 export const TYPE_TO_CONSTANT_CONFIG: Record<string, Field<any>> = {
-  "type.string": TEXT_CONSTANT_CONFIG,
-  "type.rich_text_v2": TEXT_CONSTANT_CONFIG,
+  "type.string": TRANSLATABLE_TEXT_CONSTANT_CONFIG,
+  "type.rich_text_v2": TRANSLATABLE_TEXT_CONSTANT_CONFIG,
   "type.phone": PHONE_CONSTANT_CONFIG,
   "type.image": IMAGE_CONSTANT_CONFIG,
   "type.address": ADDRESS_CONSTANT_CONFIG,

--- a/packages/visual-editor/src/editor/index.ts
+++ b/packages/visual-editor/src/editor/index.ts
@@ -6,6 +6,7 @@ export {
   type RenderYextEntityFieldSelectorProps,
   type YextEntityField,
   type YextCollection,
+  type TranslatableString,
 } from "./YextEntityFieldSelector.tsx";
 export {
   OptionalNumberField,

--- a/packages/visual-editor/src/internal/puck/constant-value-fields/Text.tsx
+++ b/packages/visual-editor/src/internal/puck/constant-value-fields/Text.tsx
@@ -1,6 +1,78 @@
-import { TextField } from "@measured/puck";
+import { AutoField, CustomField, TextField, FieldLabel } from "@measured/puck";
+import React from "react";
+import { TranslatableString } from "../../../editor/YextEntityFieldSelector.tsx";
+import { useDocument } from "../../../hooks/useDocument.tsx";
 
 export const TEXT_CONSTANT_CONFIG: TextField = {
   type: "text",
   label: "",
 };
+
+export const TRANSLATABLE_TEXT_CONSTANT_CONFIG: CustomField<TranslatableString> =
+  {
+    type: "custom",
+    render: ({ onChange, value }) => {
+      const document: any = useDocument();
+
+      const locales: string[] = [document?.locale ?? "en"];
+      if (typeof document?._pageset === "string") {
+        const parsedPageset = JSON.parse(document?._pageset || "");
+        const scopeLocales: string[] = parsedPageset?.scope?.locales;
+
+        (scopeLocales ?? []).forEach((locale: string) => {
+          locales.push(locale);
+        });
+      }
+
+      // TODO remove these
+      ["es", "fr"].forEach((locale) => {
+        locales.push(locale);
+      });
+
+      // TODO replace "en" with platform locale
+      return (
+        <>
+          {locales.map((locale: string) => {
+            const displayValue =
+              typeof value === "object" && !Array.isArray(value)
+                ? (value[locale] ?? "")
+                : typeof value === "string"
+                  ? value
+                  : "";
+
+            return (
+              <FieldLabel key={locale} label={getLocaleName(locale, "en")}>
+                <AutoField
+                  field={{ type: "text" }}
+                  value={displayValue}
+                  onChange={(val) =>
+                    onChange({
+                      ...(typeof value === "object" &&
+                      value !== null &&
+                      !Array.isArray(value)
+                        ? value
+                        : {}),
+                      [locale]: val,
+                    })
+                  }
+                />
+              </FieldLabel>
+            );
+          })}
+        </>
+      );
+    },
+  };
+
+/**
+ * Takes in a locale code like "es" and translates to the name using the targetLang
+ * ex: getLocaleName("es", "en") -> "Spanish"
+ * @param code
+ * @param targetLang
+ */
+function getLocaleName(code: string, targetLang: string): string {
+  const displayNames = new Intl.DisplayNames([targetLang], {
+    type: "language",
+  });
+  return displayNames.of(code) ?? "";
+}

--- a/packages/visual-editor/src/utils/index.ts
+++ b/packages/visual-editor/src/utils/index.ts
@@ -4,6 +4,7 @@ export {
   resolveYextSubfield,
   resolveYextStructField,
   handleResolveFieldsForCollections,
+  resolveTranslatableString,
 } from "./resolveYextEntityField.ts";
 export { themeResolver, type ThemeConfig } from "./themeResolver.ts";
 export { themeManagerCn, themeManagerTwMergeConfiguration } from "./cn.ts";

--- a/packages/visual-editor/src/utils/resolveYextEntityField.ts
+++ b/packages/visual-editor/src/utils/resolveYextEntityField.ts
@@ -1,5 +1,8 @@
 import { Fields } from "@measured/puck";
-import { YextEntityField } from "../editor/YextEntityFieldSelector.tsx";
+import {
+  TranslatableString,
+  YextEntityField,
+} from "../editor/YextEntityFieldSelector.tsx";
 import { YextStructEntityField } from "../editor/YextStructFieldSelector.tsx";
 
 export const resolveYextEntityField = <T>(
@@ -193,4 +196,36 @@ export const handleResolveFieldsForCollections = (
     isCollection,
     directChildrenFilter: collectionField,
   };
+};
+
+// Utility function to detect browser language
+const getBrowserLanguage = (): string => {
+  const browserLocales = navigator.languages || [navigator.language];
+  if (!browserLocales || browserLocales.length === 0) {
+    return "en"; // Fallback to English
+  }
+  // Return primary language code (e.g., "en" from "en-US")
+  return browserLocales[0].split("-")[0];
+};
+
+export const resolveTranslatableString = (
+  field?: TranslatableString
+): string => {
+  if (!field) {
+    return "";
+  }
+
+  if (typeof field === "object") {
+    const detectedLanguage = getBrowserLanguage();
+    if (detectedLanguage in field) {
+      return field[detectedLanguage];
+    } else if ("en" in field) {
+      // TODO: Have a fallback language that isn't just English
+      return field["en"];
+    } else {
+      return "";
+    }
+  }
+
+  return field;
 };


### PR DESCRIPTION
Adds constant value support for i18n

Uses the browser language for now

https://github.com/user-attachments/assets/534ee2f1-ff22-487c-92f9-7e86bcbf27be


TODO:
Handle strings that should not be translatable (emails)

Phone List in CoreInfoSection seems to crash

Add support in remaining components

Code cleanup/ TODOs
