### PR TITLE
fix: update faq to work without js

### DIFF
--- a/packages/visual-editor/src/components/atoms/accordion.tsx
+++ b/packages/visual-editor/src/components/atoms/accordion.tsx
@@ -1,64 +1,53 @@
-import * as React from "react";
-import * as AccordionPrimitive from "@radix-ui/react-accordion";
-import { themeManagerCn, useBackground } from "@yext/visual-editor";
-import { FaChevronDown } from "react-icons/fa";
+import React from "react";
 
-const Accordion = AccordionPrimitive.Root;
+export const Accordion = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(function Accordion({ className = "", ...props }, ref) {
+  return <div ref={ref} className={`flex flex-col ${className}`} {...props} />;
+});
 
-const AccordionItem = React.forwardRef<
-  React.ElementRef<typeof AccordionPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
->(({ className, ...props }, ref) => (
-  <AccordionPrimitive.Item
-    ref={ref}
-    className={themeManagerCn("border-b", className)}
-    {...props}
-  />
-));
-AccordionItem.displayName = "AccordionItem";
-
-const AccordionTrigger = React.forwardRef<
-  React.ElementRef<typeof AccordionPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
->(({ className, children, ...props }, ref) => {
-  const background = useBackground();
-  const hasDarkBackground = background?.textColor === "text-white";
+export const AccordionItem = React.forwardRef<
+  HTMLDetailsElement,
+  React.DetailsHTMLAttributes<HTMLDetailsElement>
+>(function AccordionItem({ className = "", ...props }, ref) {
   return (
-    <AccordionPrimitive.Header className="flex">
-      <AccordionPrimitive.Trigger
-        ref={ref}
-        className={themeManagerCn(
-          "flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180",
-          className
-        )}
-        {...props}
-      >
-        {children}
-        <FaChevronDown
-          className={themeManagerCn(
-            "h-4 w-4 shrink-0 transition-transform duration-200",
-            hasDarkBackground ? "text-white" : "text-palette-primary-dark"
-          )}
-        />
-      </AccordionPrimitive.Trigger>
-    </AccordionPrimitive.Header>
+    <details
+      ref={ref}
+      className={`group border-b py-4 last:border-none ${className}`}
+      {...props}
+    />
   );
 });
-AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName;
 
-const AccordionContent = React.forwardRef<
-  React.ElementRef<typeof AccordionPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
->(({ className, children, ...props }, ref) => (
-  <AccordionPrimitive.Content
-    ref={ref}
-    className="overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
-    {...props}
-  >
-    <div className={themeManagerCn("pb-4 pt-0", className)}>{children}</div>
-  </AccordionPrimitive.Content>
-));
+export const AccordionTrigger = React.forwardRef<
+  HTMLElement,
+  React.HTMLAttributes<HTMLElement>
+>(function AccordionTrigger({ className = "", children, ...props }, ref) {
+  return (
+    <summary
+      ref={ref}
+      className={`flex cursor-pointer list-none items-center justify-between ${className}`}
+      {...props}
+    >
+      <span>{children}</span>
+      <svg
+        className="ml-4 h-5 w-5 flex-shrink-0 transition-transform duration-300 group-open:rotate-180"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+      </svg>
+    </summary>
+  );
+});
 
-AccordionContent.displayName = AccordionPrimitive.Content.displayName;
-
-export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };
+export const AccordionContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(function AccordionContent({ className = "", ...props }, ref) {
+  return <div ref={ref} className={`pt-4 ${className}`} {...props} />;
+});

--- a/packages/visual-editor/src/components/pageSections/FAQsSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/FAQsSection.tsx
@@ -145,9 +145,9 @@ const FAQsSectionComponent: React.FC<FAQSectionProps> = ({ data, styles }) => {
           fieldId={data?.faqs.field}
           constantValueEnabled={data?.faqs.constantValueEnabled}
         >
-          <Accordion type="single" collapsible>
+          <Accordion>
             {resolvedFAQs?.faqs?.map((faqItem: FAQStruct, index: number) => (
-              <AccordionItem value={index.toString()} key={index}>
+              <AccordionItem key={index}>
                 <AccordionTrigger>
                   <Body>
                     {resolveTranslatableString(faqItem.question, i18n.language)}


### PR DESCRIPTION
This rewrites the Accordion component so that it opens and closes properly without javascript enabled. The answers within the accordion exist in the HTML even when closed.

Tested by disabling JS in the dev mode preview and confirmed that the accordion still opens and closes as expected.

https://github.com/user-attachments/assets/b7d50557-9fa6-4a7d-ae19-01145b8cd33f