### PR TITLE
feat: add Open Now button to locator

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -26,4 +26,5 @@ jobs:
           scopes: |
             components
             deps
+            locator
             util

--- a/packages/visual-editor/THIRD-PARTY-NOTICES
+++ b/packages/visual-editor/THIRD-PARTY-NOTICES
@@ -899,6 +899,36 @@ SOFTWARE.
 
 The following npm package may be included in this product:
 
+ - pack@2.2.0
+
+This package contains the following license:
+
+MIT License
+
+Copyright (c) 2018 Brandon Semilla
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-----------
+
+The following npm package may be included in this product:
+
  - prompts@2.4.2
 
 This package contains the following license:
@@ -1059,6 +1089,7 @@ The following npm packages may be included in this product:
  - @radix-ui/react-radio-group@1.3.4
  - @radix-ui/react-separator@1.1.7
  - @radix-ui/react-switch@1.2.2
+ - @radix-ui/react-toggle@1.1.9
  - @radix-ui/react-tooltip@1.2.4
 
 These packages each contain the following license:

--- a/packages/visual-editor/THIRD-PARTY-NOTICES
+++ b/packages/visual-editor/THIRD-PARTY-NOTICES
@@ -899,36 +899,6 @@ SOFTWARE.
 
 The following npm package may be included in this product:
 
- - pack@2.2.0
-
-This package contains the following license:
-
-MIT License
-
-Copyright (c) 2018 Brandon Semilla
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
------------
-
-The following npm package may be included in this product:
-
  - prompts@2.4.2
 
 This package contains the following license:

--- a/packages/visual-editor/locales/cs/visual-editor.json
+++ b/packages/visual-editor/locales/cs/visual-editor.json
@@ -161,6 +161,7 @@
       "hour12": "12 hodin",
       "hour24": "24 hodin",
       "image": "Obraz",
+      "includeOpenNow": "Zahrňte tlačítko Open Now",
       "international": "Mezinárodní",
       "international_phone number": "Mezinárodní",
       "large": "Velký",

--- a/packages/visual-editor/locales/da/visual-editor.json
+++ b/packages/visual-editor/locales/da/visual-editor.json
@@ -161,6 +161,7 @@
       "hour12": "12-timers",
       "hour24": "24-timer",
       "image": "Billede",
+      "includeOpenNow": "Inkluder åbent nu -knap",
       "international": "International",
       "international_phone number": "International",
       "large": "Stor",

--- a/packages/visual-editor/locales/de/visual-editor.json
+++ b/packages/visual-editor/locales/de/visual-editor.json
@@ -161,6 +161,7 @@
       "hour12": "12 Stunden",
       "hour24": "24 Stunden",
       "image": "Bild",
+      "includeOpenNow": "Fügen Sie Now Open Taste ein",
       "international": "International",
       "international_phone number": "Internationale",
       "large": "Groß",

--- a/packages/visual-editor/locales/en-GB/visual-editor.json
+++ b/packages/visual-editor/locales/en-GB/visual-editor.json
@@ -161,6 +161,7 @@
       "hour12": "12-hour",
       "hour24": "24-hour",
       "image": "Image",
+      "includeOpenNow": "Include Open Now Button",
       "international": "International",
       "international_phone number": "International",
       "large": "Large",

--- a/packages/visual-editor/locales/en/visual-editor.json
+++ b/packages/visual-editor/locales/en/visual-editor.json
@@ -160,6 +160,7 @@
       "hour12": "12-hour",
       "hour24": "24-hour",
       "image": "Image",
+      "includeOpenNow": "Include Open Now Button",
       "international": "International",
       "international_phone number": "International",
       "large": "Large",

--- a/packages/visual-editor/locales/es/visual-editor.json
+++ b/packages/visual-editor/locales/es/visual-editor.json
@@ -161,6 +161,7 @@
       "hour12": "De 12 horas",
       "hour24": "Las 24 horas",
       "image": "Imagen",
+      "includeOpenNow": "Incluir el botón Abrir ahora",
       "international": "Internacional",
       "international_phone number": "Internacional",
       "large": "Grande",

--- a/packages/visual-editor/locales/et/visual-editor.json
+++ b/packages/visual-editor/locales/et/visual-editor.json
@@ -161,6 +161,7 @@
       "hour12": "12-tunnine",
       "hour24": "24-tunnine",
       "image": "Pilt",
+      "includeOpenNow": "Lisage avatud nupp",
       "international": "Rahvusvaheline",
       "international_phone number": "Rahvusvaheline",
       "large": "Suur",

