### PR TITLE
fix: reduce fonts imported into generated pages

### DIFF
--- a/packages/visual-editor/src/utils/applyTheme.test.ts
+++ b/packages/visual-editor/src/utils/applyTheme.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { applyTheme, Document } from "./applyTheme.ts";
 import { ThemeConfig } from "./themeResolver.ts";
-import { defaultGoogleFontsLinkTags } from "./font_registry.js";
 
 describe("buildCssOverridesStyle", () => {
   it("should generate correct CSS with one override in c_theme", () => {
@@ -14,8 +13,7 @@ describe("buildCssOverridesStyle", () => {
     const result = applyTheme(document, themeConfig);
 
     expect(result).toBe(
-      defaultGoogleFontsLinkTags +
-        '<style id="visual-editor-theme" type="text/css">.components{' +
+      '<style id="visual-editor-theme" type="text/css">.components{' +
         "--colors-palette-text:red !important;" +
         "--colors-palette-primary-DEFAULT:hsl(0 68% 51%) !important;" +
         "--colors-palette-primary-foreground:hsl(0 0% 100%) !important;" +
@@ -40,8 +38,7 @@ describe("buildCssOverridesStyle", () => {
     const result = applyTheme(document, themeConfig);
 
     expect(result).toBe(
-      defaultGoogleFontsLinkTags +
-        '<style id="visual-editor-theme" type="text/css">.components{' +
+      '<style id="visual-editor-theme" type="text/css">.components{' +
         "--colors-palette-text:black !important;" +
         "--colors-palette-primary-DEFAULT:hsl(0 68% 51%) !important;" +
         "--colors-palette-primary-foreground:hsl(0 0% 100%) !important;" +
@@ -55,7 +52,32 @@ describe("buildCssOverridesStyle", () => {
     const result = applyTheme({} as Document, themeConfig);
 
     expect(result).toBe(
-      defaultGoogleFontsLinkTags +
+      '<style id="visual-editor-theme" type="text/css">.components{' +
+        "--colors-palette-text:black !important;" +
+        "--colors-palette-primary-DEFAULT:hsl(0 68% 51%) !important;" +
+        "--colors-palette-primary-foreground:hsl(0 0% 100%) !important;" +
+        "--borderRadius-border-lg:8px !important;" +
+        "--borderRadius-border-sm:4px !important" +
+        "}</style>"
+    );
+  });
+
+  it("should return font style tag only for fonts in theme", () => {
+    const document: Document = {
+      siteId: 123,
+      __: {
+        theme: JSON.stringify({
+          "--fontFamily-button-fontFamily": "'Adamina', serif",
+        }),
+      },
+    };
+
+    const result = applyTheme(document, themeConfig);
+
+    expect(result).toBe(
+      '<link rel="preconnect" href="https://fonts.googleapis.com">\n' +
+        '<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>\n' +
+        '<link href="https://fonts.googleapis.com/css2?family=Adamina:wght@400&display=swap" rel="stylesheet">' +
         '<style id="visual-editor-theme" type="text/css">.components{' +
         "--colors-palette-text:black !important;" +
         "--colors-palette-primary-DEFAULT:hsl(0 68% 51%) !important;" +
@@ -82,8 +104,7 @@ describe("buildCssOverridesStyle", () => {
     const result = applyTheme(document, themeConfig);
 
     expect(result).toBe(
-      defaultGoogleFontsLinkTags +
-        '<style id="visual-editor-theme" type="text/css">.components{' +
+      '<style id="visual-editor-theme" type="text/css">.components{' +
         "--colors-palette-text:black !important;" +
         "--colors-palette-primary-DEFAULT:hsl(0 68% 51%) !important;" +
         "--colors-palette-primary-foreground:hsl(0 0% 100%) !important;" +
@@ -114,8 +135,7 @@ describe("buildCssOverridesStyle", () => {
     });
 
     expect(result).toBe(
-      defaultGoogleFontsLinkTags +
-        '<style id="visual-editor-theme" type="text/css">.components{' +
+      '<style id="visual-editor-theme" type="text/css">.components{' +
         "--colors-palette-primary:#7ED321 !important;" +
         "--colors-palette-primary-contrast:#FFFFFF !important" +
         "}</style>"

--- a/packages/visual-editor/src/utils/applyTheme.test.ts
+++ b/packages/visual-editor/src/utils/applyTheme.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { applyTheme, Document } from "./applyTheme.ts";
 import { ThemeConfig } from "./themeResolver.ts";
+import { defaultGoogleFontsLinkTags } from "./font_registry.js";
 
 describe("buildCssOverridesStyle", () => {
   it("should generate correct CSS with one override in c_theme", () => {
@@ -52,7 +53,8 @@ describe("buildCssOverridesStyle", () => {
     const result = applyTheme({} as Document, themeConfig);
 
     expect(result).toBe(
-      '<style id="visual-editor-theme" type="text/css">.components{' +
+      defaultGoogleFontsLinkTags +
+        '<style id="visual-editor-theme" type="text/css">.components{' +
         "--colors-palette-text:black !important;" +
         "--colors-palette-primary-DEFAULT:hsl(0 68% 51%) !important;" +
         "--colors-palette-primary-foreground:hsl(0 0% 100%) !important;" +

--- a/packages/visual-editor/src/utils/applyTheme.ts
+++ b/packages/visual-editor/src/utils/applyTheme.ts
@@ -27,16 +27,15 @@ const devLogger = new DevLogger();
 export const applyTheme = (
   document: Document,
   themeConfig: ThemeConfig,
-  base?: string,
-  inEditor?: boolean
+  base?: string
 ): string => {
   devLogger.logFunc("applyTheme");
 
   const publishedTheme = document?.__?.theme;
   const overrides = publishedTheme ? JSON.parse(publishedTheme) : undefined;
 
-  // In the editor inject all the google font tags, else only inject the in-use font tags
-  const fontLinkTags = inEditor
+  // In the editor with no published theme, inject all the google font tags, else only inject the in-use font tags
+  const fontLinkTags = !publishedTheme
     ? googleFontLinkTags
     : constructGoogleFontLinkTags(
         extractInUseFontFamilies(overrides, defaultFonts)

--- a/packages/visual-editor/src/utils/applyTheme.ts
+++ b/packages/visual-editor/src/utils/applyTheme.ts
@@ -5,10 +5,10 @@ import {
   constructGoogleFontLinkTags,
   defaultFonts,
   extractInUseFontFamilies,
-  googleFontLinkTags,
 } from "./visualEditorFonts.ts";
 import { ThemeConfig } from "./themeResolver.ts";
 import { hexToHSL } from "./colors.ts";
+import { googleFontLinkTags } from "./visualEditorFonts";
 
 export type Document = {
   [key: string]: any;
@@ -27,16 +27,20 @@ const devLogger = new DevLogger();
 export const applyTheme = (
   document: Document,
   themeConfig: ThemeConfig,
-  base?: string
+  base?: string,
+  inEditor?: boolean
 ): string => {
   devLogger.logFunc("applyTheme");
 
   const publishedTheme = document?.__?.theme;
   const overrides = publishedTheme ? JSON.parse(publishedTheme) : undefined;
 
-  const fontLinkTags = constructGoogleFontLinkTags(
-    extractInUseFontFamilies(overrides, defaultFonts)
-  );
+  // In the editor inject all the google font tags, else only inject the in-use font tags
+  const fontLinkTags = inEditor
+    ? googleFontLinkTags
+    : constructGoogleFontLinkTags(
+        extractInUseFontFamilies(overrides, defaultFonts)
+      );
 
   if (Object.keys(themeConfig).length > 0) {
     return `${base ?? ""}${fontLinkTags}<style id="${THEME_STYLE_TAG_ID}" type="text/css">${internalApplyTheme(overrides, themeConfig)}</style>`;

--- a/packages/visual-editor/src/utils/applyTheme.ts
+++ b/packages/visual-editor/src/utils/applyTheme.ts
@@ -1,7 +1,12 @@
 import { ThemeData } from "../internal/types/themeData.ts";
 import { internalThemeResolver } from "../internal/utils/internalThemeResolver.ts";
 import { DevLogger } from "./devLogger.ts";
-import { googleFontLinkTags } from "./visualEditorFonts.ts";
+import {
+  constructGoogleFontLinkTags,
+  defaultFonts,
+  extractInUseFontFamilies,
+  googleFontLinkTags,
+} from "./visualEditorFonts.ts";
 import { ThemeConfig } from "./themeResolver.ts";
 import { hexToHSL } from "./colors.ts";
 
@@ -29,8 +34,12 @@ export const applyTheme = (
   const publishedTheme = document?.__?.theme;
   const overrides = publishedTheme ? JSON.parse(publishedTheme) : undefined;
 
+  const fontLinkTags = constructGoogleFontLinkTags(
+    extractInUseFontFamilies(overrides, defaultFonts)
+  );
+
   if (Object.keys(themeConfig).length > 0) {
-    return `${base ?? ""}${googleFontLinkTags}<style id="${THEME_STYLE_TAG_ID}" type="text/css">${internalApplyTheme(overrides, themeConfig)}</style>`;
+    return `${base ?? ""}${fontLinkTags}<style id="${THEME_STYLE_TAG_ID}" type="text/css">${internalApplyTheme(overrides, themeConfig)}</style>`;
   }
   return base ?? "";
 };

--- a/packages/visual-editor/src/utils/visualEditorFonts.test.ts
+++ b/packages/visual-editor/src/utils/visualEditorFonts.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { ThemeData } from "../internal/types/themeData.ts";
 import {
   extractInUseFontFamilies,
@@ -74,6 +74,17 @@ describe("extractInUseFontFamilies", () => {
     };
 
     expect(extractInUseFontFamilies(themeData, defaultFonts)).toEqual(expected);
+  });
+
+  it("should handle fontFamily in theme data not in available fonts", () => {
+    const consoleSpy = vi.spyOn(console, "warn");
+    const themeData: ThemeData = {
+      "--fontFamily-h1-fontFamily": "'Fake Font', sans-serif",
+    };
+    expect(extractInUseFontFamilies(themeData, defaultFonts)).toEqual({});
+    expect(consoleSpy).toHaveBeenLastCalledWith(
+      "The font 'Fake Font' is used in the theme but cannot be found in available fonts."
+    );
   });
 });
 

--- a/packages/visual-editor/src/utils/visualEditorFonts.test.ts
+++ b/packages/visual-editor/src/utils/visualEditorFonts.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from "vitest";
+import { ThemeData } from "../internal/types/themeData.ts";
+import {
+  extractInUseFontFamilies,
+  FontRegistry,
+  defaultFonts,
+  constructGoogleFontLinkTags,
+} from "./visualEditorFonts.ts";
+
+describe("extractInUseFontFamilies", () => {
+  it("should return the specifications for all fonts used in the theme", () => {
+    const themeData: ThemeData = {
+      "--fontFamily-h1-fontFamily": "'Oi', sans-serif",
+      "--fontFamily-button-fontFamily": "'Adamina', serif",
+    };
+
+    const expected: FontRegistry = {
+      Oi: { italics: false, weights: [400], fallback: "sans-serif" },
+      Adamina: { italics: false, weights: [400], fallback: "serif" },
+    };
+
+    expect(extractInUseFontFamilies(themeData, defaultFonts)).toEqual(expected);
+  });
+
+  it("should return an empty object if theme data is empty", () => {
+    const themeData: ThemeData = {};
+    expect(extractInUseFontFamilies(themeData, defaultFonts)).toEqual({});
+  });
+
+  it("should return an empty object if no font families are defined in the theme", () => {
+    const themeData: ThemeData = {
+      "--colors-palette-primary": "#CF0A2C",
+      "--fontSize-h1-fontSize": "48px",
+    };
+    expect(extractInUseFontFamilies(themeData, defaultFonts)).toEqual({});
+  });
+
+  it("should return an empty object if the list of available fonts is empty", () => {
+    const themeData: ThemeData = {
+      "--fontFamily-h1-fontFamily": "'Open Sans', sans-serif",
+    };
+    const emptyAvailableFonts = {};
+    expect(extractInUseFontFamilies(themeData, emptyAvailableFonts)).toEqual(
+      {}
+    );
+  });
+
+  it("should handle malformed or empty fontFamily values gracefully", () => {
+    const themeData: ThemeData = {
+      "--fontFamily-h1-fontFamily": "",
+      "--fontFamily-h2-fontFamily": null,
+      "--fontFamily-button-fontFamily": "'Adamina', serif",
+    };
+    const expected: FontRegistry = {
+      Adamina: { italics: false, weights: [400], fallback: "serif" },
+    };
+    expect(extractInUseFontFamilies(themeData, defaultFonts)).toEqual(expected);
+  });
+
+  it("should not include duplicate fonts, even if used multiple times", () => {
+    const themeData: ThemeData = {
+      "--fontFamily-h1-fontFamily": "'Open Sans', sans-serif",
+      "--fontFamily-h2-fontFamily": "'Open Sans', sans-serif",
+      "--fontFamily-body-fontFamily": "'Open Sans', sans-serif",
+    };
+
+    const expected: FontRegistry = {
+      "Open Sans": {
+        italics: true,
+        minWeight: 300,
+        maxWeight: 800,
+        fallback: "sans-serif",
+      },
+    };
+
+    expect(extractInUseFontFamilies(themeData, defaultFonts)).toEqual(expected);
+  });
+});
+
+describe("constructGoogleFontLinkTags", () => {
+  const preconnectTags =
+    '<link rel="preconnect" href="https://fonts.googleapis.com">\n' +
+    '<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>\n';
+
+  it("should return an empty string if the font registry is empty", () => {
+    const fonts: FontRegistry = {};
+    expect(constructGoogleFontLinkTags(fonts)).toBe("");
+  });
+
+  it("should create a correct link for a single static font without italics", () => {
+    const fonts: FontRegistry = {
+      Roboto: { weights: [400, 700], italics: false, fallback: "sans-serif" },
+    };
+    const expected =
+      preconnectTags +
+      '<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">';
+    expect(constructGoogleFontLinkTags(fonts)).toBe(expected);
+  });
+
+  it("should create a correct link for a single static font with italics", () => {
+    const fonts: FontRegistry = {
+      Lato: { weights: [400, 900], italics: true, fallback: "sans-serif" },
+    };
+    const expected =
+      preconnectTags +
+      '<link href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,400;0,900;1,400;1,900&display=swap" rel="stylesheet">';
+    expect(constructGoogleFontLinkTags(fonts)).toBe(expected);
+  });
+
+  it("should create a correct link for a single variable font without italics", () => {
+    const fonts: FontRegistry = {
+      "Open Sans": {
+        minWeight: 300,
+        maxWeight: 800,
+        italics: false,
+        fallback: "sans-serif",
+      },
+    };
+    const expected =
+      preconnectTags +
+      '<link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300..800&display=swap" rel="stylesheet">';
+    expect(constructGoogleFontLinkTags(fonts)).toBe(expected);
+  });
+
+  it("should create a correct link for a single variable font with italics", () => {
+    const fonts: FontRegistry = {
+      "Open Sans": {
+        minWeight: 300,
+        maxWeight: 800,
+        italics: true,
+        fallback: "sans-serif",
+      },
+    };
+    const expected =
+      preconnectTags +
+      '<link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap" rel="stylesheet">';
+    expect(constructGoogleFontLinkTags(fonts)).toBe(expected);
+  });
+
+  it("should handle variable fonts where min and max weight are the same", () => {
+    const fonts: FontRegistry = {
+      "Single Weight Var": {
+        minWeight: 500,
+        maxWeight: 500,
+        italics: true,
+        fallback: "sans-serif",
+      },
+    };
+    const expected =
+      preconnectTags +
+      '<link href="https://fonts.googleapis.com/css2?family=Single+Weight+Var:ital,wght@0,500;1,500&display=swap" rel="stylesheet">';
+    expect(constructGoogleFontLinkTags(fonts)).toBe(expected);
+  });
+
+  it("should combine multiple fonts into a single link tag", () => {
+    const fonts: FontRegistry = {
+      Roboto: { weights: [400], italics: false, fallback: "sans-serif" },
+      Lato: {
+        minWeight: 300,
+        maxWeight: 700,
+        italics: true,
+        fallback: "sans-serif",
+      },
+    };
+    const expected =
+      preconnectTags +
+      '<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400&family=Lato:ital,wght@0,300..700;1,300..700&display=swap" rel="stylesheet">';
+    expect(constructGoogleFontLinkTags(fonts)).toBe(expected);
+  });
+
+  it("should create multiple link tags when the number of fonts exceeds the chunk size", () => {
+    const fonts: FontRegistry = {
+      Font1: { weights: [400], italics: false, fallback: "sans-serif" },
+      Font2: { weights: [400], italics: false, fallback: "sans-serif" },
+      Font3: { weights: [400], italics: false, fallback: "sans-serif" },
+      Font4: { weights: [400], italics: false, fallback: "sans-serif" },
+      Font5: { weights: [400], italics: false, fallback: "sans-serif" },
+      Font6: { weights: [400], italics: false, fallback: "sans-serif" },
+      Font7: { weights: [400], italics: false, fallback: "sans-serif" },
+      Font8: { weights: [400], italics: false, fallback: "sans-serif" },
+    };
+
+    const link1Params =
+      "family=Font1:wght@400&family=Font2:wght@400&family=Font3:wght@400&family=Font4:wght@400&family=Font5:wght@400&family=Font6:wght@400&family=Font7:wght@400";
+    const link2Params = "family=Font8:wght@400";
+
+    const link1 = `<link href="https://fonts.googleapis.com/css2?${link1Params}&display=swap" rel="stylesheet">`;
+    const link2 = `<link href="https://fonts.googleapis.com/css2?${link2Params}&display=swap" rel="stylesheet">`;
+
+    const expected = `${preconnectTags}${link1}\n${link2}`;
+    expect(constructGoogleFontLinkTags(fonts)).toBe(expected);
+  });
+});

--- a/packages/visual-editor/src/utils/visualEditorFonts.ts
+++ b/packages/visual-editor/src/utils/visualEditorFonts.ts
@@ -247,6 +247,10 @@ export const extractInUseFontFamilies = (
   for (const fontName of fontFamilies) {
     if (avaliableFonts[fontName]) {
       inUseFonts[fontName] = avaliableFonts[fontName];
+    } else {
+      console.warn(
+        `The font '${fontName}' is used in the theme but cannot be found in available fonts.`
+      );
     }
   }
 

--- a/packages/visual-editor/src/utils/visualEditorFonts.ts
+++ b/packages/visual-editor/src/utils/visualEditorFonts.ts
@@ -2,6 +2,7 @@ import { PUCK_PREVIEW_IFRAME_ID, THEME_STYLE_TAG_ID } from "./applyTheme.ts";
 import { StyleSelectOption } from "./themeResolver.ts";
 import { defaultFonts as fontsJs } from "./font_registry.js";
 import { msg } from "./i18nPlatform.ts";
+import { ThemeData } from "../internal/types/themeData.ts";
 
 export type FontRegistry = Record<string, FontSpecification>;
 type FontSpecification = {
@@ -41,7 +42,7 @@ export const constructFontSelectOptions = (fonts: FontRegistry) => {
  * Note: Google does not return font file URLs if the params
  * fall outside of the font's supported values
  */
-const constructGoogleFontLinkTags = (fonts: FontRegistry): string => {
+export const constructGoogleFontLinkTags = (fonts: FontRegistry): string => {
   const preconnectTags =
     '<link rel="preconnect" href="https://fonts.googleapis.com">\n' +
     '<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>\n';
@@ -90,7 +91,7 @@ const constructGoogleFontLinkTags = (fonts: FontRegistry): string => {
     linkTags.push(`${prefix}${params}&${postfix}`);
   }
 
-  return preconnectTags + linkTags.join("\n");
+  return linkTags.length ? preconnectTags + linkTags.join("\n") : "";
 };
 
 export const googleFontLinkTags = constructGoogleFontLinkTags(defaultFonts);
@@ -216,4 +217,38 @@ const filterFontWeights = (
         Number(weight.value) >= font.minWeight
     );
   }
+};
+
+// Returns FontRegistry only containing fonts used in ThemeData
+export const extractInUseFontFamilies = (
+  data: ThemeData,
+  avaliableFonts: FontRegistry
+): FontRegistry => {
+  const fontFamilies = new Set<string>();
+
+  // Iterate over all the keys in the theme data to find font names.
+  for (const key in data) {
+    // searches for keys with "fontFamily" like "--fontFamily-h1-fontFamily"
+    if (typeof key === "string" && key.includes("fontFamily")) {
+      const value = data[key];
+      // key / value looks like "--fontFamily-h1-fontFamily": "'Open Sans', sans-serif"
+      // parses fontName from the value
+      if (typeof value === "string" && value.length > 0) {
+        const firstFont = value.split(",")[0];
+        const cleanedFontName = firstFont.trim().replace(/^['"]|['"]$/g, "");
+        fontFamilies.add(cleanedFontName);
+      }
+    }
+  }
+
+  const inUseFonts: FontRegistry = {};
+
+  // For each unique font family found, look it up in the avaliableFonts map.
+  for (const fontName of fontFamilies) {
+    if (avaliableFonts[fontName]) {
+      inUseFonts[fontName] = avaliableFonts[fontName];
+    }
+  }
+
+  return inUseFonts;
 };

--- a/packages/visual-editor/src/vite-plugin/templates/edit.tsx
+++ b/packages/visual-editor/src/vite-plugin/templates/edit.tsx
@@ -31,7 +31,7 @@ export const getHeadConfig: GetHeadConfig<TemplateRenderProps> = ({
   document,
 }): HeadConfig => {
   return {
-    other: fullStorySnippet + applyTheme(document, themeConfig, "", true),
+    other: fullStorySnippet + applyTheme(document, themeConfig),
   };
 };
 

--- a/packages/visual-editor/src/vite-plugin/templates/edit.tsx
+++ b/packages/visual-editor/src/vite-plugin/templates/edit.tsx
@@ -31,7 +31,7 @@ export const getHeadConfig: GetHeadConfig<TemplateRenderProps> = ({
   document,
 }): HeadConfig => {
   return {
-    other: fullStorySnippet + applyTheme(document, themeConfig),
+    other: fullStorySnippet + applyTheme(document, themeConfig, "", true),
   };
 };
 


### PR DESCRIPTION
Before:
<img width="455" alt="Screenshot 2025-07-01 at 2 26 27 PM" src="https://github.com/user-attachments/assets/ef516665-a02b-4ce7-b6d1-676132dc4189" />
Would inject every single font option

Now: 
<img width="464" alt="Screenshot 2025-07-01 at 2 26 17 PM" src="https://github.com/user-attachments/assets/766d75fb-a2e6-402d-b65b-2e5c65667f0a" />
Only injects fonts being used in the theme

Confirmed on site [here](https://www.yext.com/s/4412098/yextsites/158910/pagesets) that live pages have correct style tags and Layout Editor / Theme Editor work. Theme Editor also has all the font options still and changing fonts works as expected. 