### PR TITLE
feat: support category filtering

### DIFF
--- a/packages/visual-editor/src/internal/hooks/useMessageReceivers.ts
+++ b/packages/visual-editor/src/internal/hooks/useMessageReceivers.ts
@@ -95,7 +95,8 @@ export const useCommonMessageReceivers = (
     if (puckConfig) {
       puckConfig = filterComponentsFromConfig(
         puckConfig,
-        payload.additionalLayoutComponents
+        payload.additionalLayoutComponents,
+        payload.additionalLayoutCategories
       );
     } else {
       throw new Error(

--- a/packages/visual-editor/src/vite-plugin/templates/main.tsx
+++ b/packages/visual-editor/src/vite-plugin/templates/main.tsx
@@ -93,7 +93,8 @@ const Location: Template<TemplateRenderProps> = (props) => {
   const { document } = props;
   const filteredConfig = filterComponentsFromConfig(
     mainConfig,
-    document?._additionalLayoutComponents
+    document?._additionalLayoutComponents,
+    document?._additionalLayoutCategories
   );
 
   return (


### PR DESCRIPTION
This PR adds support for category filtering.
Slack thread for additional context: https://yext.slack.com/archives/C06A06BCUUF/p1754493867337909

J=WAT-5002
TEST=manual

referenced this packed version in a starter branch and tested in platform.
1. When the product feature is enabled, the core info category and its atoms appear in the Components column of the Editor. User can drag the grid and subcomponents onto the page.
2. When the product feature is disabled, the core info category and its atoms are hidden the Components column. Any existing grid sections already placed on the page will show a "No configuration" message in the Editor. These sections will not appear on the live site.
3. Currently, the atoms under the core info category are exclusive to that category. However, tested scenarios confirm that if an atom is shared across multiple categories:
- If the user has the atom both standalone and inside a grid, disabling the feature flag only removes the grid and its contents.
- The standalone atom remains unaffected and continues to render as expected.