### PR TITLE
fix: long directory root causes breadcrumbs overflow

### DIFF
--- a/packages/visual-editor/src/components/pageSections/Breadcrumbs.test.tsx
+++ b/packages/visual-editor/src/components/pageSections/Breadcrumbs.test.tsx
@@ -110,7 +110,8 @@ const tests: ComponentTest[] = [
     },
     props: {
       data: {
-        directoryRoot: "Locations Directory",
+        directoryRoot:
+          "Locations Directory with a really really really really long directory root prop - Locations Directory - Locations Directory - Locations Directory - Locations Directory",
       },
       styles: {
         backgroundColor: {

--- a/packages/visual-editor/src/components/pageSections/Breadcrumbs.tsx
+++ b/packages/visual-editor/src/components/pageSections/Breadcrumbs.tsx
@@ -164,7 +164,7 @@ export const BreadcrumbsComponent = ({
       aria-label={t("breadcrumb", "Breadcrumb")}
       background={styles?.backgroundColor}
     >
-      <ol className="flex flex-wrap">
+      <ol className="inline">
         {breadcrumbs.map(({ name, slug }, idx) => {
           const isRoot = idx === 0;
           const isLast = idx === breadcrumbs.length - 1;
@@ -172,15 +172,18 @@ export const BreadcrumbsComponent = ({
             ? relativePrefixToRoot + slug
             : slug;
           return (
-            <li key={idx} className="flex items-center">
+            <li key={idx} className="inline">
               <MaybeLink
                 eventName={`link${idx}`}
                 href={isLast ? "" : href}
                 // Force body-sm and link-fontFamily for all breadcrumbs
-                className="text-body-sm-fontSize font-link-fontFamily"
+                className="text-body-sm-fontSize font-link-fontFamily inline"
                 alwaysHideCaret={true}
               >
-                <Body variant={"sm"}>
+                <Body
+                  variant="sm"
+                  className="break-words whitespace-normal inline"
+                >
                   {isRoot && directoryRoot ? directoryRoot : name}
                 </Body>
               </MaybeLink>


### PR DESCRIPTION
old: 
<img width="3680" height="2382" alt="image" src="https://github.com/user-attachments/assets/9bf2c1c5-6d0f-4db2-a6dc-b0d683ebcbe2" />
