### PR TITLE
fix: display heading spans as block

### DIFF
--- a/packages/visual-editor/src/components/atoms/heading.tsx
+++ b/packages/visual-editor/src/components/atoms/heading.tsx
@@ -106,6 +106,7 @@ export const Heading = React.forwardRef<HTMLHeadingElement, HeadingProps>(
             transform,
             level,
           }),
+          Tag === "span" && "block",
           className
         )}
         ref={ref}


### PR DESCRIPTION
When the section heading is h6, the subheadings are spans. These should display: block so they render the same as headings

Before:
<img width="1064" alt="Screenshot 2025-07-09 at 11 34 34 AM" src="https://github.com/user-attachments/assets/9f19d02c-2365-4862-9ea3-fa1fe0da2895" />

After:
<img width="1069" alt="Screenshot 2025-07-09 at 11 35 36 AM" src="https://github.com/user-attachments/assets/72d4baff-245d-4325-a579-75802f37f807" />
