### PR TITLE
fix: copyright message alignment based on secondary links alignment

### DIFF
--- a/packages/visual-editor/src/components/ExpandedFooter.tsx
+++ b/packages/visual-editor/src/components/ExpandedFooter.tsx
@@ -376,7 +376,7 @@ const ExpandedFooterWrapper = ({
         as="footer"
         verticalPadding={"footer"}
         background={backgroundColor}
-        className={`flex flex-col ${primaryLinksAlignment === "right" ? `md:flex-row` : `md:flex-row-reverse`}  md:justify-start w-full md:items-start  gap-8 md:gap-10`}
+        className={`flex flex-col ${primaryLinksAlignment === "right" ? `md:flex-row` : `md:flex-row-reverse`} md:justify-start w-full md:items-start gap-8 md:gap-10`}
       >
         <div className="flex flex-col gap-10 md:gap-8">
           <EntityField
@@ -486,7 +486,7 @@ const ExpandedFooterWrapper = ({
           as="footer"
           verticalPadding={"footerSecondary"}
           background={secondaryBackgroundColor}
-          className={`flex flex-col gap-5 ${secondaryLinksAlignment === "left" ? "md:items-start" : "md:flex-row-reverse md:justify-between"}`}
+          className={`flex flex-col gap-5 ${secondaryLinksAlignment === "left" ? "md:items-start" : "md:items-end"}`}
         >
           <EntityField
             constantValueEnabled


### PR DESCRIPTION
[Ticket](https://yexttest.atlassian.net/browse/SUMO-7528)

Copyright section aligned with secondary links alignment

<img width="1254" height="421" alt="Screenshot 2025-07-11 at 12 51 29 AM" src="https://github.com/user-attachments/assets/9d11d19b-0a9f-44c1-9ecd-9f6da7b96fac" />
<img width="1280" height="416" alt="Screenshot 2025-07-11 at 12 55 52 AM" src="https://github.com/user-attachments/assets/add75c53-db54-4622-ac0f-8abbf995bdfa" />
