### PR TITLE
fix: update hero/promo images on mobile

### DIFF
--- a/packages/visual-editor/src/components/pageSections/HeroSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/HeroSection.tsx
@@ -322,6 +322,7 @@ const HeroSectionWrapper = ({ data, styles }: HeroSectionProps) => {
               image={resolvedHero?.image}
               aspectRatio={styles.image.aspectRatio}
               width={styles.image.width || 640}
+              className="max-w-full sm:max-w-initial"
             />
           </div>
         </EntityField>

--- a/packages/visual-editor/src/components/pageSections/PromoSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/PromoSection.tsx
@@ -169,6 +169,7 @@ const PromoWrapper: React.FC<PromoSectionProps> = ({ data, styles }) => {
                 : 1.78)
             }
             width={styles.image.width || 640}
+            className="max-w-full sm:max-w-initial"
           />
         </EntityField>
       )}


### PR DESCRIPTION
The width set in props usually exceeds the mobile screen width. I think there's still some adjustments to make because the new system is not very responsive but this makes it less messy for mobile sites

Before:
![mobile  version 0 props using constant values](https://github.com/user-attachments/assets/5aef2110-4ba4-4d5f-bffc-5793fac3eb60)


After:

https://github.com/user-attachments/assets/691e6d3a-d604-46ac-b7c7-303da8cec286