--- a/packages/visual-editor/locales/fi/visual-editor.json
+++ b/packages/visual-editor/locales/fi/visual-editor.json
@@ -161,6 +161,7 @@
       "hour12": "12 tunnin",
       "hour24": "24 tunnin",
       "image": "Kuva",
+      "includeOpenNow": "Sisällytä nyt -painike",
       "international": "Kansainvälinen",
       "international_phone number": "Kansainvälinen",
       "large": "Suuri",

--- a/packages/visual-editor/locales/fr/visual-editor.json
+++ b/packages/visual-editor/locales/fr/visual-editor.json
@@ -161,6 +161,7 @@
       "hour12": "12 heures",
       "hour24": "24 heures",
       "image": "Image",
+      "includeOpenNow": "Inclure le bouton Open Now",
       "international": "International",
       "international_phone number": "International",
       "large": "Grand",

--- a/packages/visual-editor/locales/hr/visual-editor.json
+++ b/packages/visual-editor/locales/hr/visual-editor.json
@@ -161,6 +161,7 @@
       "hour12": "12 sati",
       "hour24": "24-satni",
       "image": "Slika",
+      "includeOpenNow": "Uključite gumb Otvori sada",
       "international": "Međunarodni",
       "international_phone number": "Međunarodni",
       "large": "Velik",

--- a/packages/visual-editor/locales/hu/visual-editor.json
+++ b/packages/visual-editor/locales/hu/visual-editor.json
@@ -161,6 +161,7 @@
       "hour12": "12 órás",
       "hour24": "24 órás",
       "image": "Kép",
+      "includeOpenNow": "Tartalmazza a NYUTATÁS gombot",
       "international": "Nemzetközi",
       "international_phone number": "Nemzetközi",
       "large": "Nagy",

--- a/packages/visual-editor/locales/it/visual-editor.json
+++ b/packages/visual-editor/locales/it/visual-editor.json
@@ -161,6 +161,7 @@
       "hour12": "12 ore",
       "hour24": "24 ore",
       "image": "Immagine",
+      "includeOpenNow": "Includi il pulsante Open Now",
       "international": "Internazionale",
       "international_phone number": "Internazionale",
       "large": "Grande",

--- a/packages/visual-editor/locales/ja/visual-editor.json
+++ b/packages/visual-editor/locales/ja/visual-editor.json
@@ -161,6 +161,7 @@
       "hour12": "12時間",
       "hour24": "24時間",
       "image": "画像",
+      "includeOpenNow": "今すぐ開くボタンを含めます",
       "international": "国際的",
       "international_phone number": "国際",
       "large": "大きい",

--- a/packages/visual-editor/locales/lt/visual-editor.json
+++ b/packages/visual-editor/locales/lt/visual-editor.json
@@ -161,6 +161,7 @@
       "hour12": "12 valandų",
       "hour24": "24 valandas",
       "image": "Vaizdas",
+      "includeOpenNow": "Įtraukite mygtuką Atidaryti dabar",
       "international": "Tarptautinis",
       "international_phone number": "Tarptautinis",
       "large": "Didelis",

--- a/packages/visual-editor/locales/lv/visual-editor.json
+++ b/packages/visual-editor/locales/lv/visual-editor.json
@@ -161,6 +161,7 @@
       "hour12": "12 stundu",
       "hour24": "Diennakts",
       "image": "Attēls",
+      "includeOpenNow": "Iekļaujiet pogu Atvērt tūlīt",
       "international": "Starptautisks",
       "international_phone number": "Starptautiskais",
       "large": "Liels",

--- a/packages/visual-editor/locales/nb/visual-editor.json
+++ b/packages/visual-editor/locales/nb/visual-editor.json
@@ -161,6 +161,7 @@
       "hour12": "12-timers",
       "hour24": "24-timers",
       "image": "Bilde",
+      "includeOpenNow": "Inkluder åpen nå -knapp",
       "international": "Internasjonal",
       "international_phone number": "Internasjonalt",
       "large": "Stor",

--- a/packages/visual-editor/locales/nl/visual-editor.json
+++ b/packages/visual-editor/locales/nl/visual-editor.json
@@ -161,6 +161,7 @@
       "hour12": "12 uur",
       "hour24": "24 uur",
       "image": "Afbeelding",
+      "includeOpenNow": "Neem de knop Open nu open",
       "international": "Internationale",
       "international_phone number": "Internationaal",
       "large": "Groot",

