### PR TITLE
feat: display locator distance in km for all locales except 'en'

### DIFF
--- a/packages/visual-editor/locales/cs/visual-editor.json
+++ b/packages/visual-editor/locales/cs/visual-editor.json
@@ -21,6 +21,7 @@
   "date": "Datum",
   "datetime": "Datum/čas",
   "description": "Popis",
+  "distanceInUnit": "{{distanceInKilometers}} km",
   "email": "E-mail",
   "emailList": "Seznam e -mailů",
   "events": "Události",

--- a/packages/visual-editor/locales/da/visual-editor.json
+++ b/packages/visual-editor/locales/da/visual-editor.json
@@ -21,6 +21,7 @@
   "date": "Dato",
   "datetime": "Dato/tid",
   "description": "Beskrivelse",
+  "distanceInUnit": "{{distanceInKilometers}} km",
   "email": "E -mail",
   "emailList": "E -mail -liste",
   "events": "Begivenheder",

--- a/packages/visual-editor/locales/de/visual-editor.json
+++ b/packages/visual-editor/locales/de/visual-editor.json
@@ -21,6 +21,7 @@
   "date": "Datum",
   "datetime": "Datum/Uhrzeit",
   "description": "Beschreibung",
+  "distanceInUnit": "{{distanceInKilometers}} km",
   "email": "E-Mail",
   "emailList": "E -Mail -Liste",
   "events": "Ereignisse",

--- a/packages/visual-editor/locales/en-GB/visual-editor.json
+++ b/packages/visual-editor/locales/en-GB/visual-editor.json
@@ -21,6 +21,7 @@
   "date": "Date",
   "datetime": "Date/Time",
   "description": "Description",
+  "distanceInUnit": "{{distanceInKilometers}} km",
   "email": "Email",
   "emailList": "Email List",
   "events": "Events",

--- a/packages/visual-editor/locales/en/visual-editor.json
+++ b/packages/visual-editor/locales/en/visual-editor.json
@@ -21,6 +21,7 @@
   "date": "Date",
   "datetime": "Date/Time",
   "description": "Description",
+  "distanceInUnit": "{{distanceInMiles}} mi",
   "email": "Email",
   "emailList": "Email List",
   "events": "Events",

--- a/packages/visual-editor/locales/es/visual-editor.json
+++ b/packages/visual-editor/locales/es/visual-editor.json
@@ -21,6 +21,7 @@
   "date": "Fecha",
   "datetime": "Fecha/hora",
   "description": "Descripción",
+  "distanceInUnit": "{{distanceInKilometers}} km",
   "email": "Correo electrónico",
   "emailList": "Lista de correo electrónico",
   "events": "Eventos",

--- a/packages/visual-editor/locales/et/visual-editor.json
+++ b/packages/visual-editor/locales/et/visual-editor.json
@@ -21,6 +21,7 @@
   "date": "Kuupäev",
   "datetime": "Kuupäev/kellaaeg",
   "description": "Kirjeldus",
+  "distanceInUnit": "{{distanceInKilometers}} km",
   "email": "E -kiri",
   "emailList": "E -posti nimekiri",
   "events": "Sündmused",

--- a/packages/visual-editor/locales/fi/visual-editor.json
+++ b/packages/visual-editor/locales/fi/visual-editor.json
@@ -21,6 +21,7 @@
   "date": "Päivämäärä",
   "datetime": "Päivämäärä/aika",
   "description": "Kuvaus",
+  "distanceInUnit": "{{distanceInKilometers}} km",
   "email": "Sähköposti",
   "emailList": "Sähköpostiluettelo",
   "events": "Tapahtumat",

--- a/packages/visual-editor/locales/fr/visual-editor.json
+++ b/packages/visual-editor/locales/fr/visual-editor.json
@@ -21,6 +21,7 @@
   "date": "Date",
   "datetime": "Date / heure",
   "description": "Description",
+  "distanceInUnit": "{{distanceInKilometers}} km",
   "email": "E-mail",
   "emailList": "Liste de diffusion",
   "events": "Événements",

