### PR TITLE
fix: emailsComponent constant value crash

### DIFF
--- a/packages/visual-editor/src/components/contentBlocks/Emails.tsx
+++ b/packages/visual-editor/src/components/contentBlocks/Emails.tsx
@@ -64,6 +64,7 @@ const EmailsComponent: React.FC<EmailsProps> = ({
               ? resolvedEmailList.length
               : Math.min(resolvedEmailList.length, listLength!)
           )
+          .filter((e) => !!e)
           .map((email, index) => (
             <li key={index} className={`flex items-center gap-3`}>
               <Background


### PR DESCRIPTION
Fixes puck crash that would occur when EmailsList was used with constant values and one of the emails was erased.

Adds a fix where an empty email will simply not be rendered on the page.

Verified that this prevents the crash from occurring.

<img width="1302" height="859" alt="image" src="https://github.com/user-attachments/assets/417e964e-43aa-4108-b66f-060146d9d9af" />
