### PR TITLE
feat: "near me" button on locator component

### DIFF
--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -149,7 +149,7 @@
   "peerDependencies": {
     "@yext/pages-components": "^1.1.4",
     "@yext/search-headless-react": "^2.5.0",
-    "@yext/search-ui-react": "^1.8.9",
+    "@yext/search-ui-react": "^1.8.11",
     "mapbox-gl": "^2.9.2",
     "react": "^17.0.2 || ^18.2.0",
     "react-dom": "^17.0.2 || ^18.2.0"

--- a/packages/visual-editor/src/components/Locator.tsx
+++ b/packages/visual-editor/src/components/Locator.tsx
@@ -257,8 +257,9 @@ const LocatorInternal: React.FC<LocatorProps> = (props) => {
     setSearchState("loading");
   };
 
-  const [userLocation, setUserLocation] =
-    React.useState<[number, number]>(DEFAULT_MAP_CENTER);
+  const [userLocation, setUserLocation] = React.useState<
+    [number, number] | undefined
+  >(undefined);
   React.useEffect(() => {
     getUserLocation()
       .then((location) => {
@@ -378,8 +379,14 @@ const LocatorInternal: React.FC<LocatorProps> = (props) => {
             placeholder={TRANSLATIONS[locale].searchHere}
             ariaLabel={"Search Dropdown Input"}
             customCssClasses={{
-              focusedOption: "bg-gray-200",
-              inputElement: "rounded-md p-4",
+              focusedOption: "bg-gray-200 hover:bg-gray-200",
+              option: "hover:bg-gray-100 px-4 py-3",
+              inputElement: "rounded-md p-4 h-11",
+              currentLocationButton: "h-7 w-7 text-palette-primary-dark",
+            }}
+            showCurrentLocationButton={!!userLocation}
+            geolocationProps={{
+              radius: 25,
             }}
           />
         </div>
@@ -672,11 +679,11 @@ const getTranslatedResultCount = (
 ) => {
   switch (locale) {
     case "en":
-      return `${resultCount} locations near "${filterDisplayName}"`;
+      return `${resultCount} location${resultCount !== 1 ? "s" : ""} near "${filterDisplayName}"`;
     case "fr":
-      return `${resultCount} emplacements près de «${filterDisplayName}»`;
+      return `${resultCount} emplacement${resultCount !== 1 ? "s" : ""} près de «${filterDisplayName}»`;
     case "es":
-      return `${resultCount} ubicaciones cerca de "${filterDisplayName}"`;
+      return `${resultCount} ubicacion${resultCount !== 1 ? "es" : ""} cerca de "${filterDisplayName}"`;
     case "de":
       return `${resultCount} Standorte in der Nähe von "${filterDisplayName}"`;
     case "it":

--- a/packages/visual-editor/tailwind.config.ts
+++ b/packages/visual-editor/tailwind.config.ts
@@ -1,9 +1,11 @@
 import type { Config } from "tailwindcss";
+import { ComponentsContentPath } from "@yext/search-ui-react";
 
 export default {
   content: [
     "./src/**/*.{html,js,jsx,ts,tsx}",
     "!./src/components/puck/registry/**", // exclude the registry
+    ComponentsContentPath,
   ],
   prefix: "ve-",
   theme: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,8 +143,8 @@ importers:
         specifier: ^2.5.0
         version: 2.5.1(encoding@0.1.13)(react@18.3.1)
       "@yext/search-ui-react":
-        specifier: ^1.8.9
-        version: 1.8.9(@types/react@18.3.12)(@yext/search-headless-react@2.5.1(encoding@0.1.13)(react@18.3.1))(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.14(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)))
+        specifier: ^1.8.11
+        version: 1.8.11(@types/react@18.3.12)(@yext/search-headless-react@2.5.1(encoding@0.1.13)(react@18.3.1))(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.14(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)))
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
@@ -4658,6 +4658,16 @@ packages:
       {
         integrity: sha512-PFNKLHTRJNZqq6QhyTTsv7RcO9mQFtd5AMMRsiT/OFhB3YLKhAftZ0g47uRGclG9TMfx2fW5LiKfcdUdWNeRkg==,
       }
+
+  "@yext/search-ui-react@1.8.11":
+    resolution:
+      {
+        integrity: sha512-hC4T937mXiw1cmlaF3eAdsa0XrCC7+eu+2rXdHfBlNemEllOnqx5VYLQ9INKx9wZd8uk0n/eb5ct4FNej3VN8A==,
+      }
+    peerDependencies:
+      "@yext/search-headless-react": ^2.5.0
+      react: ^16.14 || ^17 || ^18
+      react-dom: ^16.14 || ^17 || ^18
 
   "@yext/search-ui-react@1.8.9":
     resolution:
@@ -15501,6 +15511,35 @@ snapshots:
       - react
       - react-redux
 
+  "@yext/search-ui-react@1.8.11(@types/react@18.3.12)(@yext/search-headless-react@2.5.1(encoding@0.1.13)(react@18.3.1))(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.14(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)))":
+    dependencies:
+      "@restart/ui": 1.9.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@tailwindcss/forms": 0.5.10(tailwindcss@3.4.14(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)))
+      "@tailwindcss/line-clamp": 0.4.4(tailwindcss@3.4.14(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)))
+      "@tailwindcss/typography": 0.5.15(tailwindcss@3.4.14(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)))
+      "@yext/analytics": 0.6.8(encoding@0.1.13)
+      "@yext/search-headless-react": 2.5.1(encoding@0.1.13)(react@18.3.1)
+      classnames: 2.5.1
+      lodash: 4.17.21
+      lodash-es: 4.17.21
+      mapbox-gl: 2.15.0
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-collapsed: 4.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      react-markdown: 6.0.3(@types/react@18.3.12)(react@18.3.1)
+      recent-searches: 1.0.5
+      rehype-raw: 5.1.0
+      rehype-sanitize: 4.0.0
+      remark-gfm: 1.0.0
+      tailwind-merge: 1.14.0
+      use-isomorphic-layout-effect: 1.2.0(@types/react@18.3.12)(react@18.3.1)
+    transitivePeerDependencies:
+      - "@types/react"
+      - encoding
+      - supports-color
+      - tailwindcss
+
   "@yext/search-ui-react@1.8.9(@types/react@18.3.12)(@yext/search-headless-react@2.5.1(encoding@0.1.13)(react@18.3.1))(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.14(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)))":
     dependencies:
       "@restart/ui": 1.9.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -19711,7 +19750,7 @@ snapshots:
   socks-proxy-agent@8.0.4:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7
+      debug: 4.4.0
       socks: 2.8.3
     transitivePeerDependencies:
       - supports-color
@@ -20171,7 +20210,7 @@ snapshots:
   tuf-js@3.0.1:
     dependencies:
       "@tufjs/models": 3.0.1
-      debug: 4.3.7
+      debug: 4.4.0
       make-fetch-happen: 14.0.3
     transitivePeerDependencies:
       - supports-color

--- a/starter/tailwind.config.ts
+++ b/starter/tailwind.config.ts
@@ -4,11 +4,13 @@ import {
   defaultThemeTailwindExtensions,
   defaultThemeConfig,
 } from "@yext/visual-editor";
+import { ComponentsContentPath } from "@yext/search-ui-react";
 
 export default {
   content: [
     "./src/**/*.{html,js,jsx,ts,tsx}",
     "./node_modules/@yext/visual-editor/dist/**/*.js",
+    ComponentsContentPath,
   ],
   theme: {
     extend: themeResolver(defaultThemeTailwindExtensions, defaultThemeConfig),


### PR DESCRIPTION
There is now a button next to the `FilterSearch` bar that, when clicked, will perform a location search near the user's location. This button will only appear if the user's location can be determined (i.e. they allow the site to access their location). Otherwise, the button will not show.

Also in this change, I added imports for `search-ui-react`'s Tailwind.
Also fixed some minor translation issues.

J=[WAT-4870](https://yexttest.atlassian.net/browse/WAT-4870?atlOrigin=eyJpIjoiYjc3NmExODg3NGY4NDEyOGI5N2YyZDI3ZWQ0OTI3MWIiLCJwIjoiaiJ9)
TEST=manual

![image](https://github.com/user-attachments/assets/f95ab852-986a-412d-af22-ebeab31812f3)
