### PR TITLE
feat: use pageset contentEndpointId

### DIFF
--- a/packages/visual-editor/src/components/header/languageDropdown.tsx
+++ b/packages/visual-editor/src/components/header/languageDropdown.tsx
@@ -236,6 +236,7 @@ export function parseDocumentForLanguageDropdown(
     try {
       const pagesetJson = JSON.parse(document?._pageset);
       contentEndpointId =
+        pagesetJson?.contentEndpointId ??
         pagesetJson?.typeConfig?.entityConfig?.contentEndpointId;
       locales = pagesetJson?.scope?.locales;
     } catch (e) {

--- a/packages/visual-editor/src/components/pageSections/NearbyLocations.tsx
+++ b/packages/visual-editor/src/components/pageSections/NearbyLocations.tsx
@@ -517,6 +517,7 @@ function parseDocument(
     try {
       const pagesetJson = JSON.parse(document?._pageset);
       contentEndpointId =
+        pagesetJson?.contentEndpointId ??
         pagesetJson?.typeConfig?.entityConfig?.contentEndpointId;
     } catch (e) {
       console.error("Failed to parse pageset from document. err=", e);


### PR DESCRIPTION
Uses the contentEndpointId from the pageset.

Fallsback to the contentEndpointId on the typeconfig if the pageset contentEndpointId is missing.