### PR TITLE
fix: nearbyLocations warning spam

### DIFF
--- a/packages/visual-editor/src/components/pageSections/NearbyLocations.tsx
+++ b/packages/visual-editor/src/components/pageSections/NearbyLocations.tsx
@@ -293,8 +293,20 @@ const NearbyLocationsComponent: React.FC<NearbyLocationsSectionProps> = ({
   );
 
   // parse variables from document
-  const { businessId, apiKey, contentEndpointId, contentDeliveryAPIDomain } =
-    parseDocument(document, contentEndpointIdEnvVar);
+  const {
+    businessId,
+    apiKey,
+    contentEndpointId,
+    contentDeliveryAPIDomain,
+  }: {
+    businessId: string;
+    apiKey: string;
+    contentEndpointId: string;
+    contentDeliveryAPIDomain: string;
+  } = React.useMemo(
+    () => parseDocument(document, contentEndpointIdEnvVar),
+    [document, contentEndpointIdEnvVar]
+  );
 
   const { data: nearbyLocationsData, status: nearbyLocationsStatus } = useQuery(
     {


### PR DESCRIPTION
Uses useMemo so that warning messages are not spammed when scrolling around the screen.