--- a/packages/visual-editor/locales/hr/visual-editor.json
+++ b/packages/visual-editor/locales/hr/visual-editor.json
@@ -21,6 +21,7 @@
   "date": "Datum",
   "datetime": "Datum/vrijeme",
   "description": "Opis",
+  "distanceInUnit": "{{distanceInKilometers}} km",
   "email": "E -pošta",
   "emailList": "Popis e -pošte",
   "events": "Događaj",

--- a/packages/visual-editor/locales/hu/visual-editor.json
+++ b/packages/visual-editor/locales/hu/visual-editor.json
@@ -21,6 +21,7 @@
   "date": "Dátum",
   "datetime": "Dátum/idő",
   "description": "Leírás",
+  "distanceInUnit": "{{distanceInKilometers}} km",
   "email": "Email",
   "emailList": "E -mail lista",
   "events": "Események",

--- a/packages/visual-editor/locales/it/visual-editor.json
+++ b/packages/visual-editor/locales/it/visual-editor.json
@@ -21,6 +21,7 @@
   "date": "Data",
   "datetime": "Data/ora",
   "description": "Descrizione",
+  "distanceInUnit": "{{distanceInKilometers}} km",
   "email": "E-mail",
   "emailList": "Elenco e -mail",
   "events": "Eventi",

--- a/packages/visual-editor/locales/ja/visual-editor.json
+++ b/packages/visual-editor/locales/ja/visual-editor.json
@@ -21,6 +21,7 @@
   "date": "日付",
   "datetime": "日付/時刻",
   "description": "説明",
+  "distanceInUnit": "{{distanceInKilometers}} km",
   "email": "メール",
   "emailList": "メーリングリスト",
   "events": "イベント",

--- a/packages/visual-editor/locales/lt/visual-editor.json
+++ b/packages/visual-editor/locales/lt/visual-editor.json
@@ -21,6 +21,7 @@
   "date": "Data",
   "datetime": "Data/laikas",
   "description": "Aprašymas",
+  "distanceInUnit": "{{distanceInKilometers}} km",
   "email": "El. Paštas",
   "emailList": "El. Pašto sąrašas",
   "events": "Įvykiai",

--- a/packages/visual-editor/locales/lv/visual-editor.json
+++ b/packages/visual-editor/locales/lv/visual-editor.json
@@ -21,6 +21,7 @@
   "date": "Datums",
   "datetime": "Datums/laiks",
   "description": "Apraksts",
+  "distanceInUnit": "{{distanceInKilometers}} km",
   "email": "E -pasts",
   "emailList": "E -pasta saraksts",
   "events": "Notikumi",

--- a/packages/visual-editor/locales/nb/visual-editor.json
+++ b/packages/visual-editor/locales/nb/visual-editor.json
@@ -21,6 +21,7 @@
   "date": "Dato",
   "datetime": "Dato/tid",
   "description": "Beskrivelse",
+  "distanceInUnit": "{{distanceInKilometers}} km",
   "email": "E -post",
   "emailList": "E -postliste",
   "events": "Hendelser",

--- a/packages/visual-editor/locales/nl/visual-editor.json
+++ b/packages/visual-editor/locales/nl/visual-editor.json
@@ -21,6 +21,7 @@
   "date": "Datum",
   "datetime": "Datum/tijd",
   "description": "Beschrijving",
+  "distanceInUnit": "{{distanceInKilometers}} km",
   "email": "E -mail",
   "emailList": "E -maillijst",
   "events": "Evenementen",

--- a/packages/visual-editor/locales/pl/visual-editor.json
+++ b/packages/visual-editor/locales/pl/visual-editor.json
@@ -21,6 +21,7 @@
   "date": "Data",
   "datetime": "Data/godzina",
   "description": "Opis",
+  "distanceInUnit": "{{distanceInKilometers}} km",
   "email": "E-mail",
   "emailList": "Lista e -mail",
   "events": "Wydarzenia",

--- a/packages/visual-editor/locales/pt/visual-editor.json
+++ b/packages/visual-editor/locales/pt/visual-editor.json
@@ -21,6 +21,7 @@
   "date": "Data",
   "datetime": "Data/hora",
   "description": "Descrição",
