### PR TITLE
fix: use previously selected field for HeroSection and PromoSection

### DIFF
--- a/packages/visual-editor/src/editor/YextStructFieldSelector.tsx
+++ b/packages/visual-editor/src/editor/YextStructFieldSelector.tsx
@@ -67,16 +67,13 @@ export const YextStructFieldSelector = <U extends Record<string, any>>(
           ])
         );
 
-        // Automatically select the first field when constantValue is disabled.
-        let newField = value.field;
-        if (value.constantValueEnabled && !constantValueEnabled) {
-          if (filteredEntityFields.length) {
-            newField = filteredEntityFields[0].name;
-          }
-        }
+        // The first field in the entity list, to be used if no value.field
+        const firstField = filteredEntityFields.length
+          ? filteredEntityFields[0].name
+          : "";
 
         onChange({
-          field: newField,
+          field: value.field ?? firstField,
           constantValue: value.constantValue,
           constantValueEnabled: constantValueEnabled,
           constantValueOverride: updateOverrides,


### PR DESCRIPTION
When the static value / entity field is toggled, the previously selected field is used instead of the first one in the list. 