### PR TITLE
fix: prevent infinite re-renders with PhoneInput

### DIFF
--- a/packages/visual-editor/src/internal/puck/constant-value-fields/Phone.tsx
+++ b/packages/visual-editor/src/internal/puck/constant-value-fields/Phone.tsx
@@ -4,17 +4,39 @@ import { PhoneInput } from "react-international-phone";
 import "react-international-phone/style.css";
 import "../ui/puck.css";
 import { pt } from "../../../utils/i18n/platform.ts";
+import React from "react";
 
 export const PHONE_CONSTANT_CONFIG: CustomField<string | undefined> = {
   type: "custom",
   render: ({ value, onChange }) => {
+    console.log("existing value:", value);
+    // By removing useCallback, we ensure this function doesn't close over a stale `value`.
+    const tempOnChange = (newVal: any) => {
+      // This check is still useful to prevent unnecessary re-renders if the value hasn't changed.
+      if (newVal === value) return;
+      onChange(newVal);
+    };
+
     return (
       <div className="ve-mt-[12px]">
         <FieldLabel
           label={pt("fields.phoneNumber", "Phone Number")}
           icon={<Phone size={16} />}
         >
-          <PhoneInput value={value} defaultCountry="us" onChange={onChange} />
+          {/* FieldLabel grabs the onclick event for the first button in its children, 
+                and applies it to the whole area covered by the FieldLabel and its children.
+                This hidden button catches clicks on the label/phone input to block unintended behavior. */}
+          <button
+            className="ve-absolute ve-inset-0 ve-z-10 ve-hidden"
+            onClick={(e) => e.stopPropagation()}
+          />
+          {/* By removing useMemo, we ensure the component always receives the latest props. */}
+          <PhoneInput
+            key={value}
+            value={value}
+            defaultCountry="us"
+            onChange={tempOnChange}
+          />
         </FieldLabel>
       </div>
     );

--- a/packages/visual-editor/src/internal/puck/constant-value-fields/Phone.tsx
+++ b/packages/visual-editor/src/internal/puck/constant-value-fields/Phone.tsx
@@ -9,12 +9,13 @@ import React from "react";
 export const PHONE_CONSTANT_CONFIG: CustomField<string | undefined> = {
   type: "custom",
   render: ({ value, onChange }) => {
-    console.log("existing value:", value);
-    // By removing useCallback, we ensure this function doesn't close over a stale `value`.
-    const tempOnChange = (newVal: any) => {
-      // This check is still useful to prevent unnecessary re-renders if the value hasn't changed.
-      if (newVal === value) return;
-      onChange(newVal);
+    /* Managing an internal state is necessary to prevent PhoneInput from 
+       reverting back to its initial value unexpectedly. */
+    const [phoneNumber, setPhoneNumber] = React.useState(value);
+
+    const handleOnChange = (newPhoneNumber: any) => {
+      setPhoneNumber(newPhoneNumber);
+      onChange(newPhoneNumber);
     };
 
     return (
@@ -24,18 +25,16 @@ export const PHONE_CONSTANT_CONFIG: CustomField<string | undefined> = {
           icon={<Phone size={16} />}
         >
           {/* FieldLabel grabs the onclick event for the first button in its children, 
-                and applies it to the whole area covered by the FieldLabel and its children.
-                This hidden button catches clicks on the label/phone input to block unintended behavior. */}
+              and applies it to the whole area covered by the FieldLabel and its children.
+              This hidden button catches clicks on the label/phone input to block unintended behavior. */}
           <button
             className="ve-absolute ve-inset-0 ve-z-10 ve-hidden"
             onClick={(e) => e.stopPropagation()}
           />
-          {/* By removing useMemo, we ensure the component always receives the latest props. */}
           <PhoneInput
-            key={value}
-            value={value}
+            value={phoneNumber}
             defaultCountry="us"
-            onChange={tempOnChange}
+            onChange={handleOnChange}
           />
         </FieldLabel>
       </div>


### PR DESCRIPTION
The new `PhoneInput` component exhibits weird behavior that our old one did not. When selecting a new country code with the dropdown, it would repeatedly swap back and forth between the new country code and the old phone number. This seems to be caused by how it interacts with the `value` that is passed into `PHONE_CONSTANT_CONFIG`'s renderer. Managing the value in an internal state fixes this issue, and adding a hidden dummy button before the `PhoneInput` prevents the dropdown from re-opening after selecting a new country code.

https://github.com/user-attachments/assets/d25a6dab-04e7-4e69-b7e5-b968ff9a3c8e

