### PR TITLE
fix: ignore email list length in constant value mode

### DIFF
--- a/packages/visual-editor/src/components/contentBlocks/Emails.tsx
+++ b/packages/visual-editor/src/components/contentBlocks/Emails.tsx
@@ -58,7 +58,12 @@ const EmailsComponent: React.FC<EmailsProps> = ({
     >
       <ul className="components list-inside">
         {resolvedEmailList
-          .slice(0, Math.min(resolvedEmailList.length, listLength ?? Infinity))
+          .slice(
+            0,
+            emailListField.constantValueEnabled
+              ? resolvedEmailList.length
+              : Math.min(resolvedEmailList.length, listLength!)
+          )
           ?.map((email, index) => (
             <li key={index} className={`mb-2 flex items-center`}>
               <FaEnvelope className={"mr-2 my-auto"} />

--- a/packages/visual-editor/src/components/pageSections/CoreInfoSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/CoreInfoSection.tsx
@@ -357,10 +357,12 @@ const CoreInfoSectionWrapper = ({ data, styles }: CoreInfoSectionProps) => {
               {resolvedEmails
                 .slice(
                   0,
-                  Math.min(
-                    resolvedEmails.length,
-                    styles.info.emailsListLength ?? Infinity
-                  )
+                  data.info.emails.constantValueEnabled
+                    ? resolvedEmails.length
+                    : Math.min(
+                        resolvedEmails.length,
+                        styles.info.emailsListLength!
+                      )
                 )
                 .map((email, index) => (
                   <li key={index} className={`flex items-center gap-3`}>


### PR DESCRIPTION
If a list length was already set, it would previously still use that length even in constant value mode. This ensures it ignores the length in constant value mode.