### PR TITLE
feat: edit constant value rtf fields in drawer

### DIFF
--- a/packages/visual-editor/src/editor/index.css
+++ b/packages/visual-editor/src/editor/index.css
@@ -62,3 +62,22 @@
 .ObjectField + .ObjectField {
   margin-top: 12px;
 }
+
+.RTFTextAreaField {
+  border: 1px solid var(--puck-color-grey-09);
+  border-radius: 4px;
+  font-size: 14px;
+  padding: 12px 15px;
+  width: 100%;
+  height: calc(3lh + 24px);
+  text-align: left;
+  display: inline-flex;
+}
+
+.RTFTextAreaField:focus {
+  outline: 2px solid var(--puck-color-azure-05);
+}
+
+.RTFTextAreaField:hover {
+  border-color: var(--puck-color-grey-05);
+}

--- a/packages/visual-editor/src/internal/puck/constant-value-fields/EventSection.tsx
+++ b/packages/visual-editor/src/internal/puck/constant-value-fields/EventSection.tsx
@@ -52,15 +52,12 @@ const EventStructArrayField = (): ArrayField<EventStruct[]> => {
   }, []);
 
   const descriptionField = useMemo(() => {
-    return TranslatableRichTextField<TranslatableRichText | undefined>(
-      {
-        key: "description",
-        options: {
-          defaultValue: "Description",
-        },
+    return TranslatableRichTextField<TranslatableRichText | undefined>({
+      key: "description",
+      options: {
+        defaultValue: "Description",
       },
-      "textarea"
-    );
+    });
   }, []);
 
   return {

--- a/packages/visual-editor/src/internal/puck/constant-value-fields/FAQsSection.tsx
+++ b/packages/visual-editor/src/internal/puck/constant-value-fields/FAQsSection.tsx
@@ -45,15 +45,12 @@ const FAQStructArrayField = (): ArrayField<FAQStruct[]> => {
   }, []);
 
   const answerField = useMemo(() => {
-    return TranslatableRichTextField(
-      {
-        key: "answer",
-        options: {
-          defaultValue: "Answer",
-        },
+    return TranslatableRichTextField({
+      key: "answer",
+      options: {
+        defaultValue: "Answer",
       },
-      "textarea"
-    );
+    });
   }, []);
 
   return {

--- a/packages/visual-editor/src/internal/puck/constant-value-fields/InsightSection.tsx
+++ b/packages/visual-editor/src/internal/puck/constant-value-fields/InsightSection.tsx
@@ -41,7 +41,7 @@ const InsightStructArrayField = (): ArrayField<InsightStruct[]> => {
   const { t, i18n } = usePlatformTranslation();
 
   const nameField = useMemo(() => {
-    return TranslatableRichTextField<TranslatableString | undefined>(
+    return TranslatableStringField<TranslatableString | undefined>(
       {
         key: "name",
         options: {
@@ -65,15 +65,12 @@ const InsightStructArrayField = (): ArrayField<InsightStruct[]> => {
   }, []);
 
   const descriptionField = useMemo(() => {
-    return TranslatableRichTextField<TranslatableRichText | undefined>(
-      {
-        key: "description",
-        options: {
-          defaultValue: "Description",
-        },
+    return TranslatableRichTextField<TranslatableRichText | undefined>({
+      key: "description",
+      options: {
+        defaultValue: "Description",
       },
-      "textarea"
-    );
+    });
   }, []);
 
   return {

--- a/packages/visual-editor/src/internal/puck/constant-value-fields/ProductSection.tsx
+++ b/packages/visual-editor/src/internal/puck/constant-value-fields/ProductSection.tsx
@@ -64,15 +64,12 @@ const ProductStructArrayField = (): ArrayField<ProductStruct[]> => {
   }, []);
 
   const descriptionField = useMemo(() => {
-    return TranslatableRichTextField<TranslatableRichText | undefined>(
-      {
-        key: "description",
-        options: {
-          defaultValue: "Description",
-        },
+    return TranslatableRichTextField<TranslatableRichText | undefined>({
+      key: "description",
+      options: {
+        defaultValue: "Description",
       },
-      "textarea"
-    );
+    });
   }, []);
 
   return {

--- a/packages/visual-editor/src/internal/puck/constant-value-fields/TestimonialSection.tsx
+++ b/packages/visual-editor/src/internal/puck/constant-value-fields/TestimonialSection.tsx
@@ -55,15 +55,12 @@ const TestimonialStructArrayField = (): ArrayField<TestimonialStruct[]> => {
   }, []);
 
   const descriptionField = useMemo(() => {
-    return TranslatableRichTextField<TranslatableRichText | undefined>(
-      {
-        key: "description",
-        options: {
-          defaultValue: "Description",
-        },
+    return TranslatableRichTextField<TranslatableRichText | undefined>({
+      key: "description",
+      options: {
+        defaultValue: "Description",
       },
-      "text"
-    );
+    });
   }, []);
 
   return {

--- a/packages/visual-editor/src/internal/puck/constant-value-fields/Text.tsx
+++ b/packages/visual-editor/src/internal/puck/constant-value-fields/Text.tsx
@@ -15,4 +15,4 @@ export const TRANSLATABLE_STRING_CONSTANT_CONFIG: CustomField<TranslatableString
   TranslatableStringField(undefined, "text");
 
 export const TRANSLATABLE_RICH_TEXT_CONSTANT_CONFIG: CustomField<TranslatableRichText> =
-  TranslatableRichTextField(undefined, "text");
+  TranslatableRichTextField();


### PR DESCRIPTION
Pops a drawer in Storm that will be used to edit RTF. For now, these fields just use a simple string.

Although RTF could have been done without storm, the mocks show the drawer taking the full screen height which can't be done in the iframe, we get access to Mana, and we're going to need to do this for image assets anyway.

To Do (probably in separate PRs): 
- Build RTF editor in storm
- Handle storing/passing/rendering RTF
- Handle or potentially remove non translatable RTF?



https://github.com/user-attachments/assets/2bd5cfa1-aca9-49a6-af44-5c96b8676f1d

