### PR TITLE
chore: update screenshot writing

### DIFF
--- a/packages/visual-editor/src/components/testing/componentTests.d.ts
+++ b/packages/visual-editor/src/components/testing/componentTests.d.ts
@@ -20,7 +20,9 @@ declare module "@vitest/browser/context" {
   interface BrowserCommands {
     compareScreenshot: (
       screenshotName: string,
-      updatedScreenshotData: string
-    ) => Promise<number>;
+      updatedScreenshotData: string,
+      customThreshold?: number,
+      ignoreExact?: number[]
+    ) => Promise<{ passes: boolean; numDiffPixels: number }>;
   }
 }

--- a/packages/visual-editor/src/components/testing/componentTests.setup.ts
+++ b/packages/visual-editor/src/components/testing/componentTests.setup.ts
@@ -43,29 +43,16 @@ expect.extend({
       })
     );
 
-    const numDiffPixels = await commands.compareScreenshot(
+    const { passes, numDiffPixels } = await commands.compareScreenshot(
       screenshotName,
-      updatedScreenshotData
+      updatedScreenshotData,
+      options?.customThreshold,
+      options?.ignoreExact
     );
 
-    if ((options?.ignoreExact ?? []).includes(numDiffPixels)) {
-      return {
-        pass: true,
-        message: () =>
-          `Screenshots differed by ${numDiffPixels} pixels. Ignoring difference.`,
-      };
-    }
-
-    if (numDiffPixels > (options?.customThreshold ?? 0)) {
-      return {
-        pass: false,
-        message: () => `Screenshots differed by ${numDiffPixels} pixels`,
-      };
-    }
-
     return {
-      pass: true,
-      message: () => "Screenshots matched",
+      pass: passes,
+      message: () => `Screenshots differed by ${numDiffPixels} pixels`,
     };
   },
 });


### PR DESCRIPTION
Moves the threshold logic to the node side, so we only write screenshots if they exceed the threshold options

Also makes new screenshots fail the tests so that the commit step runs