--- a/packages/visual-editor/locales/pl/visual-editor.json
+++ b/packages/visual-editor/locales/pl/visual-editor.json
@@ -161,6 +161,7 @@
       "hour12": "12-godzinny",
       "hour24": "24 godziny",
       "image": "Obraz",
+      "includeOpenNow": "Dołącz przycisk Otwórz teraz",
       "international": "Międzynarodowy",
       "international_phone number": "Międzynarodowy",
       "large": "Duży",

--- a/packages/visual-editor/locales/pt/visual-editor.json
+++ b/packages/visual-editor/locales/pt/visual-editor.json
@@ -161,6 +161,7 @@
       "hour12": "12 horas",
       "hour24": "24 horas",
       "image": "Imagem",
+      "includeOpenNow": "Inclua o botão aberto agora",
       "international": "Internacional",
       "international_phone number": "Internacional",
       "large": "Grande",

--- a/packages/visual-editor/locales/ro/visual-editor.json
+++ b/packages/visual-editor/locales/ro/visual-editor.json
@@ -161,6 +161,7 @@
       "hour12": "12 ore",
       "hour24": "24 de ore",
       "image": "Imagine",
+      "includeOpenNow": "Includeți butonul Deschideți acum",
       "international": "Internaţional",
       "international_phone number": "Internaţional",
       "large": "Mare",

--- a/packages/visual-editor/locales/sk/visual-editor.json
+++ b/packages/visual-editor/locales/sk/visual-editor.json
@@ -161,6 +161,7 @@
       "hour12": "12-hodinový",
       "hour24": "24-hodinový",
       "image": "Obraz",
+      "includeOpenNow": "Zahrňte tlačidlo Otvorené teraz",
       "international": "Medzinárodný",
       "international_phone number": "Medzinárodné",
       "large": "Veľký",

--- a/packages/visual-editor/locales/sv/visual-editor.json
+++ b/packages/visual-editor/locales/sv/visual-editor.json
@@ -161,6 +161,7 @@
       "hour12": "12-timmars",
       "hour24": "24-timmars",
       "image": "Bild",
+      "includeOpenNow": "Inkludera öppen nu -knapp",
       "international": "Internationell",
       "international_phone number": "Internationellt",
       "large": "Stor",

--- a/packages/visual-editor/locales/tr/visual-editor.json
+++ b/packages/visual-editor/locales/tr/visual-editor.json
@@ -161,6 +161,7 @@
       "hour12": "12 saat",
       "hour24": "24 saat",
       "image": "İmaj",
+      "includeOpenNow": "Now Düğmesini Ekle",
       "international": "Uluslararası",
       "international_phone number": "Uluslararası",
       "large": "Büyük",

--- a/packages/visual-editor/locales/zh-CN/visual-editor.json
+++ b/packages/visual-editor/locales/zh-CN/visual-editor.json
@@ -161,6 +161,7 @@
       "hour12": "12小时",
       "hour24": "24小时",
       "image": "图像",
+      "includeOpenNow": "包括“立即打开”按钮",
       "international": "国际的",
       "international_phone number": "国际",
       "large": "大的",

--- a/packages/visual-editor/locales/zh-TW/visual-editor.json
+++ b/packages/visual-editor/locales/zh-TW/visual-editor.json
@@ -161,6 +161,7 @@
       "hour12": "12小時",
       "hour24": "24小時",
       "image": "圖像",
+      "includeOpenNow": "包括“立即打開”按鈕",
       "international": "國際的",
       "international_phone number": "國際",
       "large": "大的",

--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -77,7 +77,6 @@
     "lucide-react": "^0.414.0",
     "lz-string": "1.5.0",
     "next-themes": "^0.3.0",
-    "pack": "^2.2.0",
     "picocolors": "^1.0.1",
     "prompts": "^2.4.2",
     "pure-react-carousel": "^1.32.0",

--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -66,6 +66,7 @@
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-switch": "^1.1.0",
+    "@radix-ui/react-toggle": "^1.1.9",
     "@radix-ui/react-tooltip": "^1.1.2",
     "@tanstack/react-query": "^5.71.5",
     "class-variance-authority": "^0.7.0",
@@ -76,6 +77,7 @@
     "lucide-react": "^0.414.0",
     "lz-string": "1.5.0",
     "next-themes": "^0.3.0",
+    "pack": "^2.2.0",
     "picocolors": "^1.0.1",
     "prompts": "^2.4.2",
     "pure-react-carousel": "^1.32.0",
