### PR TITLE
fix: re-add directory card border

### DIFF
--- a/packages/visual-editor/src/components/Directory.tsx
+++ b/packages/visual-editor/src/components/Directory.tsx
@@ -108,7 +108,7 @@ const DirectoryCard = ({
 }) => {
   return (
     <Background
-      className="rounded h-full flex flex-col"
+      className="h-full flex flex-col p-8 border border-gray-400 rounded gap-4"
       background={cardStyles.backgroundColor}
     >
       <div>


### PR DESCRIPTION
Got lost in a recent PR; noticed while reviewing the new screenshots