### PR TITLE
chore: hide translation diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+starter/localData/** linguist-generated=true
+starter/src/dev.config.ts linguist-generated=true
+packages/visual-editor/locales/** linguist-generated=true
+packages/visual-editor/locales/en/visual-editor.json linguist-generated=false


### PR DESCRIPTION
![Screenshot 2025-06-13 at 11 06 54 AM](https://github.com/user-attachments/assets/a83d9167-be4d-43d4-8ed7-120ecbe105e2)

I'm not sure if this is better but we might want can auto-hide the translation diffs? I wish they appeared smaller 