### PR TITLE
fix: translate "Get Directions"

### DIFF
--- a/packages/visual-editor/src/components/contentBlocks/GetDirections.tsx
+++ b/packages/visual-editor/src/components/contentBlocks/GetDirections.tsx
@@ -11,6 +11,7 @@ import {
   CTA,
   CTAProps,
   YextField,
+  pt,
 } from "@yext/visual-editor";
 
 export type GetDirectionsProps = {
@@ -53,12 +54,12 @@ const GetDirectionsComponent = ({
 
   return (
     <EntityField
-      displayName={t("getDirections", "Get Directions")}
+      displayName={pt("getDirections", "Get Directions")}
       fieldId={coordinateField.field}
       constantValueEnabled={coordinateField.constantValueEnabled}
     >
       <CTA
-        label={"Get Directions"}
+        label={t("getDirections", "Get Directions")}
         link={searchQuery}
         linkType={"DRIVING_DIRECTIONS"}
         variant={variant}


### PR DESCRIPTION
The actual displayed text was not being translated

The entity field label should use the platform locale

The actual text should use the document locale