### PR TITLE
feat: enable session tracking in locator

### DIFF
--- a/packages/visual-editor/src/components/Locator.tsx
+++ b/packages/visual-editor/src/components/Locator.tsx
@@ -184,6 +184,7 @@ const LocatorWrapper: React.FC<LocatorProps> = (props) => {
     );
     return <></>;
   }
+  searcher.setSessionTrackingEnabled(true);
   return (
     <SearchHeadlessProvider searcher={searcher}>
       <AnalyticsProvider {...(searchAnalyticsConfig as any)}>


### PR DESCRIPTION
This allows the searches to be grouped together based on session, which is useful for various analytics purposes

J=[WAT-4881](https://yexttest.atlassian.net/browse/WAT-4881?atlOrigin=eyJpIjoiYmRmODg2NzEwZTY5NGJjMmFjZmU2NzViNzU3ZmJjOWMiLCJwIjoiaiJ9)
TEST=manual
spun up local; saw searches have same session id in Snowflake when they didn't previously 