### PR TITLE
refactor: enable locales in hours status

### DIFF
--- a/packages/visual-editor/src/components/contentBlocks/HoursStatus.tsx
+++ b/packages/visual-editor/src/components/contentBlocks/HoursStatus.tsx
@@ -68,7 +68,6 @@ const HoursStatusWrapper: React.FC<HoursStatusProps> = ({
   const document = useDocument();
   const { t } = useTranslation();
   const hours = resolveYextEntityField(document, hoursField);
-  const locale = "en-US"; // TODO pass real locale through
 
   if (!hours) {
     return null;
@@ -82,9 +81,7 @@ const HoursStatusWrapper: React.FC<HoursStatusProps> = ({
     >
       <HoursStatusAtom
         hours={hours}
-        t={t}
         className={className}
-        locale={locale}
         showCurrentStatus={showCurrentStatus}
         showDayNames={showDayNames}
         timeFormat={timeFormat}

--- a/packages/visual-editor/src/components/pageSections/HeroSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/HeroSection.tsx
@@ -125,7 +125,6 @@ const heroSectionFields: Fields<HeroSectionProps> = {
 const HeroSectionWrapper = ({ data, styles }: HeroSectionProps) => {
   const { t } = useTranslation();
   const document = useDocument() as any;
-  const locale = "en-US"; // TODO override with real locale
   const resolvedBusinessName = resolveYextEntityField<string>(
     document,
     data?.businessName
@@ -197,12 +196,7 @@ const HeroSectionWrapper = ({ data, styles }: HeroSectionProps) => {
               fieldId={data?.hours.field}
               constantValueEnabled={data?.hours.constantValueEnabled}
             >
-              <HoursStatusAtom
-                hours={resolvedHours}
-                t={t}
-                timezone={timezone}
-                locale={locale}
-              />
+              <HoursStatusAtom hours={resolvedHours} timezone={timezone} />
             </EntityField>
           )}
         </header>

--- a/packages/visual-editor/src/components/pageSections/NearbyLocations.tsx
+++ b/packages/visual-editor/src/components/pageSections/NearbyLocations.tsx
@@ -22,8 +22,6 @@ import {
   AnalyticsScopeProvider,
 } from "@yext/pages-components";
 import * as React from "react";
-import { useTranslation } from "react-i18next";
-import { TFunction } from "i18next";
 
 export interface NearbyLocationsSectionProps {
   data: {
@@ -164,8 +162,6 @@ const LocationCard = ({
   address,
   timezone,
   mainPhone,
-  locale,
-  t,
 }: {
   key: number;
   styles: NearbyLocationsSectionProps["styles"];
@@ -174,8 +170,6 @@ const LocationCard = ({
   address: any;
   timezone: string;
   mainPhone: string;
-  locale: string;
-  t: TFunction;
 }) => {
   return (
     <Background
@@ -188,13 +182,10 @@ const LocationCard = ({
         <div className="mb-2 font-semibold font-body-fontFamily text-body-fontSize">
           <HoursStatusAtom
             hours={hours}
-            t={t}
             className="h-full"
             timezone={timezone}
             showCurrentStatus={styles?.hours?.showCurrentStatus}
-            timeFormat={"12h"}
             dayOfWeekFormat={styles?.hours?.dayOfWeekFormat}
-            locale={locale}
           />
         </div>
       )}
@@ -229,8 +220,6 @@ const NearbyLocationsComponent: React.FC<NearbyLocationsSectionProps> = ({
   contentEndpointIdEnvVar,
 }: NearbyLocationsSectionProps) => {
   const document = useDocument<any>();
-  const { t } = useTranslation();
-  const locale = "en-US"; // TODO replace with real locale
   const coordinate = resolveYextEntityField<Coordinate>(
     document,
     data?.coordinate
@@ -305,8 +294,6 @@ const NearbyLocationsComponent: React.FC<NearbyLocationsSectionProps> = ({
                     hours={location.hours}
                     timezone={location.timezone}
                     mainPhone={location.mainPhone}
-                    locale={locale}
-                    t={t}
                   />
                 )
               )}


### PR DESCRIPTION
Updated to use the translation hook that is set based on the document locale. Also added format conversion for the time for countries that use 24hr notation.

https://github.com/user-attachments/assets/e0df1e61-fadd-483d-9168-6b5a0c21640f



