### PR TITLE
fix: small translation bugs for ExpandedFooter

### DIFF
--- a/packages/visual-editor/src/components/footer/ExpandedFooter.tsx
+++ b/packages/visual-editor/src/components/footer/ExpandedFooter.tsx
@@ -53,6 +53,17 @@ const defaultFooterLink = {
   link: "#",
 };
 
+const defaultExpandedFooterLinkSection = {
+  label: { en: "Footer Label", hasLocalizedValue: "true" as const },
+  links: [
+    defaultFooterLink,
+    defaultFooterLink,
+    defaultFooterLink,
+    defaultFooterLink,
+    defaultFooterLink,
+  ],
+};
+
 export const validPatterns: Record<string, RegExp> = {
   xLink: /^https:\/\/(www\.)?(x\.com|twitter\.com)\/.+/,
   facebookLink: /^https:\/\/(www\.)?facebook\.com\/.+/,
@@ -195,8 +206,8 @@ const expandedFooterSectionFields: Fields<ExpandedFooterProps> = {
             {
               type: "array",
               arrayFields: {
-                label: YextField(msg("fields.label", "Label"), {
-                  type: "text",
+                label: TranslatableStringField(msg("fields.label", "Label"), {
+                  types: ["type.string"],
                 }),
                 links: YextField(msg("fields.links", "Links"), {
                   type: "array",
@@ -815,46 +826,10 @@ export const ExpandedFooter: ComponentConfig<ExpandedFooterProps> = {
         utilityImages: [],
         expandedFooter: false,
         expandedFooterLinks: [
-          {
-            label: "Footer Label",
-            links: [
-              defaultFooterLink,
-              defaultFooterLink,
-              defaultFooterLink,
-              defaultFooterLink,
-              defaultFooterLink,
-            ],
-          },
-          {
-            label: "Footer Label",
-            links: [
-              defaultFooterLink,
-              defaultFooterLink,
-              defaultFooterLink,
-              defaultFooterLink,
-              defaultFooterLink,
-            ],
-          },
-          {
-            label: "Footer Label",
-            links: [
-              defaultFooterLink,
-              defaultFooterLink,
-              defaultFooterLink,
-              defaultFooterLink,
-              defaultFooterLink,
-            ],
-          },
-          {
-            label: "Footer Label",
-            links: [
-              defaultFooterLink,
-              defaultFooterLink,
-              defaultFooterLink,
-              defaultFooterLink,
-              defaultFooterLink,
-            ],
-          },
+          defaultExpandedFooterLinkSection,
+          defaultExpandedFooterLinkSection,
+          defaultExpandedFooterLinkSection,
+          defaultExpandedFooterLinkSection,
         ],
       },
       secondaryFooter: {

--- a/packages/visual-editor/src/utils/resolveComponentData.test.tsx
+++ b/packages/visual-editor/src/utils/resolveComponentData.test.tsx
@@ -265,6 +265,11 @@ describe("resolveComponentData", () => {
       expect(resolveComponentData(data, "fr", mockDocument)).toBe("");
     });
 
+    it("returns an empty string if the locale is missing from a non-entity TranslatableString", () => {
+      const data: TranslatableString = { hasLocalizedValue: "true", en: "Hi" };
+      expect(resolveComponentData(data, "fr")).toBe("");
+    });
+
     it("returns an empty string if the locale is missing from a TranslatableRichText", () => {
       const data: TranslatableRichText = {
         hasLocalizedValue: "true",

--- a/packages/visual-editor/src/utils/resolveComponentData.tsx
+++ b/packages/visual-editor/src/utils/resolveComponentData.tsx
@@ -101,6 +101,11 @@ const resolveTranslatableType = (
     return toStringOrElement(value[locale]);
   }
 
+  // Handle missing translation
+  if (value.hasLocalizedValue === "true" && !value[locale]) {
+    return "";
+  }
+
   if (Array.isArray(value)) {
     return value.map((item) => resolveTranslatableType(item, locale));
   }


### PR DESCRIPTION
Noticed while doing the translation warning updates
- the expanded footer label wasn't a translatable string
- [object Object] sometimes appeared in the box