@@ -141,8 +143,8 @@
   },
   "peerDependencies": {
     "@yext/pages-components": "^1.1.4",
-    "@yext/search-headless-react": "^2.5.2",
-    "@yext/search-ui-react": "^1.8.13",
+    "@yext/search-headless-react": "^2.5.3",
+    "@yext/search-ui-react": "^1.8.15",
     "mapbox-gl": "^2.9.2",
     "react": "^17.0.2 || ^18.2.0",
     "react-dom": "^17.0.2 || ^18.2.0"

--- a/packages/visual-editor/src/components/DefaultThemeConfig.ts
+++ b/packages/visual-editor/src/components/DefaultThemeConfig.ts
@@ -356,8 +356,8 @@ export const defaultThemeConfig: ThemeConfig = {
         type: "select",
         plugin: "display",
         options: [
-          { label: msg("yes", "Yes"), value: "block" },
-          { label: msg("no", "No"), value: "none" },
+          { label: msg("fields.options.yes", "Yes"), value: "block" },
+          { label: msg("fields.options.no", "No"), value: "none" },
         ],
         default: "block",
       },

--- a/packages/visual-editor/src/components/Locator.tsx
+++ b/packages/visual-editor/src/components/Locator.tsx
@@ -50,6 +50,7 @@ import {
 import { MapPinIcon } from "./MapPinIcon.js";
 import { FaAngleRight } from "react-icons/fa";
 import { formatPhoneNumber } from "./atoms/phone.js";
+import { YextField } from "../editor";
 
 const DEFAULT_FIELD = "builtin.location";
 const DEFAULT_ENTITY_TYPE = "location";
@@ -59,6 +60,7 @@ const HOURS_FIELD = "builtin.hours";
 
 export type LocatorProps = {
   mapStyle?: string;
+  openNowButton?: boolean;
   entityTypeEnvVar?: string; // to be set via withPropOverrides
   experienceKeyEnvVar?: string; // to be set via withPropOverrides
 };
@@ -91,6 +93,13 @@ const locatorFields: Fields<LocatorProps> = {
         label: msg("fields.options.navigationNight", "Navigation (Night)"),
         value: "mapbox://styles/mapbox/navigation-night-v1",
       },
+    ],
+  }),
+  openNowButton: YextField("Include Open Now Button", {
+    type: "radio",
+    options: [
+      { label: "Yes", value: true },
+      { label: "No", value: false },
     ],
   }),
 };
@@ -139,7 +148,7 @@ type SearchState = "not started" | "loading" | "complete";
 
 const LocatorInternal: React.FC<LocatorProps> = (props) => {
   const { t } = useTranslation();
-  const { mapStyle, entityTypeEnvVar } = props;
+  const { mapStyle, openNowButton, entityTypeEnvVar } = props;
   const entityType = getEntityType(entityTypeEnvVar);
   const resultCount = useSearchState(
     (state) => state.vertical.resultsCount || 0
@@ -368,13 +377,15 @@ const LocatorInternal: React.FC<LocatorProps> = (props) => {
               radius: 25,
             }}
           />
-          <Toggle
-            pressed={isSelected}
-            onPressedChange={(pressed) => handleOpenNowClick(pressed)}
-            className="py-2 px-2"
-          >
-            {t("openNow", "Open Now")}
-          </Toggle>
+          {openNowButton && (
+            <Toggle
+              pressed={isSelected}
+              onPressedChange={(pressed) => handleOpenNowClick(pressed)}
+              className="py-2 px-2"
+            >
+              {t("openNow", "Open Now")}
+            </Toggle>
+          )}
         </div>
         <div className="px-8 py-4 text-body-fontSize border-y border-gray-300">
           {resultCount === 0 &&

--- a/packages/visual-editor/src/components/Locator.tsx
+++ b/packages/visual-editor/src/components/Locator.tsx
@@ -99,8 +99,8 @@ const locatorFields: Fields<LocatorProps> = {
     {
       type: "radio",
       options: [
-        { label: msg("yes", "Yes"), value: true },
-        { label: msg("no", "No"), value: false },
+        { label: msg("fields.options.yes", "Yes"), value: true },
+        { label: msg("fields.options.no", "No"), value: false },
       ],
     }
   ),

--- a/packages/visual-editor/src/components/Locator.tsx
+++ b/packages/visual-editor/src/components/Locator.tsx
@@ -330,7 +330,7 @@ const LocatorInternal: React.FC<LocatorProps> = (props) => {
         value: "now",
       },
       selected,
-      displayName: "Open Now",
+      displayName: t("openNow", "Open Now"),
     });
     setIsSelected(isSelected);
     searchActions.setOffset(0);

