### PR TITLE
fix: text wrapping for footer links

### DIFF
--- a/packages/visual-editor/src/components/ExpandedFooter.tsx
+++ b/packages/visual-editor/src/components/ExpandedFooter.tsx
@@ -413,23 +413,23 @@ const ExpandedFooterWrapper = ({
           </div>
         </div>
         {expandedFooter ? (
-          <div className="grid grid-cols-1 md:grid-cols-4 w-full text-center md:text-left justify-items-center md:justify-items-start gap-6 md:gap-0">
-            {expandedFooterLinks.map((item, index) => (
-              <EntityField
-                constantValueEnabled
-                key={index}
-                displayName={pt(
-                  "fields.expandedFooterLinks",
-                  "Expanded Footer Links"
-                )}
-              >
+          <EntityField
+            constantValueEnabled
+            displayName={pt(
+              "fields.expandedFooterLinks",
+              "Expanded Footer Links"
+            )}
+          >
+            <div className="grid grid-cols-1 md:grid-cols-4 w-full text-center md:text-left justify-items-center md:justify-items-start gap-6">
+              {expandedFooterLinks.map((item, index) => (
                 <ExpandedFooterLinks
                   label={resolveTranslatableString(item.label, i18n.language)}
                   links={item.links}
+                  key={index}
                 />
-              </EntityField>
-            ))}
-          </div>
+              ))}
+            </div>
+          </EntityField>
         ) : (
           <div className="w-full">
             <EntityField
@@ -531,7 +531,7 @@ const FooterLinks = ({
               label={resolveTranslatableString(item.label, i18n.language)}
               linkType={item.linkType}
               link={item.link}
-              className={`justify-center md:justify-start`}
+              className="justify-center md:justify-start block break-words whitespace-normal"
             />
           </li>
         );
@@ -550,19 +550,19 @@ const ExpandedFooterLinks = ({
   const { i18n } = useTranslation();
 
   return (
-    <ul className={`flex flex-col items-center md:items-start gap-4`}>
-      <li>
-        <Body>{label}</Body>
+    <ul className={`flex flex-col items-center md:items-start gap-4 w-full`}>
+      <li className="w-full">
+        <Body className="break-words">{label}</Body>
       </li>
       {links.map((item, index) => (
-        <li key={index}>
+        <li key={index} className="w-full">
           <CTA
             variant={"headerFooterMainLink"}
             eventName={`cta${index}-Link-${index + 1}`}
             label={resolveTranslatableString(item.label, i18n.language)}
             linkType={item.linkType}
             link={item.link}
-            className={`justify-start `}
+            className={"justify-start block break-words whitespace-normal"}
           />
         </li>
       ))}
@@ -716,6 +716,7 @@ const FooterIcons = ({
             eventName={`socialLink.${label.toLowerCase()}`}
             ariaLabel={`${label} ${t("link", "link")}`}
             alwaysHideCaret={true}
+            className="block break-words whitespace-normal"
           />
         ))}
       </div>


### PR DESCRIPTION
<img width="418" height="741" alt="Screenshot 2025-07-10 at 1 07 37 PM" src="https://github.com/user-attachments/assets/5497147c-d478-4d2c-8322-c3a68f31e6a2" />
<img width="1073" height="451" alt="Screenshot 2025-07-10 at 1 07 33 PM" src="https://github.com/user-attachments/assets/883d5d1d-24dd-4210-a68a-9e245dbc610a" />
<img width="1077" height="331" alt="Screenshot 2025-07-10 at 1 01 37 PM" src="https://github.com/user-attachments/assets/6bc51bb7-6493-4ba5-8275-55a830958016" />
<img width="405" height="742" alt="Screenshot 2025-07-10 at 1 01 32 PM" src="https://github.com/user-attachments/assets/9ad3de4b-1fdb-4a2f-a5d8-9a75fde852e1" />

The entity field tooltip was also causing some boxing issues so I moved it outside all the links, which I think is fine because it just says "static content"