### PR TITLE
feat: use starter template for StackBlitz

### DIFF
--- a/.github/workflows/create-dev-release.yml
+++ b/.github/workflows/create-dev-release.yml
@@ -37,7 +37,7 @@ jobs:
         run: pnpm run build
 
       - name: "Publish temporary version with pkg.pr.new"
-        run: pnpx pkg-pr-new publish './packages/visual-editor'
+        run: pnpx pkg-pr-new publish './packages/visual-editor' --template './starter'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This should allow us to test using the starter in the generated StackBlitz link, will test as the workflow runs