### PR TITLE
fix: limit mapbox size

### DIFF
--- a/packages/visual-editor/src/components/contentBlocks/MapboxStaticMap.tsx
+++ b/packages/visual-editor/src/components/contentBlocks/MapboxStaticMap.tsx
@@ -33,7 +33,7 @@ const DEFAULT_WIDTH = 1024;
 const DEFAULT_HEIGHT = 300;
 const MIN_HEIGHT = 300;
 const MIN_WIDTH = 100;
-const MAX_SIZE = 2048;
+const MAX_SIZE = 1280;
 
 const getPrimaryColor = (document: any) => {
   if (document?.__?.theme) {


### PR DESCRIPTION
This limits the mapbox height and width to the size limits defined here: https://docs.mapbox.com/api/maps/static-images/#retrieve-a-static-map-from-a-style