### PR TITLE
fix: default language dropdown value in Editor

### DIFF
--- a/packages/visual-editor/src/components/header/languageDropdown.tsx
+++ b/packages/visual-editor/src/components/header/languageDropdown.tsx
@@ -48,6 +48,11 @@ export const LanguageDropdown: React.FC<LanguageDropdownProps> = ({
   >("UNSET");
   const [open, setOpen] = React.useState<boolean>(false);
 
+  // In Editor if locale changes, have selected change as well.
+  React.useEffect(() => {
+    setSelected(currentLocale);
+  }, [currentLocale]);
+
   // on dropdown clicked, compare the actual locales of the entity to the pageset's scoped locales
   const handleOpenChange = async (isOpen: boolean) => {
     setOpen(isOpen);


### PR DESCRIPTION
Now when you toggle locales in the editor (layout and theme), the language dropdown selected value changes as well. 