--- a/packages/visual-editor/src/components/Locator.tsx
+++ b/packages/visual-editor/src/components/Locator.tsx
@@ -21,7 +21,6 @@ import {
   Result,
   SearchHeadlessProvider,
   SelectableStaticFilter,
-  StaticFilter,
   useSearchActions,
   useSearchState,
 } from "@yext/search-headless-react";
@@ -39,6 +38,7 @@ import {
   useDocument,
   useTemplateProps,
   Toggle,
+  YextField,
 } from "@yext/visual-editor";
 import mapboxgl, { LngLat, LngLatBounds, MarkerOptions } from "mapbox-gl";
 import {
@@ -50,7 +50,6 @@ import {
 import { MapPinIcon } from "./MapPinIcon.js";
 import { FaAngleRight } from "react-icons/fa";
 import { formatPhoneNumber } from "./atoms/phone.js";
-import { YextField } from "../editor";
 
 const DEFAULT_FIELD = "builtin.location";
 const DEFAULT_ENTITY_TYPE = "location";
@@ -95,13 +94,16 @@ const locatorFields: Fields<LocatorProps> = {
       },
     ],
   }),
-  openNowButton: YextField("Include Open Now Button", {
-    type: "radio",
-    options: [
-      { label: "Yes", value: true },
-      { label: "No", value: false },
-    ],
-  }),
+  openNowButton: YextField(
+    msg("fields.options.includeOpenNow", "Include Open Now Button"),
+    {
+      type: "radio",
+      options: [
+        { label: msg("yes", "Yes"), value: true },
+        { label: msg("no", "No"), value: false },
+      ],
+    }
+  ),
 };
 
 export const LocatorComponent: ComponentConfig<LocatorProps> = {

--- a/packages/visual-editor/src/components/atoms/index.ts
+++ b/packages/visual-editor/src/components/atoms/index.ts
@@ -16,3 +16,4 @@ export {
   type TimestampProps,
   TimestampOption,
 } from "./timestamp.tsx";
+export { Toggle } from "./toggle.tsx";

--- a/packages/visual-editor/src/components/atoms/toggle.tsx
+++ b/packages/visual-editor/src/components/atoms/toggle.tsx
@@ -9,6 +9,10 @@ function Toggle({
   return (
     <TogglePrimitive.Root
       data-slot="toggle"
+      style={{
+        // @ts-expect-error ts(2322) the css variable here resolves to a valid enum value
+        textTransform: "var(--textTransform-button-textTransform)",
+      }}
       className={themeManagerCn(
         "items-center justify-center gap-2 rounded-full text-black " +
           "data-[state=on]:bg-palette-secondary data-[state=on]:border-palette-secondary " +

--- a/packages/visual-editor/src/components/atoms/toggle.tsx
+++ b/packages/visual-editor/src/components/atoms/toggle.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import * as React from "react";
 import * as TogglePrimitive from "@radix-ui/react-toggle";
 import { themeManagerCn } from "@yext/visual-editor";

--- a/packages/visual-editor/src/components/atoms/toggle.tsx
+++ b/packages/visual-editor/src/components/atoms/toggle.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import * as React from "react";
+import * as TogglePrimitive from "@radix-ui/react-toggle";
+import { themeManagerCn } from "@yext/visual-editor";
+
+function Toggle({
+  className,
+  ...props
+}: React.ComponentProps<typeof TogglePrimitive.Root>) {
+  return (
+    <TogglePrimitive.Root
+      data-slot="toggle"
+      className={themeManagerCn(
+        "items-center justify-center gap-2 rounded-full text-black " +
+          "data-[state=on]:bg-palette-secondary data-[state=on]:border-palette-secondary " +
+          "whitespace-nowrap border-gray-200 border border-solid hover:underline " +
+          "font-button-fontFamily text-button-fontSize font-button-fontWeight tracking-button-letterSpacing",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Toggle };

--- a/packages/visual-editor/src/components/pageSections/NearbyLocations.tsx
+++ b/packages/visual-editor/src/components/pageSections/NearbyLocations.tsx
@@ -143,8 +143,8 @@ const nearbyLocationsSectionFields: Fields<NearbyLocationsSectionProps> = {
         {
           type: "radio",
           options: [
-            { label: msg("yes", "Yes"), value: true },
-            { label: msg("no", "No"), value: false },
+            { label: msg("fields.options.yes", "Yes"), value: true },
+            { label: msg("fields.options.no", "No"), value: false },
           ],
         }
       ),
@@ -156,8 +156,8 @@ const nearbyLocationsSectionFields: Fields<NearbyLocationsSectionProps> = {
             {
               type: "radio",
               options: [
-                { label: msg("yes", "Yes"), value: true },
-                { label: msg("no", "No"), value: false },
+                { label: msg("fields.options.yes", "Yes"), value: true },
+                { label: msg("fields.options.no", "No"), value: false },
               ],
             }
           ),
@@ -173,8 +173,8 @@ const nearbyLocationsSectionFields: Fields<NearbyLocationsSectionProps> = {
             {
               type: "radio",
               options: [
-                { label: msg("yes", "Yes"), value: true },
-                { label: msg("no", "No"), value: false },
+                { label: msg("fields.options.yes", "Yes"), value: true },
+                { label: msg("fields.options.no", "No"), value: false },
               ],
             }
           ),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,9 @@ importers:
       "@radix-ui/react-switch":
         specifier: ^1.1.0
         version: 1.2.2(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-toggle":
+        specifier: ^1.1.9
+        version: 1.1.9(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       "@radix-ui/react-tooltip":
         specifier: ^1.1.2
         version: 1.2.4(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -125,11 +128,11 @@ importers:
         specifier: ^1.1.4
         version: 1.1.5(@lexical/clipboard@0.12.6(lexical@0.12.6))(@lexical/selection@0.12.6(lexical@0.12.6))(@types/react@18.3.20)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(yjs@13.6.26)
       "@yext/search-headless-react":
-        specifier: ^2.5.2
-        version: 2.5.2(encoding@0.1.13)(react@18.3.1)
+        specifier: ^2.5.3
+        version: 2.5.3(encoding@0.1.13)(react@18.3.1)
       "@yext/search-ui-react":
-        specifier: ^1.8.13
-        version: 1.8.13(@types/react@18.3.20)(@yext/search-headless-react@2.5.2(encoding@0.1.13)(react@18.3.1))(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.17.32)(typescript@5.8.3)))
+        specifier: ^1.8.15
+        version: 1.8.15(@types/react@18.3.20)(@yext/search-headless-react@2.5.3(encoding@0.1.13)(react@18.3.1))(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.17.32)(typescript@5.8.3)))
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.1
@@ -157,6 +160,9 @@ importers:
       next-themes:
         specifier: ^0.3.0
         version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      pack:
+        specifier: ^2.2.0
+        version: 2.2.0
       picocolors:
         specifier: ^1.0.1
         version: 1.1.1
@@ -366,11 +372,11 @@ importers:
         specifier: ^20.12.3
         version: 20.17.32
       "@yext/search-headless-react":
-        specifier: ^2.5.2
-        version: 2.5.2(encoding@0.1.13)(react@18.3.1)
+        specifier: ^2.5.3
+        version: 2.5.3(encoding@0.1.13)(react@18.3.1)
       "@yext/search-ui-react":
-        specifier: ^1.8.13
-        version: 1.8.13(@types/react@18.3.20)(@yext/search-headless-react@2.5.2(encoding@0.1.13)(react@18.3.1))(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.17.32)(typescript@5.8.3)))
+        specifier: ^1.8.15
+        version: 1.8.15(@types/react@18.3.20)(@yext/search-headless-react@2.5.3(encoding@0.1.13)(react@18.3.1))(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.17.32)(typescript@5.8.3)))
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.1
@@ -3045,6 +3051,22 @@ packages:
       "@types/react-dom":
         optional: true
 
+  "@radix-ui/react-toggle@1.1.9":
+    resolution:
+      {
+        integrity: sha512-ZoFkBBz9zv9GWer7wIjvdRxmh2wyc2oKWw6C6CseWd6/yq1DK/l5lJ+wnsmFwJZbBYqr02mrf8A2q/CVCuM3ZA==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      "@types/react-dom": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      "@types/react-dom":
+        optional: true
+
   "@radix-ui/react-tooltip@1.2.4":
     resolution:
       {
@@ -4295,34 +4317,34 @@ packages:
       react-dom: ^17.0.2 || ^18.2.0
       vite: ^4.3.0 || ^5.0.2
 
-  "@yext/search-core@2.6.1":
+  "@yext/search-core@2.6.2":
     resolution:
       {
-        integrity: sha512-w+B+b+4kW/g/BZdvOGKQxOsPRqGVpFcYgIP7uQwgIZ3n28LbciC1+P22p7xAoaDJQFToYeGwuvmLxlyFNiBL7g==,
+        integrity: sha512-Kx6aug/pIF3/A5JRU2ikigkzw8wXEJl09+JJEUBOaF1A2i6TTE5CkZ7VK3ebmp51/K4YJanbZInGOgADoIZlBA==,
       }
     engines: { node: ">=12" }
 
-  "@yext/search-headless-react@2.5.2":
+  "@yext/search-headless-react@2.5.3":
     resolution:
       {
-        integrity: sha512-8jKfKMwvDdCiZ2/NSt7AgmuU/ukCxsfn51EBi0iglhJ+krhK5S9zlXKLMl/Iyat6GBjfaTaYNRej2S9zDlh5EA==,
+        integrity: sha512-W/VhM1rx/KVhWHKV/KCCvdwilUlWIRDacJVwpYzEHUEmVf76KCMC3kxbcYhftph4hUK3UldbA+/fTN/o5cBYWA==,
       }
     peerDependencies:
       react: ^16.14 || ^17 || ^18
 
-  "@yext/search-headless@2.6.2":
+  "@yext/search-headless@2.6.3":
     resolution:
       {
-        integrity: sha512-z5LKC3gU2K0Fe5zoPrLsIqvaWL0KBC8/21Nzsn5cKXft2SXPAvj+y+SjtaO0VGEd6WAOGuexDbf2GybOi8Ei9Q==,
+        integrity: sha512-GezFq+f7r4pfFlAJ6V8VGgend14IGbM5/pfrsxroqenwLudV+6MdK5B8xcWjAwbCPX/InvswSd6aR/koDO3h0g==,
       }
 
-  "@yext/search-ui-react@1.8.13":
+  "@yext/search-ui-react@1.8.15":
     resolution:
       {
-        integrity: sha512-Z2T4aJrgD2j2Fl975b/hg+lMP5yT08/1Tu5AYAVBmUgqkFfauTUCGTptqPHtlmPgrt88sMu44bi3BUwVHrHyTA==,
+        integrity: sha512-Z4L1pwK3ezYxyKFoqIxnf1QG1WiYRPnJ2npliF9FM29nIL36TK0WveEjflnbyfnBUXDeQt4Ot0IQjOAV+qjiqQ==,
       }
     peerDependencies:
-      "@yext/search-headless-react": ^2.5.0
+      "@yext/search-headless-react": ^2.5.3
       react: ^16.14 || ^17 || ^18
       react-dom: ^16.14 || ^17 || ^18
 
@@ -8188,6 +8210,12 @@ packages:
         integrity: sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==,
       }
     engines: { node: ">=18" }
+
+  pack@2.2.0:
+    resolution:
+      {
+        integrity: sha512-Nira/5OGkacGuRhpZ4p+Z//hRhReMcPmGNa58ozPATauouRyjeIV/fAmEUzQehOnuyaAAefvPZJS26Jrh1ltsQ==,
+      }
 
   package-json-from-dist@1.0.1:
     resolution:
@@ -12734,6 +12762,17 @@ snapshots:
       "@types/react": 18.3.20
       "@types/react-dom": 18.3.6(@types/react@18.3.20)
 
+  "@radix-ui/react-toggle@1.1.9(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
+    dependencies:
+      "@radix-ui/primitive": 1.1.2
+      "@radix-ui/react-primitive": 2.1.3(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@radix-ui/react-use-controllable-state": 1.2.2(@types/react@18.3.20)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      "@types/react": 18.3.20
+      "@types/react-dom": 18.3.6(@types/react@18.3.20)
+
   "@radix-ui/react-tooltip@1.2.4(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
     dependencies:
       "@radix-ui/primitive": 1.1.2
@@ -13631,26 +13670,26 @@ snapshots:
       - terser
       - universal-cookie
 
-  "@yext/search-core@2.6.1(encoding@0.1.13)":
+  "@yext/search-core@2.6.2(encoding@0.1.13)":
     dependencies:
       "@babel/runtime-corejs3": 7.27.1
       cross-fetch: 3.2.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
 
-  "@yext/search-headless-react@2.5.2(encoding@0.1.13)(react@18.3.1)":
+  "@yext/search-headless-react@2.5.3(encoding@0.1.13)(react@18.3.1)":
     dependencies:
-      "@yext/search-headless": 2.6.2(encoding@0.1.13)(react@18.3.1)
+      "@yext/search-headless": 2.6.3(encoding@0.1.13)(react@18.3.1)
       react: 18.3.1
       use-sync-external-store: 1.5.0(react@18.3.1)
     transitivePeerDependencies:
       - encoding
       - react-redux
 
-  "@yext/search-headless@2.6.2(encoding@0.1.13)(react@18.3.1)":
+  "@yext/search-headless@2.6.3(encoding@0.1.13)(react@18.3.1)":
     dependencies:
       "@reduxjs/toolkit": 1.9.7(react@18.3.1)
-      "@yext/search-core": 2.6.1(encoding@0.1.13)
+      "@yext/search-core": 2.6.2(encoding@0.1.13)
       js-levenshtein: 1.1.6
       lodash: 4.17.21
     transitivePeerDependencies:
@@ -13658,14 +13697,14 @@ snapshots:
       - react
       - react-redux
 
-  "@yext/search-ui-react@1.8.13(@types/react@18.3.20)(@yext/search-headless-react@2.5.2(encoding@0.1.13)(react@18.3.1))(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.17.32)(typescript@5.8.3)))":
+  "@yext/search-ui-react@1.8.15(@types/react@18.3.20)(@yext/search-headless-react@2.5.3(encoding@0.1.13)(react@18.3.1))(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.17.32)(typescript@5.8.3)))":
     dependencies:
       "@restart/ui": 1.9.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       "@tailwindcss/forms": 0.5.10(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.17.32)(typescript@5.8.3)))
       "@tailwindcss/line-clamp": 0.4.4(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.17.32)(typescript@5.8.3)))
       "@tailwindcss/typography": 0.5.16(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.17.32)(typescript@5.8.3)))
       "@yext/analytics": 0.6.8(encoding@0.1.13)
