### PR TITLE
fix: image rendering on live page

### DIFF
--- a/packages/visual-editor/src/components/pageSections/PromoSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/PromoSection.tsx
@@ -160,17 +160,19 @@ const PromoWrapper: React.FC<PromoSectionProps> = ({ data, styles }) => {
           fieldId={data.promo.field}
           constantValueEnabled={data.promo.constantValueOverride.image}
         >
-          <Image
-            image={resolvedPromo.image}
-            aspectRatio={
-              styles.image.aspectRatio ??
-              (resolvedPromo.image.width && resolvedPromo.image.height
-                ? resolvedPromo.image.width / resolvedPromo.image.height
-                : 1.78)
-            }
-            width={styles.image.width || 640}
-            className="max-w-full sm:max-w-initial rounded-image-borderRadius"
-          />
+          <div className="w-full">
+            <Image
+              image={resolvedPromo.image}
+              aspectRatio={
+                styles.image.aspectRatio ??
+                (resolvedPromo.image.width && resolvedPromo.image.height
+                  ? resolvedPromo.image.width / resolvedPromo.image.height
+                  : 1.78)
+              }
+              width={styles.image.width || 640}
+              className="max-w-full sm:max-w-initial rounded-image-borderRadius"
+            />
+          </div>
         </EntityField>
       )}
       <div className="flex flex-col justify-center gap-y-4 md:gap-y-8 md:px-16 pt-4 md:pt-0 w-full break-words">

--- a/packages/visual-editor/src/editor/EntityField.tsx
+++ b/packages/visual-editor/src/editor/EntityField.tsx
@@ -50,11 +50,11 @@ export const EntityField = ({
   }
 
   return (
-    <div>
+    <span>
       <TooltipProvider>
         <Tooltip open={!!tooltipContent && tooltipsVisible}>
           <TooltipTrigger asChild>
-            <div
+            <span
               className={
                 tooltipsVisible
                   ? "ve-outline-2 ve-outline-dotted" +
@@ -63,7 +63,7 @@ export const EntityField = ({
               }
             >
               <MemoizedChildren>{children}</MemoizedChildren>
-            </div>
+            </span>
           </TooltipTrigger>
           <TooltipContent
             zoomWithViewport
@@ -77,7 +77,7 @@ export const EntityField = ({
           </TooltipContent>
         </Tooltip>
       </TooltipProvider>
-    </div>
+    </span>
   );
 };
 


### PR DESCRIPTION
Verified in dev that the image size is the same in both the editor and live page.