+  "distanceInUnit": "{{distanceInKilometers}} km",
   "email": "E-mail",
   "emailList": "Lista de e -mails",
   "events": "Eventos",

--- a/packages/visual-editor/locales/ro/visual-editor.json
+++ b/packages/visual-editor/locales/ro/visual-editor.json
@@ -21,6 +21,7 @@
   "date": "Data",
   "datetime": "Data/ora",
   "description": "Descriere",
+  "distanceInUnit": "{{distanceInKilometers}} km",
   "email": "E-mail",
   "emailList": "Lista de e -mailuri",
   "events": "Evenimente",

--- a/packages/visual-editor/locales/sk/visual-editor.json
+++ b/packages/visual-editor/locales/sk/visual-editor.json
@@ -21,6 +21,7 @@
   "date": "Dátum",
   "datetime": "Dátum/čas",
   "description": "Opis",
+  "distanceInUnit": "{{distanceInKilometers}} km",
   "email": "E -mail",
   "emailList": "Zoznam e -mailov",
   "events": "Udalosti",

--- a/packages/visual-editor/locales/sv/visual-editor.json
+++ b/packages/visual-editor/locales/sv/visual-editor.json
@@ -21,6 +21,7 @@
   "date": "Datum",
   "datetime": "Datum/tid",
   "description": "Beskrivning",
+  "distanceInUnit": "{{distanceInKilometers}} km",
   "email": "E-post",
   "emailList": "E -postlista",
   "events": "Evenemang",

--- a/packages/visual-editor/locales/tr/visual-editor.json
+++ b/packages/visual-editor/locales/tr/visual-editor.json
@@ -21,6 +21,7 @@
   "date": "Tarih",
   "datetime": "Tarih/saat",
   "description": "Tanım",
+  "distanceInUnit": "{{distanceInKilometers}} km",
   "email": "E -posta",
   "emailList": "E -posta Listesi",
   "events": "Olaylar",

--- a/packages/visual-editor/locales/zh-CN/visual-editor.json
+++ b/packages/visual-editor/locales/zh-CN/visual-editor.json
@@ -21,6 +21,7 @@
   "date": "日期",
   "datetime": "日期/时间",
   "description": "描述",
+  "distanceInUnit": "{{distanceInKilometers}} km",
   "email": "电子邮件",
   "emailList": "电子邮件列表",
   "events": "事件",

--- a/packages/visual-editor/locales/zh-TW/visual-editor.json
+++ b/packages/visual-editor/locales/zh-TW/visual-editor.json
@@ -21,6 +21,7 @@
   "date": "日期",
   "datetime": "日期/時間",
   "description": "描述",
+  "distanceInUnit": "{{distanceInKilometers}} km",
   "email": "電子郵件",
   "emailList": "電子郵件列表",
   "events": "事件",

--- a/packages/visual-editor/src/components/Locator.tsx
+++ b/packages/visual-editor/src/components/Locator.tsx
@@ -472,6 +472,10 @@ const LocationCard: CardComponent<Location> = ({
     ? (distance / 1609.344).toFixed(1)
     : undefined;
 
+  const distanceInKilometers = distance
+    ? (distance / 1000).toFixed(1)
+    : undefined;
+
   const handleGetDirectionsClick = useCardAnalyticsCallback(
     result,
     "DRIVING_DIRECTIONS"
@@ -499,9 +503,12 @@ const LocationCard: CardComponent<Location> = ({
             <Heading className="font-bold text-palette-primary-dark" level={4}>
               {location.name}
             </Heading>
-            {distanceInMiles && (
+            {distance && (
               <div className="font-body-fontFamily font-body-sm-fontWeight text-body-sm-fontSize">
-                {distanceInMiles + " mi"}
+                {t("distanceInUnit", `${distanceInMiles} mi`, {
+                  distanceInMiles,
+                  distanceInKilometers,
+                })}
               </div>
             )}
           </div>


### PR DESCRIPTION
tested in dev mode to verify distance is displayed in 'mi' for 'en' locale and 'km' for 'es' locale. Note that 'km' abbreviation is commonly understood accross languages and do not need to be translated.