### PR TITLE
feat(components): add card styles

### DIFF
--- a/packages/visual-editor/src/components/Directory.test.tsx
+++ b/packages/visual-editor/src/components/Directory.test.tsx
@@ -192,6 +192,112 @@ const tests: ComponentTest[] = [
       expect(page.getByText("Directory Root")).toBeVisible();
     },
   },
+  {
+    name: "version 7 with non-default props",
+    document: {
+      _site: {
+        name: "Example Business",
+      },
+      meta: { entityType: { id: "dm_region", uid: 123 }, locale: "en" },
+      dm_addressCountryDisplayName: "United States",
+      dm_addressRegionDisplayName: "Virginia",
+      dm_childEntityIds: ["8932945"],
+      dm_directoryChildren: [
+        {
+          name: "Arlington",
+          slug: "us/va/arlington",
+          dm_addressCountryDisplayName: "United States",
+          dm_addressRegionDisplayName: "Virginia",
+        },
+      ],
+      dm_directoryManagerId: "63590-locations",
+      dm_directoryParents_63590_locations: [
+        {
+          name: "Locations Directory",
+          slug: "en/index.html",
+          dm_addressCountryDisplayName: "United States",
+          dm_addressRegionDisplayName: "Virginia",
+        },
+        {
+          name: "US",
+          slug: "en/us",
+          dm_addressCountryDisplayName: "United States",
+        },
+      ],
+    },
+    props: {
+      data: {
+        directoryRoot: "Not Default Root",
+      },
+      styles: {
+        cards: {
+          backgroundColor: {
+            bgColor: "bg-palette-primary-light",
+            textColor: "text-black",
+          },
+          headingLevel: 3,
+        },
+      },
+      liveVisibility: true,
+    },
+    version: 7,
+    tests: async (page) => {
+      expect(page.getByText("Not Default Root")).toBeVisible();
+    },
+  },
+  {
+    name: "version 7 with default props",
+    document: {
+      _site: {
+        name: "Example Business",
+      },
+      meta: { entityType: { id: "dm_region", uid: 123 }, locale: "en" },
+      dm_addressCountryDisplayName: "United States",
+      dm_addressRegionDisplayName: "Virginia",
+      dm_childEntityIds: ["8932945"],
+      dm_directoryChildren: [
+        {
+          name: "Arlington",
+          slug: "us/va/arlington",
+          dm_addressCountryDisplayName: "United States",
+          dm_addressRegionDisplayName: "Virginia",
+        },
+      ],
+      dm_directoryManagerId: "63590-locations",
+      dm_directoryParents_63590_locations: [
+        {
+          name: "Locations Directory",
+          slug: "en/index.html",
+          dm_addressCountryDisplayName: "United States",
+          dm_addressRegionDisplayName: "Virginia",
+        },
+        {
+          name: "US",
+          slug: "en/us",
+          dm_addressCountryDisplayName: "United States",
+        },
+      ],
+    },
+    props: {
+      data: {
+        directoryRoot: "Directory Root",
+      },
+      styles: {
+        cards: {
+          backgroundColor: {
+            bgColor: "bg-palette-primary-light",
+            textColor: "text-black",
+          },
+          headingLevel: 3,
+        },
+      },
+      liveVisibility: true,
+    },
+    version: 7,
+    tests: async (page) => {
+      expect(page.getByText("Directory Root")).toBeVisible();
+    },
+  },
 ];
 
 const testsWithViewports: ComponentTest[] = [

--- a/packages/visual-editor/src/components/Directory.tsx
+++ b/packages/visual-editor/src/components/Directory.tsx
@@ -11,9 +11,12 @@ import {
   YextField,
   TranslatableStringField,
   TranslatableString,
+  HeadingLevel,
+  BackgroundStyle,
+  Background,
 } from "@yext/visual-editor";
 import { BreadcrumbsComponent } from "./pageSections/Breadcrumbs.tsx";
-import { ComponentConfig } from "@measured/puck";
+import { ComponentConfig, Fields } from "@measured/puck";
 import {
   Address,
   AnalyticsScopeProvider,
@@ -24,10 +27,50 @@ export interface DirectoryProps {
   data: {
     directoryRoot: TranslatableString;
   };
+  styles: {
+    cards: {
+      headingLevel: HeadingLevel;
+      backgroundColor?: BackgroundStyle;
+    };
+  };
   analytics?: {
     scope?: string;
   };
 }
+
+const directoryFields: Fields<DirectoryProps> = {
+  data: YextField(msg("fields.data", "Data"), {
+    type: "object",
+    objectFields: {
+      directoryRoot: TranslatableStringField(
+        msg("fields.directoryRootLinkLabel", "Directory Root Link Label"),
+        "text"
+      ),
+    },
+  }),
+  styles: YextField(msg("fields.styles", "Styles"), {
+    type: "object",
+    objectFields: {
+      cards: YextField(msg("fields.cards", "Cards"), {
+        type: "object",
+        objectFields: {
+          headingLevel: YextField(msg("fields.headingLevel", "Heading Level"), {
+            type: "select",
+            hasSearch: true,
+            options: "HEADING_LEVEL",
+          }),
+          backgroundColor: YextField(
+            msg("fields.backgroundColor", "Background Color"),
+            {
+              type: "select",
+              options: "BACKGROUND_COLOR",
+            }
+          ),
+        },
+      }),
+    },
+  }),
+};
 
 // isDirectoryGrid indicates whether the children should appear in
 // DirectoryGrid or DirectoryList dependent on the dm_directoryChildren type.
@@ -56,13 +99,18 @@ const DirectoryCard = ({
   cardNumber,
   profile,
   relativePrefixToRoot,
+  cardStyles,
 }: {
   cardNumber: number;
   profile: any;
   relativePrefixToRoot: string;
+  cardStyles: DirectoryProps["styles"]["cards"];
 }) => {
   return (
-    <div className="flex flex-col p-8 border border-gray-400 rounded h-full gap-4">
+    <Background
+      className="rounded h-full flex flex-col"
+      background={cardStyles.backgroundColor}
+    >
       <div>
         <MaybeLink
           eventName={`link${cardNumber}`}
@@ -74,9 +122,7 @@ const DirectoryCard = ({
               : profile.slug
           }
         >
-          <Heading level={4} semanticLevelOverride={3}>
-            {profile.name}
-          </Heading>
+          <Heading level={cardStyles.headingLevel}>{profile.name}</Heading>
         </MaybeLink>
         {profile.hours && (
           <div className="font-semibold font-body-fontFamily text-body-fontSize">
@@ -109,7 +155,7 @@ const DirectoryCard = ({
           />
         </div>
       )}
-    </div>
+    </Background>
   );
 };
 
@@ -117,9 +163,11 @@ const DirectoryCard = ({
 const DirectoryGrid = ({
   directoryChildren,
   relativePrefixToRoot,
+  cardStyles,
 }: {
   directoryChildren: any[];
   relativePrefixToRoot: string;
+  cardStyles: DirectoryProps["styles"]["cards"];
 }) => {
   const sortedDirectoryChildren = sortAlphabetically(directoryChildren, "name");
 
@@ -140,6 +188,7 @@ const DirectoryGrid = ({
           cardNumber={idx}
           profile={child}
           relativePrefixToRoot={relativePrefixToRoot}
+          cardStyles={cardStyles}
         />
       ))}
     </PageSection>
@@ -197,7 +246,7 @@ const DirectoryList = ({
   );
 };
 
-const DirectoryComponent = ({ data }: DirectoryProps) => {
+const DirectoryComponent = ({ data, styles }: DirectoryProps) => {
   const { document, relativePrefixToRoot } = useTemplateProps<any>();
 
   let headingText;
@@ -232,6 +281,7 @@ const DirectoryComponent = ({ data }: DirectoryProps) => {
           <DirectoryGrid
             directoryChildren={document.dm_directoryChildren}
             relativePrefixToRoot={relativePrefixToRoot}
+            cardStyles={styles.cards}
           />
         )}
       {document.dm_directoryChildren &&
@@ -248,22 +298,18 @@ const DirectoryComponent = ({ data }: DirectoryProps) => {
 
 export const Directory: ComponentConfig<DirectoryProps> = {
   label: msg("components.directory", "Directory"),
-  fields: {
-    data: YextField(msg("fields.data", "Data"), {
-      type: "object",
-      objectFields: {
-        directoryRoot: TranslatableStringField(
-          msg("fields.directoryRootLinkLabel", "Directory Root Link Label"),
-          "text"
-        ),
-      },
-    }),
-  },
+  fields: directoryFields,
   defaultProps: {
     data: {
       directoryRoot: {
         en: "Directory Root",
         hasLocalizedValue: "true",
+      },
+    },
+    styles: {
+      cards: {
+        backgroundColor: backgroundColors.background1.value,
+        headingLevel: 3,
       },
     },
     analytics: {

--- a/packages/visual-editor/src/components/migrations/0007_add_card_styles.ts
+++ b/packages/visual-editor/src/components/migrations/0007_add_card_styles.ts
@@ -1,0 +1,106 @@
+import { Migration } from "../../utils/migrate.ts";
+
+export const addCardStylesMigration: Migration = {
+  EventSection: {
+    action: "updated",
+    propTransformation: ({ styles, ...props }) => {
+      const { cardBackgroundColor, heading, ...otherStyles } = styles || {};
+      return {
+        styles: {
+          heading: heading,
+          cards: {
+            headingLevel: heading.level < 6 ? heading.level + 1 : 3,
+            backgroundColor: cardBackgroundColor,
+          },
+          ...otherStyles,
+        },
+        ...props,
+      };
+    },
+  },
+  InsightSection: {
+    action: "updated",
+    propTransformation: ({ styles, ...props }) => {
+      const { cardBackgroundColor, heading, ...otherStyles } = styles || {};
+      return {
+        styles: {
+          heading: heading,
+          cards: {
+            headingLevel: heading.level < 6 ? heading.level + 1 : 3,
+            backgroundColor: cardBackgroundColor,
+          },
+          ...otherStyles,
+        },
+        ...props,
+      };
+    },
+  },
+  NearbyLocationsSection: {
+    action: "updated",
+    propTransformation: ({ styles, ...props }) => {
+      const { cardBackgroundColor, cardHeadingLevel, ...otherStyles } =
+        styles || {};
+      return {
+        styles: {
+          cards: {
+            headingLevel: cardHeadingLevel,
+            backgroundColor: cardBackgroundColor,
+          },
+          ...otherStyles,
+        },
+        ...props,
+      };
+    },
+  },
+  ProductSection: {
+    action: "updated",
+    propTransformation: ({ styles, ...props }) => {
+      const { cardBackgroundColor, heading, ...otherStyles } = styles || {};
+      return {
+        styles: {
+          heading: heading,
+          cards: {
+            headingLevel: heading.level < 6 ? heading.level + 1 : 3,
+            backgroundColor: cardBackgroundColor,
+          },
+          ...otherStyles,
+        },
+        ...props,
+      };
+    },
+  },
+  TeamSection: {
+    action: "updated",
+    propTransformation: ({ styles, ...props }) => {
+      const { cardBackgroundColor, heading, ...otherStyles } = styles || {};
+      return {
+        styles: {
+          heading: heading,
+          cards: {
+            headingLevel: heading.level < 6 ? heading.level + 1 : 3,
+            backgroundColor: cardBackgroundColor,
+          },
+          ...otherStyles,
+        },
+        ...props,
+      };
+    },
+  },
+  TestimonialSection: {
+    action: "updated",
+    propTransformation: ({ styles, ...props }) => {
+      const { cardBackgroundColor, heading, ...otherStyles } = styles || {};
+      return {
+        styles: {
+          heading: heading,
+          cards: {
+            headingLevel: heading.level < 6 ? heading.level + 1 : 3,
+            backgroundColor: cardBackgroundColor,
+          },
+          ...otherStyles,
+        },
+        ...props,
+      };
+    },
+  },
+};

--- a/packages/visual-editor/src/components/migrations/migrationRegistry.ts
+++ b/packages/visual-editor/src/components/migrations/migrationRegistry.ts
@@ -5,6 +5,7 @@ import { adjustStructFields } from "./0003_adjust_struct_fields.ts";
 import { addDirectoryRootPropMigration } from "./0004_add_directory_root_prop.ts";
 import { addPromoHeadingStylesMigration } from "./0005_add_promo_heading_styles.ts";
 import { updateImageStylingMigration } from "./0006_update_image_styling.ts";
+import { addCardStylesMigration } from "./0007_add_card_styles.ts";
 
 // To add a migration:
 // Create a new file in this directory that exports a Migration
@@ -18,4 +19,5 @@ export const migrationRegistry: MigrationRegistry = [
   addDirectoryRootPropMigration,
   addPromoHeadingStylesMigration,
   updateImageStylingMigration,
+  addCardStylesMigration,
 ];

--- a/packages/visual-editor/src/components/pageSections/EventSection.test.tsx
+++ b/packages/visual-editor/src/components/pageSections/EventSection.test.tsx
@@ -157,7 +157,7 @@ const tests: ComponentTest[] = [
           bgColor: "bg-palette-primary-light",
           textColor: "text-black",
         },
-        headingLevel: 5,
+        headingLevel: 2,
       },
       liveVisibility: true,
     },
@@ -217,6 +217,114 @@ const tests: ComponentTest[] = [
       liveVisibility: true,
     },
     version: 0,
+    tests: async (page) => {
+      expect(page.getByText("Upcoming")).toBeVisible();
+      expect(page.getByText("Event 1")).toBeVisible();
+      expect(page.getByText("Event 2")).toBeVisible();
+      expect(page.getByText("2020")).toBeVisible();
+      expect(page.getByText("Test Description")).toBeVisible();
+      expect(page.getByText("Test CTA")).toBeVisible();
+    },
+  },
+  {
+    name: "version 7 props with entity values",
+    document: { c_events: eventsData, name: "Test Name" },
+    props: {
+      data: {
+        heading: {
+          field: "name",
+          constantValue: "Upcoming Events",
+          constantValueEnabled: false,
+          constantValueOverride: {},
+        },
+        events: {
+          field: "c_events",
+          constantValue: { events: [{}] },
+          constantValueEnabled: false,
+          constantValueOverride: {},
+        },
+      },
+      styles: {
+        backgroundColor: {
+          bgColor: "bg-palette-secondary-dark",
+          textColor: "text-white",
+        },
+        heading: {
+          level: 3,
+          align: "left",
+        },
+        cards: {
+          backgroundColor: {
+            bgColor: "bg-palette-primary-light",
+            textColor: "text-black",
+          },
+          headingLevel: 4,
+        },
+      },
+      liveVisibility: true,
+    },
+    version: 7,
+    tests: async (page) => {
+      expect(page.getByText("Test Name")).toBeVisible();
+      expect(
+        page.getByRole("heading", { name: "Cooking Class" })
+      ).toBeVisible();
+      expect(page.getByRole("heading", { name: "Hike" })).toBeVisible();
+      expect(page.getByText("2025")).toBeVisible();
+      expect(page.getByText("2026")).toBeVisible();
+      expect(page.getByText("Learn More")).toBeVisible();
+      expect(page.getByText("Sign Up")).toBeVisible();
+      expect(page.getByText("inner chef")).toBeVisible();
+      expect(page.getByText("local trails")).toBeVisible();
+    },
+  },
+  {
+    name: "version 7 props with constant value",
+    document: { c_events: eventsData },
+    props: {
+      data: {
+        heading: {
+          field: "name",
+          constantValue: "Upcoming",
+          constantValueEnabled: true,
+        },
+        events: {
+          field: "c_exampleEvents",
+          constantValue: {
+            events: [
+              { title: "Event 1" },
+              {
+                image: { url: "https://placehold.co/600x400" },
+                title: "Event 2",
+                dateTime: "2020-02-02T10:10",
+                description: "Test Description",
+                cta: { label: "Test CTA", link: "https://yext.com" },
+              },
+            ],
+          },
+          constantValueEnabled: true,
+        },
+      },
+      styles: {
+        backgroundColor: {
+          bgColor: "bg-palette-secondary-dark",
+          textColor: "text-white",
+        },
+        heading: {
+          level: 3,
+          align: "left",
+        },
+        cards: {
+          backgroundColor: {
+            bgColor: "bg-palette-primary-light",
+            textColor: "text-black",
+          },
+          headingLevel: 4,
+        },
+      },
+      liveVisibility: true,
+    },
+    version: 7,
     tests: async (page) => {
       expect(page.getByText("Upcoming")).toBeVisible();
       expect(page.getByText("Event 1")).toBeVisible();

--- a/packages/visual-editor/src/components/pageSections/EventSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/EventSection.tsx
@@ -39,10 +39,13 @@ export interface EventSectionProps {
   };
   styles: {
     backgroundColor?: BackgroundStyle;
-    cardBackgroundColor?: BackgroundStyle;
     heading: {
       level: HeadingLevel;
       align: "left" | "center" | "right";
+    };
+    cards: {
+      headingLevel: HeadingLevel;
+      backgroundColor?: BackgroundStyle;
     };
   };
   analytics?: {
@@ -80,17 +83,10 @@ const eventSectionFields: Fields<EventSectionProps> = {
           options: "BACKGROUND_COLOR",
         }
       ),
-      cardBackgroundColor: YextField(
-        msg("fields.cardBackgroundColor", "Card Background Color"),
-        {
-          type: "select",
-          options: "BACKGROUND_COLOR",
-        }
-      ),
       heading: YextField(msg("fields.heading", "Heading"), {
         type: "object",
         objectFields: {
-          level: YextField(msg("fields.headingLevel", "Level"), {
+          level: YextField(msg("fields.level", "Level"), {
             type: "select",
             hasSearch: true,
             options: "HEADING_LEVEL",
@@ -99,6 +95,23 @@ const eventSectionFields: Fields<EventSectionProps> = {
             type: "radio",
             options: ThemeOptions.ALIGNMENT,
           }),
+        },
+      }),
+      cards: YextField(msg("fields.cards", "Cards"), {
+        type: "object",
+        objectFields: {
+          headingLevel: YextField(msg("fields.headingLevel", "Heading Level"), {
+            type: "select",
+            hasSearch: true,
+            options: "HEADING_LEVEL",
+          }),
+          backgroundColor: YextField(
+            msg("fields.backgroundColor", "Background Color"),
+            {
+              type: "select",
+              options: "BACKGROUND_COLOR",
+            }
+          ),
         },
       }),
     },
@@ -118,18 +131,16 @@ const eventSectionFields: Fields<EventSectionProps> = {
 const EventCard = ({
   cardNumber,
   event,
-  backgroundColor,
-  sectionHeadingLevel,
+  cardStyles,
 }: {
   cardNumber: number;
   event: EventStruct;
-  backgroundColor?: BackgroundStyle;
-  sectionHeadingLevel: HeadingLevel;
+  cardStyles: EventSectionProps["styles"]["cards"];
 }) => {
   const { i18n } = useTranslation();
   return (
     <Background
-      background={backgroundColor}
+      background={cardStyles.backgroundColor}
       className={`flex flex-col md:flex-row rounded-lg overflow-hidden h-fit md:h-64`}
     >
       <div className="lg:w-[45%] w-full h-full">
@@ -148,14 +159,7 @@ const EventCard = ({
       </div>
       <div className="flex flex-col gap-2 p-6 w-full md:w-[55%]">
         {event.title && (
-          <Heading
-            level={6}
-            semanticLevelOverride={
-              sectionHeadingLevel < 6
-                ? ((sectionHeadingLevel + 1) as HeadingLevel)
-                : "span"
-            }
-          >
+          <Heading level={cardStyles.headingLevel}>
             {resolveTranslatableString(event.title, i18n.language)}
           </Heading>
         )}
@@ -229,8 +233,7 @@ const EventSectionWrapper: React.FC<EventSectionProps> = (props) => {
                 key={index}
                 cardNumber={index}
                 event={event}
-                backgroundColor={styles.cardBackgroundColor}
-                sectionHeadingLevel={styles.heading.level}
+                cardStyles={styles.cards}
               />
             ))}
           </div>
@@ -260,10 +263,13 @@ export const EventSection: ComponentConfig<EventSectionProps> = {
     },
     styles: {
       backgroundColor: backgroundColors.background3.value,
-      cardBackgroundColor: backgroundColors.background1.value,
       heading: {
         level: 2,
         align: "left",
+      },
+      cards: {
+        headingLevel: 3,
+        backgroundColor: backgroundColors.background1.value,
       },
     },
     analytics: {

--- a/packages/visual-editor/src/components/pageSections/InsightSection.test.tsx
+++ b/packages/visual-editor/src/components/pageSections/InsightSection.test.tsx
@@ -200,7 +200,7 @@ const tests: ComponentTest[] = [
           bgColor: "bg-palette-primary-dark",
           textColor: "text-white",
         },
-        headingLevel: 6,
+        headingLevel: 4,
       },
       data: {
         heading: {
@@ -227,6 +227,109 @@ const tests: ComponentTest[] = [
       liveVisibility: true,
     },
     version: 0,
+    tests: async (page) => {
+      expect(page.getByText("Insights")).toBeVisible();
+      expect(page.getByText("Insight 1")).toBeVisible();
+      expect(page.getByText("Category 1")).toBeVisible();
+      expect(page.getByText("2025")).toBeVisible();
+      expect(page.getByText("CTA")).toBeVisible();
+      expect(page.getByText("Description")).toBeVisible();
+    },
+  },
+  {
+    name: "version 7 props with entity values",
+    document: { c_insights: insightsData, name: "test name" },
+    props: {
+      data: {
+        heading: {
+          field: "name",
+          constantValue: "Insights",
+          constantValueEnabled: false,
+          constantValueOverride: {},
+        },
+        insights: {
+          field: "c_insights",
+          constantValue: { insights: [] },
+          constantValueEnabled: false,
+          constantValueOverride: {},
+        },
+      },
+      styles: {
+        backgroundColor: {
+          bgColor: "bg-palette-secondary-light",
+          textColor: "text-black",
+        },
+        heading: {
+          level: 2,
+          align: "left",
+        },
+        cards: {
+          backgroundColor: { bgColor: "bg-white", textColor: "text-black" },
+          headingLevel: 3,
+        },
+      },
+      liveVisibility: true,
+    },
+    version: 7,
+    tests: async (page) => {
+      expect(page.getByText("test name")).toBeVisible();
+      expect(page.getByText("Fresh Flavors Fast")).toBeVisible();
+      expect(page.getByText("Blog")).toBeVisible();
+      expect(page.getByText("2025")).toBeVisible();
+      expect(page.getByText("Read Now")).toBeVisible();
+      expect(page.getByText("Discover how")).toBeVisible();
+      expect(page.getByText("Beyond the Burger")).toBeVisible();
+      expect(page.getByText("wide range")).toBeVisible();
+      expect(page.getByText("Order Now")).toBeVisible();
+      expect(page.getByText("Our Commitment to Community")).toBeVisible();
+      expect(page.getByText("Impact")).toBeVisible();
+      expect(page.getByText("2018")).toBeVisible();
+      expect(page.getByText("farmers")).toBeVisible();
+    },
+  },
+  {
+    name: "version 7 props with constant value",
+    document: { c_insights: insightsData },
+    props: {
+      data: {
+        heading: {
+          field: "name",
+          constantValue: "Insights",
+          constantValueEnabled: true,
+        },
+        insights: {
+          field: "c_insights",
+          constantValue: {
+            insights: [
+              {
+                name: "Insight 1",
+                category: "Category 1",
+                publishTime: "2025-05-14",
+                description: "Description",
+                cta: { label: "CTA" },
+              },
+            ],
+          },
+          constantValueEnabled: true,
+        },
+      },
+      styles: {
+        backgroundColor: {
+          bgColor: "bg-palette-secondary-light",
+          textColor: "text-black",
+        },
+        heading: {
+          level: 2,
+          align: "left",
+        },
+        cards: {
+          backgroundColor: { bgColor: "bg-white", textColor: "text-black" },
+          headingLevel: 3,
+        },
+      },
+      liveVisibility: true,
+    },
+    version: 7,
     tests: async (page) => {
       expect(page.getByText("Insights")).toBeVisible();
       expect(page.getByText("Insight 1")).toBeVisible();

--- a/packages/visual-editor/src/components/pageSections/InsightSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/InsightSection.tsx
@@ -38,10 +38,13 @@ export interface InsightSectionProps {
   };
   styles: {
     backgroundColor?: BackgroundStyle;
-    cardBackgroundColor?: BackgroundStyle;
     heading: {
       level: HeadingLevel;
       align: "left" | "center" | "right";
+    };
+    cards: {
+      headingLevel: HeadingLevel;
+      backgroundColor?: BackgroundStyle;
     };
   };
   analytics?: {
@@ -79,17 +82,10 @@ const insightSectionFields: Fields<InsightSectionProps> = {
           options: "BACKGROUND_COLOR",
         }
       ),
-      cardBackgroundColor: YextField(
-        msg("fields.cardBackgroundColor", "Card Background Color"),
-        {
-          type: "select",
-          options: "BACKGROUND_COLOR",
-        }
-      ),
       heading: YextField(msg("fields.heading", "Heading"), {
         type: "object",
         objectFields: {
-          level: YextField(msg("fields.headingLevel", "Level"), {
+          level: YextField(msg("fields.level", "Level"), {
             type: "select",
             hasSearch: true,
             options: "HEADING_LEVEL",
@@ -98,6 +94,23 @@ const insightSectionFields: Fields<InsightSectionProps> = {
             type: "radio",
             options: ThemeOptions.ALIGNMENT,
           }),
+        },
+      }),
+      cards: YextField(msg("fields.cards", "Cards"), {
+        type: "object",
+        objectFields: {
+          headingLevel: YextField(msg("fields.headingLevel", "Heading Level"), {
+            type: "select",
+            hasSearch: true,
+            options: "HEADING_LEVEL",
+          }),
+          backgroundColor: YextField(
+            msg("fields.backgroundColor", "Background Color"),
+            {
+              type: "select",
+              options: "BACKGROUND_COLOR",
+            }
+          ),
         },
       }),
     },
@@ -117,20 +130,18 @@ const insightSectionFields: Fields<InsightSectionProps> = {
 const InsightCard = ({
   cardNumber,
   insight,
-  backgroundColor,
-  sectionHeadingLevel,
+  cardStyles,
 }: {
   cardNumber: number;
   insight: InsightStruct;
-  backgroundColor?: BackgroundStyle;
-  sectionHeadingLevel: HeadingLevel;
+  cardStyles: InsightSectionProps["styles"]["cards"];
 }) => {
   const { i18n } = useTranslation();
 
   return (
     <Background
       className="rounded h-full flex flex-col"
-      background={backgroundColor}
+      background={cardStyles.backgroundColor}
     >
       {insight.image ? (
         <Image
@@ -157,14 +168,7 @@ const InsightCard = ({
             </div>
           )}
           {insight.name && (
-            <Heading
-              level={3}
-              semanticLevelOverride={
-                sectionHeadingLevel < 6
-                  ? ((sectionHeadingLevel + 1) as HeadingLevel)
-                  : "span"
-              }
-            >
+            <Heading level={cardStyles.headingLevel}>
               {resolveTranslatableString(insight.name, i18n.language)}
             </Heading>
           )}
@@ -232,8 +236,7 @@ const InsightSectionWrapper = ({ data, styles }: InsightSectionProps) => {
                 key={index}
                 cardNumber={index}
                 insight={insight}
-                backgroundColor={styles.cardBackgroundColor}
-                sectionHeadingLevel={styles.heading.level}
+                cardStyles={styles.cards}
               />
             ))}
           </div>
@@ -263,10 +266,13 @@ export const InsightSection: ComponentConfig<InsightSectionProps> = {
     },
     styles: {
       backgroundColor: backgroundColors.background2.value,
-      cardBackgroundColor: backgroundColors.background1.value,
       heading: {
-        level: 2,
+        level: 3,
         align: "left",
+      },
+      cards: {
+        backgroundColor: backgroundColors.background1.value,
+        headingLevel: 4,
       },
     },
     analytics: {

--- a/packages/visual-editor/src/components/pageSections/NearbyLocations.tsx
+++ b/packages/visual-editor/src/components/pageSections/NearbyLocations.tsx
@@ -39,12 +39,14 @@ export interface NearbyLocationsSectionProps {
   };
   styles: {
     backgroundColor?: BackgroundStyle;
-    cardBackgroundColor?: BackgroundStyle;
     heading: {
       level: HeadingLevel;
       align: "left" | "center" | "right";
     };
-    cardHeadingLevel: HeadingLevel;
+    cards: {
+      headingLevel: HeadingLevel;
+      backgroundColor?: BackgroundStyle;
+    };
     phoneNumberFormat: "domestic" | "international";
     phoneNumberLink: boolean;
     hours: {
@@ -102,17 +104,10 @@ const nearbyLocationsSectionFields: Fields<NearbyLocationsSectionProps> = {
           options: "BACKGROUND_COLOR",
         }
       ),
-      cardBackgroundColor: YextField(
-        msg("fields.cardBackgroundColor", "Card Background Color"),
-        {
-          type: "select",
-          options: "BACKGROUND_COLOR",
-        }
-      ),
       heading: YextField(msg("fields.heading", "Heading"), {
         type: "object",
         objectFields: {
-          level: YextField(msg("fields.headingLevel", "Level"), {
+          level: YextField(msg("fields.level", "Level"), {
             type: "select",
             hasSearch: true,
             options: "HEADING_LEVEL",
@@ -123,14 +118,23 @@ const nearbyLocationsSectionFields: Fields<NearbyLocationsSectionProps> = {
           }),
         },
       }),
-      cardHeadingLevel: YextField(
-        msg("fields.cardHeadingLevel", "Card Heading Level"),
-        {
-          type: "select",
-          hasSearch: true,
-          options: "HEADING_LEVEL",
-        }
-      ),
+      cards: YextField(msg("fields.cards", "Cards"), {
+        type: "object",
+        objectFields: {
+          headingLevel: YextField(msg("fields.headingLevel", "Heading Level"), {
+            type: "select",
+            hasSearch: true,
+            options: "HEADING_LEVEL",
+          }),
+          backgroundColor: YextField(
+            msg("fields.backgroundColor", "Background Color"),
+            {
+              type: "select",
+              options: "BACKGROUND_COLOR",
+            }
+          ),
+        },
+      }),
       phoneNumberFormat: YextField(
         msg("fields.phoneNumberFormat", "Phone Number Format"),
         {
@@ -227,7 +231,7 @@ const LocationCard = ({
 }) => {
   return (
     <Background
-      background={styles?.cardBackgroundColor}
+      background={styles?.cards.backgroundColor}
       className="flex flex-col flew-grow h-full rounded-lg overflow-hidden border p-6 sm:p-8"
       as="section"
     >
@@ -237,7 +241,7 @@ const LocationCard = ({
         className="mb-2"
         href={relativePrefixToRoot && slug ? relativePrefixToRoot + slug : slug}
       >
-        <Heading level={styles?.cardHeadingLevel}>{name}</Heading>
+        <Heading level={styles?.cards.headingLevel}>{name}</Heading>
       </MaybeLink>
       {hours && (
         <div className="mb-2 font-semibold font-body-fontFamily text-body-fontSize">
@@ -470,12 +474,14 @@ export const NearbyLocationsSection: ComponentConfig<NearbyLocationsSectionProps
       },
       styles: {
         backgroundColor: backgroundColors.background1.value,
-        cardBackgroundColor: backgroundColors.background1.value,
         heading: {
-          level: 3,
+          level: 2,
           align: "left",
         },
-        cardHeadingLevel: 4,
+        cards: {
+          backgroundColor: backgroundColors.background1.value,
+          headingLevel: 3,
+        },
         hours: {
           showCurrentStatus: true,
           timeFormat: "12h",

--- a/packages/visual-editor/src/components/pageSections/ProductSection.test.tsx
+++ b/packages/visual-editor/src/components/pageSections/ProductSection.test.tsx
@@ -25,7 +25,7 @@ const productsData = {
         linkType: "OTHER",
       },
       description: {
-        html: '\u003ch1 dir="ltr" style="font-size: 14.67px; font-weight: 400; line-height: 18.67px; color: rgb(0, 0, 0); margin: 0; padding: 3px 2px 3px 2px; position: relative;"\u003e\u003cspan\u003eOur signature burger! A juicy beef patty topped with melted cheese, crisp lettuce, ripe tomato, and our special Galaxy sauce, all served on a toasted sesame seed bun.\u003c/span\u003e\u003c/p\u003e',
+        html: '<p dir="ltr" style="font-size: 14.67px; font-weight: 400; line-height: 18.67px; color: rgb(0, 0, 0); margin: 0; padding: 3px 2px 3px 2px; position: relative;"><span>Our signature burger! A juicy beef patty topped with melted cheese, crisp lettuce, ripe tomato, and our special Galaxy sauce, all served on a toasted sesame seed bun.</span></p>',
       },
       image: {
         height: 2048,
@@ -160,7 +160,7 @@ const tests: ComponentTest[] = [
           textColor: "text-white",
         },
         cardBackgroundColor: { bgColor: "bg-white", textColor: "text-black" },
-        headingLevel: 6,
+        headingLevel: 5,
       },
       liveVisibility: true,
     },
@@ -215,6 +215,108 @@ const tests: ComponentTest[] = [
       liveVisibility: true,
     },
     version: 0,
+    tests: async (page) => {
+      expect(page.getByText("Featured Products")).toBeVisible();
+      expect(page.getByText("Product 1")).toBeVisible();
+      expect(page.getByText("Category")).toBeVisible();
+      expect(page.getByText("Description")).toBeVisible();
+      expect(page.getByText("CTA")).toBeVisible();
+    },
+  },
+  {
+    name: "version 7 props with entity values",
+    document: { c_products: productsData, name: "Test Name" },
+    props: {
+      data: {
+        heading: {
+          field: "name",
+          constantValue: "Featured Products",
+          constantValueEnabled: false,
+          constantValueOverride: {},
+        },
+        products: {
+          field: "c_products",
+          constantValue: { products: [] },
+          constantValueEnabled: false,
+          constantValueOverride: {},
+        },
+      },
+      styles: {
+        backgroundColor: {
+          bgColor: "bg-palette-secondary-light",
+          textColor: "text-black",
+        },
+        heading: {
+          level: 2,
+          align: "left",
+        },
+        cards: {
+          backgroundColor: {
+            bgColor: "bg-palette-primary-light",
+            textColor: "text-black",
+          },
+          headingLevel: 3,
+        },
+      },
+      liveVisibility: true,
+    },
+    version: 7,
+    tests: async (page) => {
+      expect(page.getByText("Test Name")).toBeVisible();
+      expect(page.getByText("Galaxy Burger")).toBeVisible();
+      expect(page.getByText("Burgers")).toBeVisible();
+      expect(page.getByText("Order Now").elements()).toHaveLength(2);
+      expect(page.getByText("Galaxy Salad")).toBeVisible();
+      expect(page.getByText("Galaxy Milkshake")).toBeVisible();
+      expect(page.getByText("Desserts")).toBeVisible();
+      expect(page.getByText("cherry")).toBeVisible();
+    },
+  },
+  {
+    name: "version 7 props with constant value",
+    document: { c_products: productsData },
+    props: {
+      data: {
+        heading: {
+          field: "name",
+          constantValue: "Featured Products",
+          constantValueEnabled: true,
+        },
+        products: {
+          field: "c_products",
+          constantValue: {
+            products: [
+              {
+                name: "Product 1",
+                category: "Category",
+                description: "Description",
+                cta: { label: "CTA" },
+              },
+            ],
+          },
+          constantValueEnabled: true,
+        },
+      },
+      styles: {
+        backgroundColor: {
+          bgColor: "bg-palette-secondary-light",
+          textColor: "text-black",
+        },
+        heading: {
+          level: 2,
+          align: "left",
+        },
+        cards: {
+          backgroundColor: {
+            bgColor: "bg-palette-primary-light",
+            textColor: "text-black",
+          },
+          headingLevel: 3,
+        },
+      },
+      liveVisibility: true,
+    },
+    version: 7,
     tests: async (page) => {
       expect(page.getByText("Featured Products")).toBeVisible();
       expect(page.getByText("Product 1")).toBeVisible();

--- a/packages/visual-editor/src/components/pageSections/ProductSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/ProductSection.tsx
@@ -37,10 +37,13 @@ export interface ProductSectionProps {
   };
   styles: {
     backgroundColor?: BackgroundStyle;
-    cardBackgroundColor?: BackgroundStyle;
     heading: {
       level: HeadingLevel;
       align: "left" | "center" | "right";
+    };
+    cards: {
+      headingLevel: HeadingLevel;
+      backgroundColor?: BackgroundStyle;
     };
   };
   analytics?: {
@@ -78,17 +81,10 @@ const productSectionFields: Fields<ProductSectionProps> = {
           options: "BACKGROUND_COLOR",
         }
       ),
-      cardBackgroundColor: YextField(
-        msg("fields.cardBackgroundColor", "Card Background Color"),
-        {
-          type: "select",
-          options: "BACKGROUND_COLOR",
-        }
-      ),
       heading: YextField(msg("fields.heading", "Heading"), {
         type: "object",
         objectFields: {
-          level: YextField(msg("fields.headingLevel", "Level"), {
+          level: YextField(msg("fields.level", "Level"), {
             type: "select",
             hasSearch: true,
             options: "HEADING_LEVEL",
@@ -97,6 +93,23 @@ const productSectionFields: Fields<ProductSectionProps> = {
             type: "radio",
             options: ThemeOptions.ALIGNMENT,
           }),
+        },
+      }),
+      cards: YextField(msg("fields.cards", "Cards"), {
+        type: "object",
+        objectFields: {
+          headingLevel: YextField(msg("fields.headingLevel", "Heading Level"), {
+            type: "select",
+            hasSearch: true,
+            options: "HEADING_LEVEL",
+          }),
+          backgroundColor: YextField(
+            msg("fields.backgroundColor", "Background Color"),
+            {
+              type: "select",
+              options: "BACKGROUND_COLOR",
+            }
+          ),
         },
       }),
     },
@@ -116,19 +129,17 @@ const productSectionFields: Fields<ProductSectionProps> = {
 const ProductCard = ({
   cardNumber,
   product,
-  backgroundColor,
-  sectionHeadingLevel,
+  cardStyles,
 }: {
   cardNumber: number;
   product: ProductStruct;
-  backgroundColor?: BackgroundStyle;
-  sectionHeadingLevel: HeadingLevel;
+  cardStyles: ProductSectionProps["styles"]["cards"];
 }) => {
   const { i18n } = useTranslation();
   return (
     <Background
       className="flex flex-col rounded-lg overflow-hidden border h-full"
-      background={backgroundColor}
+      background={cardStyles.backgroundColor}
     >
       {product.image ? (
         <Image
@@ -142,15 +153,7 @@ const ProductCard = ({
       <div className="p-8 gap-8 flex flex-col flex-grow">
         <div className="gap-4 flex flex-col">
           {product.name && (
-            <Heading
-              level={3}
-              semanticLevelOverride={
-                sectionHeadingLevel < 6
-                  ? ((sectionHeadingLevel + 1) as HeadingLevel)
-                  : "span"
-              }
-              className="mb-2"
-            >
+            <Heading level={cardStyles.headingLevel} className="mb-2">
               {resolveTranslatableString(product.name, i18n.language)}
             </Heading>
           )}
@@ -210,9 +213,7 @@ const ProductSectionWrapper = ({ data, styles }: ProductSectionProps) => {
           constantValueEnabled={data.heading.constantValueEnabled}
         >
           <div className={`flex ${justifyClass}`}>
-            <Heading level={styles?.heading?.level ?? 2}>
-              {resolvedHeading}
-            </Heading>
+            <Heading level={styles?.heading?.level}>{resolvedHeading}</Heading>
           </div>
         </EntityField>
       )}
@@ -228,8 +229,7 @@ const ProductSectionWrapper = ({ data, styles }: ProductSectionProps) => {
                 key={index}
                 cardNumber={index}
                 product={product}
-                backgroundColor={styles.cardBackgroundColor}
-                sectionHeadingLevel={styles.heading.level}
+                cardStyles={styles.cards}
               />
             ))}
           </div>
@@ -259,10 +259,13 @@ export const ProductSection: ComponentConfig<ProductSectionProps> = {
     },
     styles: {
       backgroundColor: backgroundColors.background2.value,
-      cardBackgroundColor: backgroundColors.background1.value,
       heading: {
         level: 2,
         align: "left",
+      },
+      cards: {
+        backgroundColor: backgroundColors.background1.value,
+        headingLevel: 3,
       },
     },
     analytics: {

--- a/packages/visual-editor/src/components/pageSections/TeamSection.test.tsx
+++ b/packages/visual-editor/src/components/pageSections/TeamSection.test.tsx
@@ -222,6 +222,112 @@ const tests: ComponentTest[] = [
       expect(page.getByText("CTA")).toBeVisible();
     },
   },
+  {
+    name: "version 7 props with entity values",
+    document: { c_team: teamData, name: "Test Name" },
+    props: {
+      data: {
+        heading: {
+          field: "name",
+          constantValue: "Meet Our Team",
+          constantValueEnabled: false,
+          constantValueOverride: {},
+        },
+        people: {
+          field: "c_team",
+          constantValue: { people: [] },
+          constantValueEnabled: false,
+          constantValueOverride: {},
+        },
+      },
+      styles: {
+        backgroundColor: {
+          bgColor: "bg-palette-secondary-dark",
+          textColor: "text-white",
+        },
+        heading: {
+          level: 2,
+          align: "left",
+        },
+        cards: {
+          backgroundColor: {
+            bgColor: "bg-palette-secondary-light",
+            textColor: "text-black",
+          },
+          headingLevel: 3,
+        },
+      },
+      liveVisibility: true,
+    },
+    version: 7,
+    tests: async (page) => {
+      expect(page.getByText("Captain Cosmo")).toBeVisible();
+      expect(page.getByText("Chef Nova")).toBeVisible();
+      expect(page.getByText("Admiral Aster")).toBeVisible();
+      expect(page.getByText("Founder & CEO")).toBeVisible();
+      expect(page.getByText("Culinary Director")).toBeVisible();
+      expect(page.getByText("Operations Manager")).toBeVisible();
+      expect(page.getByText("Email Me").elements()).toHaveLength(2);
+      expect(page.getByText("(800) 555-1010")).toBeVisible();
+      expect(page.getByText("+52 800 555 1010")).toBeVisible();
+    },
+  },
+  {
+    name: "version 7 props with constant value",
+    document: { c_team: teamData },
+    props: {
+      data: {
+        heading: {
+          field: "name",
+          constantValue: "Meet Our Team",
+          constantValueEnabled: true,
+          constantValueOverride: {},
+        },
+        people: {
+          field: "c_team",
+          constantValue: {
+            people: [
+              {
+                name: "Name",
+                title: "Title",
+                phoneNumber: "8888888888",
+                email: "email",
+                cta: { label: "CTA" },
+              },
+            ],
+          },
+          constantValueEnabled: true,
+        },
+      },
+      styles: {
+        backgroundColor: {
+          bgColor: "bg-palette-secondary-dark",
+          textColor: "text-white",
+        },
+        heading: {
+          level: 2,
+          align: "left",
+        },
+        cards: {
+          backgroundColor: {
+            bgColor: "bg-palette-secondary-light",
+            textColor: "text-black",
+          },
+          headingLevel: 3,
+        },
+      },
+      liveVisibility: true,
+    },
+    version: 7,
+    tests: async (page) => {
+      expect(page.getByText("Meet Our Team")).toBeVisible();
+      expect(page.getByText("Name")).toBeVisible();
+      expect(page.getByText("Title")).toBeVisible();
+      expect(page.getByText("8888888888")).toBeVisible();
+      expect(page.getByText("email")).toBeVisible();
+      expect(page.getByText("CTA")).toBeVisible();
+    },
+  },
 ];
 
 const testsWithViewports: ComponentTest[] = [

--- a/packages/visual-editor/src/components/pageSections/TeamSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/TeamSection.tsx
@@ -32,17 +32,20 @@ import { AnalyticsScopeProvider } from "@yext/pages-components";
 import { defaultPerson } from "../../internal/puck/constant-value-fields/TeamSection.tsx";
 
 export interface TeamSectionProps {
+  data: {
+    heading: YextEntityField<TranslatableString>;
+    people: YextEntityField<TeamSectionType>;
+  };
   styles: {
     backgroundColor?: BackgroundStyle;
-    cardBackgroundColor?: BackgroundStyle;
     heading: {
       level: HeadingLevel;
       align: "left" | "center" | "right";
     };
-  };
-  data: {
-    heading: YextEntityField<TranslatableString>;
-    people: YextEntityField<TeamSectionType>;
+    cards: {
+      headingLevel: HeadingLevel;
+      backgroundColor?: BackgroundStyle;
+    };
   };
   analytics?: {
     scope?: string;
@@ -79,17 +82,10 @@ const TeamSectionFields: Fields<TeamSectionProps> = {
           options: "BACKGROUND_COLOR",
         }
       ),
-      cardBackgroundColor: YextField(
-        msg("fields.cardBackgroundColor", "Card Background Color"),
-        {
-          type: "select",
-          options: "BACKGROUND_COLOR",
-        }
-      ),
       heading: YextField(msg("fields.heading", "Heading"), {
         type: "object",
         objectFields: {
-          level: YextField(msg("fields.headingLevel", "Level"), {
+          level: YextField(msg("fields.level", "Level"), {
             type: "select",
             hasSearch: true,
             options: "HEADING_LEVEL",
@@ -98,6 +94,23 @@ const TeamSectionFields: Fields<TeamSectionProps> = {
             type: "radio",
             options: ThemeOptions.ALIGNMENT,
           }),
+        },
+      }),
+      cards: YextField(msg("fields.cards", "Cards"), {
+        type: "object",
+        objectFields: {
+          headingLevel: YextField(msg("fields.headingLevel", "Heading Level"), {
+            type: "select",
+            hasSearch: true,
+            options: "HEADING_LEVEL",
+          }),
+          backgroundColor: YextField(
+            msg("fields.backgroundColor", "Background Color"),
+            {
+              type: "select",
+              options: "BACKGROUND_COLOR",
+            }
+          ),
         },
       }),
     },
@@ -117,19 +130,20 @@ const TeamSectionFields: Fields<TeamSectionProps> = {
 const PersonCard = ({
   cardNumber,
   person,
-  backgroundColor,
-  sectionHeadingLevel,
+  cardStyles,
 }: {
   cardNumber: number;
   person: PersonStruct;
-  backgroundColor?: BackgroundStyle;
-  sectionHeadingLevel: HeadingLevel;
+  cardStyles: TeamSectionProps["styles"]["cards"];
 }) => {
   const { i18n } = useTranslation();
 
   return (
     <div className="flex flex-col rounded-lg overflow-hidden border bg-white h-full">
-      <Background background={backgroundColor} className="flex p-8 gap-6">
+      <Background
+        background={cardStyles.backgroundColor}
+        className="flex p-8 gap-6"
+      >
         <div className="w-20 h-20 flex-shrink-0 rounded-full overflow-hidden">
           {person.headshot && (
             <Image
@@ -144,14 +158,7 @@ const PersonCard = ({
         </div>
         <div className="flex flex-col justify-center gap-1">
           {person.name && (
-            <Heading
-              level={3}
-              semanticLevelOverride={
-                sectionHeadingLevel < 6
-                  ? ((sectionHeadingLevel + 1) as HeadingLevel)
-                  : "span"
-              }
-            >
+            <Heading level={cardStyles.headingLevel}>
               {resolveTranslatableString(person.name, i18n.language)}
             </Heading>
           )}
@@ -262,8 +269,7 @@ const TeamSectionWrapper = ({ data, styles }: TeamSectionProps) => {
                 key={index}
                 cardNumber={index}
                 person={person}
-                backgroundColor={styles.cardBackgroundColor}
-                sectionHeadingLevel={styles.heading.level}
+                cardStyles={styles.cards}
               />
             ))}
           </div>
@@ -293,10 +299,13 @@ export const TeamSection: ComponentConfig<TeamSectionProps> = {
     },
     styles: {
       backgroundColor: backgroundColors.background3.value,
-      cardBackgroundColor: backgroundColors.background1.value,
       heading: {
         level: 2,
         align: "left",
+      },
+      cards: {
+        backgroundColor: backgroundColors.background1.value,
+        headingLevel: 3,
       },
     },
     analytics: {

--- a/packages/visual-editor/src/components/pageSections/TestimonialSection.test.tsx
+++ b/packages/visual-editor/src/components/pageSections/TestimonialSection.test.tsx
@@ -75,7 +75,7 @@ const tests: ComponentTest[] = [
           bgColor: "bg-palette-primary-dark",
           textColor: "text-white",
         },
-        headingLevel: 6,
+        headingLevel: 4,
       },
       data: {
         heading: {
@@ -193,6 +193,57 @@ const tests: ComponentTest[] = [
       liveVisibility: true,
     },
     version: 1,
+    tests: async (page) => {
+      expect(page.getByText("Featured Testimonials")).toBeVisible();
+      expect(page.getByText("Name")).toBeVisible();
+      expect(page.getByText("Description")).toBeVisible();
+      expect(page.getByText("Jan 1, 2025")).toBeVisible();
+    },
+  },
+  {
+    name: "version 7 props with constant value",
+    document: { c_testimonials: testimonialData },
+    props: {
+      data: {
+        heading: {
+          field: "name",
+          constantValue: "Featured Testimonials",
+          constantValueEnabled: true,
+        },
+        testimonials: {
+          field: "c_testimonials",
+          constantValue: {
+            testimonials: [
+              {
+                description: "Description",
+                contributorName: "Name",
+                contributionDate: "2025-01-01",
+              },
+            ],
+          },
+          constantValueEnabled: true,
+        },
+      },
+      styles: {
+        backgroundColor: {
+          bgColor: "bg-palette-primary-dark",
+          textColor: "text-white",
+        },
+        heading: {
+          level: 2,
+          align: "left",
+        },
+        cards: {
+          backgroundColor: {
+            bgColor: "bg-palette-primary-light",
+            textColor: "text-black",
+          },
+          headingLevel: 3,
+        },
+      },
+      liveVisibility: true,
+    },
+    version: 7,
     tests: async (page) => {
       expect(page.getByText("Featured Testimonials")).toBeVisible();
       expect(page.getByText("Name")).toBeVisible();

--- a/packages/visual-editor/src/components/pageSections/TestimonialSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/TestimonialSection.tsx
@@ -34,10 +34,13 @@ export interface TestimonialSectionProps {
   };
   styles: {
     backgroundColor?: BackgroundStyle;
-    cardBackgroundColor?: BackgroundStyle;
     heading: {
       level: HeadingLevel;
       align: "left" | "center" | "right";
+    };
+    cards: {
+      headingLevel: HeadingLevel;
+      backgroundColor?: BackgroundStyle;
     };
   };
   liveVisibility: boolean;
@@ -75,17 +78,10 @@ const testimonialSectionFields: Fields<TestimonialSectionProps> = {
           options: "BACKGROUND_COLOR",
         }
       ),
-      cardBackgroundColor: YextField(
-        msg("fields.cardBackgroundColor", "Card Background Color"),
-        {
-          type: "select",
-          options: "BACKGROUND_COLOR",
-        }
-      ),
       heading: YextField(msg("fields.heading", "Heading"), {
         type: "object",
         objectFields: {
-          level: YextField(msg("fields.headingLevel", "Level"), {
+          level: YextField(msg("fields.level", "Level"), {
             type: "select",
             hasSearch: true,
             options: "HEADING_LEVEL",
@@ -94,6 +90,23 @@ const testimonialSectionFields: Fields<TestimonialSectionProps> = {
             type: "radio",
             options: ThemeOptions.ALIGNMENT,
           }),
+        },
+      }),
+      cards: YextField(msg("fields.cards", "Cards"), {
+        type: "object",
+        objectFields: {
+          headingLevel: YextField(msg("fields.headingLevel", "Heading Level"), {
+            type: "select",
+            hasSearch: true,
+            options: "HEADING_LEVEL",
+          }),
+          backgroundColor: YextField(
+            msg("fields.backgroundColor", "Background Color"),
+            {
+              type: "select",
+              options: "BACKGROUND_COLOR",
+            }
+          ),
         },
       }),
     },
@@ -112,12 +125,10 @@ const testimonialSectionFields: Fields<TestimonialSectionProps> = {
 
 const TestimonialCard = ({
   testimonial,
-  backgroundColor,
-  sectionHeadingLevel,
+  cardStyles,
 }: {
   testimonial: TestimonialStruct;
-  backgroundColor?: BackgroundStyle;
-  sectionHeadingLevel: HeadingLevel;
+  cardStyles: TestimonialSectionProps["styles"]["cards"];
 }) => {
   const { i18n } = useTranslation();
 
@@ -129,16 +140,9 @@ const TestimonialCard = ({
       >
         {resolveTranslatableRichText(testimonial.description, i18n.language)}
       </Background>
-      <Background background={backgroundColor} className="p-8">
+      <Background background={cardStyles.backgroundColor} className="p-8">
         {testimonial.contributorName && (
-          <Heading
-            level={3}
-            semanticLevelOverride={
-              sectionHeadingLevel < 6
-                ? ((sectionHeadingLevel + 1) as HeadingLevel)
-                : "span"
-            }
-          >
+          <Heading level={cardStyles.headingLevel}>
             {resolveTranslatableString(
               testimonial.contributorName,
               i18n.language
@@ -207,8 +211,7 @@ const TestimonialSectionWrapper = ({
               <TestimonialCard
                 key={index}
                 testimonial={testimonial}
-                backgroundColor={styles.cardBackgroundColor}
-                sectionHeadingLevel={styles?.heading?.level}
+                cardStyles={styles.cards}
               />
             ))}
           </div>
@@ -224,10 +227,13 @@ export const TestimonialSection: ComponentConfig<TestimonialSectionProps> = {
   defaultProps: {
     styles: {
       backgroundColor: backgroundColors.background2.value,
-      cardBackgroundColor: backgroundColors.background1.value,
       heading: {
         level: 2,
         align: "left",
+      },
+      cards: {
+        backgroundColor: backgroundColors.background1.value,
+        headingLevel: 3,
       },
     },
     data: {


### PR DESCRIPTION
This added card heading level to relevant components. 

Checked with aaron and we wanted it look like: 
```
styles: {
  cards: {
     backgroundColor: ...
     headingLevel: ....
  }
}
```

And we want the card heading level to default to h3. 

Added migration and tests. 