### PR TITLE
fix: fix path logic for linked entities

### DIFF
--- a/packages/visual-editor/src/components/Locator.tsx
+++ b/packages/visual-editor/src/components/Locator.tsx
@@ -622,7 +622,7 @@ const getPath = (location: Location, locale: string) => {
 
   const localePath = locale !== "en" ? `${locale}/` : "";
   const path = location.address
-    ? `${localePath}${location.address.region}/${location.address.city}/${location.address.line1}`
+    ? `${localePath}${location.address.region}/${location.address.city}/${location.address.line1}-${location.id}`
     : `${localePath}${location.id}`;
 
   return normalizeSlug(path);


### PR DESCRIPTION
The path creating logic was changed in the main template, but not in our Locator component, so the links were no longer pointing to the correct path. Here I have updated the logic to be the same as the main template