-      "@yext/search-headless-react": 2.5.2(encoding@0.1.13)(react@18.3.1)
+      "@yext/search-headless-react": 2.5.3(encoding@0.1.13)(react@18.3.1)
       classnames: 2.5.1
       lodash: 4.17.21
       lodash-es: 4.17.21
@@ -16206,6 +16245,8 @@ snapshots:
 
   p-map@7.0.3: {}
 
+  pack@2.2.0: {}
+
   package-json-from-dist@1.0.1: {}
 
   package-json@10.0.1:
@@ -16769,7 +16810,7 @@ snapshots:
 
   redux@4.2.1:
     dependencies:
-      "@babel/runtime": 7.27.0
+      "@babel/runtime": 7.27.6
 
   regenerator-runtime@0.14.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,9 +160,6 @@ importers:
       next-themes:
         specifier: ^0.3.0
         version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      pack:
-        specifier: ^2.2.0
-        version: 2.2.0
       picocolors:
         specifier: ^1.0.1
         version: 1.1.1
@@ -8211,12 +8208,6 @@ packages:
       }
     engines: { node: ">=18" }
 
-  pack@2.2.0:
-    resolution:
-      {
-        integrity: sha512-Nira/5OGkacGuRhpZ4p+Z//hRhReMcPmGNa58ozPATauouRyjeIV/fAmEUzQehOnuyaAAefvPZJS26Jrh1ltsQ==,
-      }
-
   package-json-from-dist@1.0.1:
     resolution:
       {
@@ -16244,8 +16235,6 @@ snapshots:
       p-limit: 3.1.0
 
   p-map@7.0.3: {}
-
-  pack@2.2.0: {}
 
   package-json-from-dist@1.0.1: {}
 

--- a/starter/package.json
+++ b/starter/package.json
@@ -39,8 +39,8 @@
     "sonner": "^1.4.41",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",
-    "@yext/search-ui-react": "^1.8.13",
-    "@yext/search-headless-react": "^2.5.2",
+    "@yext/search-ui-react": "^1.8.15",
+    "@yext/search-headless-react": "^2.5.3",
     "@types/mapbox-gl": "^2.7.5",
     "mapbox-gl": "^2.9.2"
   },


### PR DESCRIPTION
This PR adds the ability to add an 'Open Now' button to the
Locator component. If enabled, and if clicked, a filter is
applied to only show the currently open results.

To accomplish this, a new component atom, toggle, has also been added. For now it has
no props, and always uses the secondary color when toggled.
J=WAT-4908
TEST=manual

Ran in interactive dev mode and saw all expected behavior.
Reference the Jam video
https://jam.dev/c/bb97c575-2e20-4d9e-83c0-0e9594e584c0