### PR TITLE
chore: upgrade to Puck 0.20.1

### DIFF
--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -56,7 +56,7 @@
     "i18n:check-empty": "pnpm exec tsx scripts/checkEmptyTranslations.ts"
   },
   "dependencies": {
-    "@measured/puck": "0.19.3",
+    "@measured/puck": "0.20.1",
     "@microsoft/api-documenter": "^7.26.29",
     "@microsoft/api-extractor": "^7.52.8",
     "@microsoft/api-extractor-model": "^7.30.6",

--- a/packages/visual-editor/src/components/CustomCodeSection.test.tsx
+++ b/packages/visual-editor/src/components/CustomCodeSection.test.tsx
@@ -56,7 +56,7 @@ describe("CustomCodeSection", async () => {
   const puckConfig: Config = {
     components: { CustomCodeSection },
     root: {
-      render: ({ children }) => {
+      render: ({ children }: { children: React.ReactNode }) => {
         return <>{children}</>;
       },
     },

--- a/packages/visual-editor/src/components/CustomCodeSection.tsx
+++ b/packages/visual-editor/src/components/CustomCodeSection.tsx
@@ -130,7 +130,9 @@ const CustomCodeSectionWrapper = ({
  * It is useful for integrating third-party widgets or custom scripts that are not supported by the visual editor natively.
  * Only available with additional feature flag enabled.
  */
-export const CustomCodeSection: ComponentConfig<CustomCodeSectionProps> = {
+export const CustomCodeSection: ComponentConfig<{
+  props: CustomCodeSectionProps;
+}> = {
   label: msg("components.customCodeSection", "Custom Code Section"),
   fields: customCodeSectionFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/Directory.test.tsx
+++ b/packages/visual-editor/src/components/Directory.test.tsx
@@ -685,7 +685,7 @@ describe("Directory", async () => {
   const puckConfig: Config = {
     components: { Directory },
     root: {
-      render: ({ children }) => {
+      render: ({ children }: { children: React.ReactNode }) => {
         return <>{children}</>;
       },
     },

--- a/packages/visual-editor/src/components/Directory.tsx
+++ b/packages/visual-editor/src/components/Directory.tsx
@@ -464,7 +464,7 @@ const DirectoryComponent = ({ data, styles, analytics }: DirectoryProps) => {
  * The Directory Page component serves as a navigational hub, displaying a list of child entities within a hierarchical structure (e.g., a list of states in a country, or cities in a state). It includes breadcrumbs for easy navigation and renders each child item as a distinct card.
  * Available on Directory templates.
  */
-export const Directory: ComponentConfig<DirectoryProps> = {
+export const Directory: ComponentConfig<{ props: DirectoryProps }> = {
   label: msg("components.directory", "Directory"),
   fields: directoryFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/Layout.tsx
+++ b/packages/visual-editor/src/components/Layout.tsx
@@ -105,10 +105,19 @@ export const layoutFields: Fields<layoutProps> = {
     msg("fields.backgroundColor", "Background Color"),
     {
       type: "select",
+      isOptional: true,
       options: "BACKGROUND_COLOR",
     }
   ),
-  gap: SpacingSelector("Gap", "gap", false),
-  verticalPadding: SpacingSelector("Top/Bottom Padding", "padding", true),
-  horizontalPadding: SpacingSelector("Left/Right Padding", "padding", false),
+  gap: SpacingSelector<layoutProps["gap"]>("Gap", "gap", false),
+  verticalPadding: SpacingSelector<layoutProps["verticalPadding"]>(
+    "Top/Bottom Padding",
+    "padding",
+    true
+  ),
+  horizontalPadding: SpacingSelector<layoutProps["horizontalPadding"]>(
+    "Left/Right Padding",
+    "padding",
+    false
+  ),
 };

--- a/packages/visual-editor/src/components/Locator.test.tsx
+++ b/packages/visual-editor/src/components/Locator.test.tsx
@@ -122,7 +122,7 @@ describe("Locator", async () => {
   const puckConfig: Config = {
     components: { LocatorComponent },
     root: {
-      render: ({ children }) => {
+      render: ({ children }: { children: React.ReactNode }) => {
         return <>{children}</>;
       },
     },

--- a/packages/visual-editor/src/components/Locator.tsx
+++ b/packages/visual-editor/src/components/Locator.tsx
@@ -74,7 +74,7 @@ export interface LocatorProps {
 }
 
 const locatorFields: Fields<LocatorProps> = {
-  mapStyle: BasicSelector({
+  mapStyle: BasicSelector<LocatorProps["mapStyle"]>({
     label: msg("fields.mapStyle", "Map Style"),
     options: [
       {
@@ -107,6 +107,7 @@ const locatorFields: Fields<LocatorProps> = {
     msg("fields.options.includeOpenNow", "Include Open Now Button"),
     {
       type: "radio",
+      isOptional: true,
       options: [
         { label: msg("fields.options.yes", "Yes"), value: true },
         { label: msg("fields.options.no", "No"), value: false },
@@ -118,7 +119,7 @@ const locatorFields: Fields<LocatorProps> = {
 /**
  * Available on Locator templates.
  */
-export const LocatorComponent: ComponentConfig<LocatorProps> = {
+export const LocatorComponent: ComponentConfig<{ props: LocatorProps }> = {
   fields: locatorFields,
   label: msg("components.locator", "Locator"),
   render: (props) => <LocatorWrapper {...props} />,

--- a/packages/visual-editor/src/components/contentBlocks/Address.tsx
+++ b/packages/visual-editor/src/components/contentBlocks/Address.tsx
@@ -39,7 +39,9 @@ export const AddressDataField = YextField<any, AddressType>(
 
 // Address style fields used in Address and CoreInfoSection
 export const AddressStyleFields = {
-  showGetDirectionsLink: YextField(
+  // By explicitly providing `<boolean>`, we tell YextField what type to use,
+  // which prevents TypeScript from incorrectly inferring `any`.
+  showGetDirectionsLink: YextField<boolean>(
     msg("fields.showGetDirectionsLink", "Show Get Directions Link"),
     {
       type: "radio",
@@ -49,10 +51,14 @@ export const AddressStyleFields = {
       ],
     }
   ),
-  ctaVariant: YextField(msg("fields.ctaVariant", "CTA Variant"), {
-    type: "radio",
-    options: "CTA_VARIANT",
-  }),
+  // We do the same for the ctaVariant, specifying its exact type.
+  ctaVariant: YextField<CTAProps["variant"]>(
+    msg("fields.ctaVariant", "CTA Variant"),
+    {
+      type: "radio",
+      options: "CTA_VARIANT",
+    }
+  ),
 };
 
 const addressFields: Fields<AddressProps> = {
@@ -118,7 +124,9 @@ const AddressComponent = ({ data, styles }: AddressProps) => {
   );
 };
 
-export const Address: ComponentConfig<AddressProps> = {
+export const Address: ComponentConfig<{
+  props: AddressProps;
+}> = {
   label: msg("components.address", "Address"),
   fields: addressFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/contentBlocks/Address.tsx
+++ b/packages/visual-editor/src/components/contentBlocks/Address.tsx
@@ -39,8 +39,6 @@ export const AddressDataField = YextField<any, AddressType>(
 
 // Address style fields used in Address and CoreInfoSection
 export const AddressStyleFields = {
-  // By explicitly providing `<boolean>`, we tell YextField what type to use,
-  // which prevents TypeScript from incorrectly inferring `any`.
   showGetDirectionsLink: YextField<boolean>(
     msg("fields.showGetDirectionsLink", "Show Get Directions Link"),
     {
@@ -51,7 +49,6 @@ export const AddressStyleFields = {
       ],
     }
   ),
-  // We do the same for the ctaVariant, specifying its exact type.
   ctaVariant: YextField<CTAProps["variant"]>(
     msg("fields.ctaVariant", "CTA Variant"),
     {

--- a/packages/visual-editor/src/components/contentBlocks/BodyText.tsx
+++ b/packages/visual-editor/src/components/contentBlocks/BodyText.tsx
@@ -70,7 +70,7 @@ const BodyTextComponent = React.forwardRef<HTMLParagraphElement, BodyTextProps>(
   }
 );
 
-export const BodyText: ComponentConfig<BodyTextProps> = {
+export const BodyText: ComponentConfig<{ props: BodyTextProps }> = {
   label: msg("components.bodyText", "Body Text"),
   fields: bodyTextFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/contentBlocks/CTAGroup.tsx
+++ b/packages/visual-editor/src/components/contentBlocks/CTAGroup.tsx
@@ -85,7 +85,7 @@ const CTAGroupComponent = ({ buttons }: CTAGroupProps) => {
   );
 };
 
-export const CTAGroup: ComponentConfig<CTAGroupProps> = {
+export const CTAGroup: ComponentConfig<{ props: CTAGroupProps }> = {
   label: msg("components.ctaGroup", "CTA Group"),
   fields: ctaGroupFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/contentBlocks/CtaWrapper.tsx
+++ b/packages/visual-editor/src/components/contentBlocks/CtaWrapper.tsx
@@ -64,7 +64,7 @@ const CTAWrapperComponent: React.FC<CTAWrapperProps> = ({
   );
 };
 
-export const CTAWrapper: ComponentConfig<CTAWrapperProps> = {
+export const CTAWrapper: ComponentConfig<{ props: CTAWrapperProps }> = {
   label: msg("components.callToAction", "Call to Action"),
   fields: ctaWrapperFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/contentBlocks/Emails.tsx
+++ b/packages/visual-editor/src/components/contentBlocks/Emails.tsx
@@ -86,7 +86,7 @@ const EmailsComponent: React.FC<EmailsProps> = ({
   );
 };
 
-export const Emails: ComponentConfig<EmailsProps> = {
+export const Emails: ComponentConfig<{ props: EmailsProps }> = {
   label: msg("components.emails", "Emails"),
   fields: EmailsFields,
   resolveFields: (data, { fields }) => {
@@ -98,6 +98,7 @@ export const Emails: ComponentConfig<EmailsProps> = {
       ...fields,
       listLength: YextField(msg("fields.listLength", "List Length"), {
         type: "number",
+        isOptional: true,
         min: 1,
         max: 5,
       }),

--- a/packages/visual-editor/src/components/contentBlocks/GetDirections.tsx
+++ b/packages/visual-editor/src/components/contentBlocks/GetDirections.tsx
@@ -75,7 +75,7 @@ const GetDirectionsComponent = ({
   );
 };
 
-export const GetDirections: ComponentConfig<GetDirectionsProps> = {
+export const GetDirections: ComponentConfig<{ props: GetDirectionsProps }> = {
   label: msg("components.getDirections", "Get Directions"),
   fields: getDirectionsFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/contentBlocks/HeadingText.tsx
+++ b/packages/visual-editor/src/components/contentBlocks/HeadingText.tsx
@@ -55,7 +55,7 @@ const headingTextFields: Fields<HeadingTextProps> = {
   }),
 };
 
-export const HeadingText: ComponentConfig<HeadingTextProps> = {
+export const HeadingText: ComponentConfig<{ props: HeadingTextProps }> = {
   label: msg("components.headingText", "Heading Text"),
   fields: headingTextFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/contentBlocks/HoursStatus.tsx
+++ b/packages/visual-editor/src/components/contentBlocks/HoursStatus.tsx
@@ -33,6 +33,7 @@ const hoursStatusWrapperFields: Fields<HoursStatusProps> = {
     msg("fields.showCurrentStatus", "Show Current Status"),
     {
       type: "radio",
+      isOptional: true,
       options: [
         { label: msg("fields.options.yes", "Yes"), value: true },
         { label: msg("fields.options.no", "No"), value: false },
@@ -41,6 +42,7 @@ const hoursStatusWrapperFields: Fields<HoursStatusProps> = {
   ),
   timeFormat: YextField(msg("fields.timeFormat", "Time Format"), {
     type: "radio",
+    isOptional: true,
     options: [
       { label: msg("fields.options.hour12", "12-hour"), value: "12h" },
       { label: msg("fields.options.hour24", "24-hour"), value: "24h" },
@@ -48,6 +50,7 @@ const hoursStatusWrapperFields: Fields<HoursStatusProps> = {
   }),
   showDayNames: YextField(msg("fields.showDayNames", "Show Day Names"), {
     type: "radio",
+    isOptional: true,
     options: [
       { label: msg("fields.options.yes", "Yes"), value: true },
       { label: msg("fields.options.no", "No"), value: false },
@@ -57,6 +60,7 @@ const hoursStatusWrapperFields: Fields<HoursStatusProps> = {
     msg("fields.dayOfWeekFormat", "Day of Week Format"),
     {
       type: "radio",
+      isOptional: true,
       options: [
         { label: msg("fields.options.short", "Short"), value: "short" },
         { label: msg("fields.options.long", "Long"), value: "long" },
@@ -99,7 +103,7 @@ const HoursStatusWrapper: React.FC<HoursStatusProps> = ({
   );
 };
 
-export const HoursStatus: ComponentConfig<HoursStatusProps> = {
+export const HoursStatus: ComponentConfig<{ props: HoursStatusProps }> = {
   label: msg("components.hoursStatus", "Hours Status"),
   fields: hoursStatusWrapperFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/contentBlocks/HoursTable.tsx
+++ b/packages/visual-editor/src/components/contentBlocks/HoursTable.tsx
@@ -38,19 +38,25 @@ export const HoursTableDataField = YextField<any, HoursType>(
 
 // HoursTable style fields used in HoursTable and CoreInfoSection
 export const HoursTableStyleFields = {
-  startOfWeek: YextField(msg("fields.startOfTheWeek", "Start of the Week"), {
-    type: "select",
-    hasSearch: true,
-    options: "HOURS_OPTIONS",
-  }),
-  collapseDays: YextField(msg("fields.collapseDays", "Collapse Days"), {
-    type: "radio",
-    options: [
-      { label: msg("fields.options.yes", "Yes"), value: true },
-      { label: msg("fields.options.no", "No"), value: false },
-    ],
-  }),
-  showAdditionalHoursText: YextField(
+  startOfWeek: YextField<keyof DayOfWeekNames | "today">(
+    msg("fields.startOfTheWeek", "Start of the Week"),
+    {
+      type: "select",
+      hasSearch: true,
+      options: "HOURS_OPTIONS",
+    }
+  ),
+  collapseDays: YextField<boolean>(
+    msg("fields.collapseDays", "Collapse Days"),
+    {
+      type: "radio",
+      options: [
+        { label: msg("fields.options.yes", "Yes"), value: true },
+        { label: msg("fields.options.no", "No"), value: false },
+      ],
+    }
+  ),
+  showAdditionalHoursText: YextField<boolean>(
     msg("fields.options.showAdditionalHoursText", "Show additional hours text"),
     {
       type: "radio",
@@ -125,7 +131,7 @@ const VisualEditorHoursTable = ({ data, styles }: HoursTableProps) => {
   );
 };
 
-export const HoursTable: ComponentConfig<HoursTableProps> = {
+export const HoursTable: ComponentConfig<{ props: HoursTableProps }> = {
   fields: hoursTableFields,
   defaultProps: {
     data: {

--- a/packages/visual-editor/src/components/contentBlocks/MapboxStaticMap.tsx
+++ b/packages/visual-editor/src/components/contentBlocks/MapboxStaticMap.tsx
@@ -172,7 +172,7 @@ export const MapboxStaticMapComponent = ({
   );
 };
 
-export const MapboxStaticMap: ComponentConfig<MapboxStaticProps> = {
+export const MapboxStaticMap: ComponentConfig<{ props: MapboxStaticProps }> = {
   label: msg("components.mapboxStaticMap", "Mapbox Static Map"),
   fields: mapboxFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/contentBlocks/Phone.tsx
+++ b/packages/visual-editor/src/components/contentBlocks/Phone.tsx
@@ -32,7 +32,7 @@ export const PhoneDataFields = {
       types: ["type.phone"],
     },
   }),
-  label: YextField(msg("fields.label", "Label"), {
+  label: YextField<TranslatableString>(msg("fields.label", "Label"), {
     type: "translatableString",
     filter: { types: ["type.string"] },
   }),
@@ -40,11 +40,15 @@ export const PhoneDataFields = {
 
 // Phone style definitions used in Phone and CoreInfoSection
 export const PhoneStyleFields = {
-  phoneFormat: YextField(msg("fields.phoneFormat", "Phone Format"), {
-    type: "radio",
-    options: "PHONE_OPTIONS",
-  }),
-  includePhoneHyperlink: YextField(
+  phoneFormat: YextField<"domestic" | "international">(
+    msg("fields.phoneFormat", "Phone Format"),
+    {
+      type: "radio",
+      options: "PHONE_OPTIONS",
+    }
+  ),
+  // By adding `<boolean>`, we make the type explicit.
+  includePhoneHyperlink: YextField<boolean>(
     msg("fields.includePhoneHyperlink", "Include Phone Hyperlink"),
     {
       type: "radio",
@@ -99,7 +103,7 @@ const PhoneComponent = ({ data, styles }: PhoneProps) => {
   );
 };
 
-export const Phone: ComponentConfig<PhoneProps> = {
+export const Phone: ComponentConfig<{ props: PhoneProps }> = {
   label: msg("components.phone", "Phone"),
   fields: PhoneFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/contentBlocks/TextList.tsx
+++ b/packages/visual-editor/src/components/contentBlocks/TextList.tsx
@@ -67,7 +67,7 @@ const TextListComponent: React.FC<TextListProps> = ({
   );
 };
 
-export const TextList: ComponentConfig<TextListProps> = {
+export const TextList: ComponentConfig<{ props: TextListProps }> = {
   label: msg("components.textList", "Text List"),
   fields: textListFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/contentBlocks/image/Image.tsx
+++ b/packages/visual-editor/src/components/contentBlocks/image/Image.tsx
@@ -76,7 +76,7 @@ const ImageWrapperComponent = ({ data, styles }: ImageWrapperProps) => {
   );
 };
 
-export const ImageWrapper: ComponentConfig<ImageWrapperProps> = {
+export const ImageWrapper: ComponentConfig<{ props: ImageWrapperProps }> = {
   label: msg("components.image", "Image"),
   fields: ImageWrapperFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/contentBlocks/image/styling.ts
+++ b/packages/visual-editor/src/components/contentBlocks/image/styling.ts
@@ -9,6 +9,7 @@ export interface ImageStylingProps {
 export const ImageStylingFields: Fields<ImageStylingProps> = {
   width: YextField(msg("fields.options.width", "Width"), {
     type: "number",
+    isOptional: true,
     min: 0,
   }),
   aspectRatio: YextField(msg("fields.options.aspectRatio", "Aspect Ratio"), {

--- a/packages/visual-editor/src/components/footer/ExpandedFooter.test.tsx
+++ b/packages/visual-editor/src/components/footer/ExpandedFooter.test.tsx
@@ -468,7 +468,7 @@ describe("ExpandedFooter", async () => {
   const puckConfig: Config = {
     components: { ExpandedFooter },
     root: {
-      render: ({ children }) => {
+      render: ({ children }: { children: React.ReactNode }) => {
         return <>{children}</>;
       },
     },

--- a/packages/visual-editor/src/components/footer/ExpandedFooter.tsx
+++ b/packages/visual-editor/src/components/footer/ExpandedFooter.tsx
@@ -900,7 +900,7 @@ const FooterIcons = ({
  * The Expanded Footer is a comprehensive, two-tiered site-wide component for large websites. It includes a primary footer area for a logo, social media links, and utility images, and features two distinct layouts: a standard link list or an "expanded" multi-column mega-footer. It also includes an optional secondary sub-footer for copyright notices and legal links.
  * Avalible on Location templates.
  */
-export const ExpandedFooter: ComponentConfig<ExpandedFooterProps> = {
+export const ExpandedFooter: ComponentConfig<{ props: ExpandedFooterProps }> = {
   label: msg("components.expandedFooter", "Expanded Footer"),
   fields: expandedFooterSectionFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/footer/Footer.test.tsx
+++ b/packages/visual-editor/src/components/footer/Footer.test.tsx
@@ -46,7 +46,7 @@ describe("Footer", async () => {
   const puckConfig: Config = {
     components: { Footer },
     root: {
-      render: ({ children }) => {
+      render: ({ children }: { children: React.ReactNode }) => {
         return <>{children}</>;
       },
     },

--- a/packages/visual-editor/src/components/footer/Footer.tsx
+++ b/packages/visual-editor/src/components/footer/Footer.tsx
@@ -49,6 +49,7 @@ const footerFields: Fields<FooterProps> = {
     msg("fields.backgroundColor", "Background Color"),
     {
       type: "select",
+      isOptional: true,
       options: "BACKGROUND_COLOR",
     }
   ),
@@ -67,7 +68,7 @@ const footerFields: Fields<FooterProps> = {
  * The Footer appears at the bottom of the page. It serves as a container for secondary navigation, social media links, legal disclaimers, and copyright information. See [Expanded Footer](#expanded-footer) for the newest footer component.
  * Available on Directory and Locator templates.
  */
-export const Footer: ComponentConfig<FooterProps> = {
+export const Footer: ComponentConfig<{ props: FooterProps }> = {
   label: msg("components.footer", "Footer"),
   fields: footerFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/header/ExpandedHeader.test.tsx
+++ b/packages/visual-editor/src/components/header/ExpandedHeader.test.tsx
@@ -391,7 +391,7 @@ describe("ExpandedHeader", async () => {
   const puckConfig: Config = {
     components: { ExpandedHeader },
     root: {
-      render: ({ children }) => {
+      render: ({ children }: { children: React.ReactNode }) => {
         return <>{children}</>;
       },
     },

--- a/packages/visual-editor/src/components/header/ExpandedHeader.tsx
+++ b/packages/visual-editor/src/components/header/ExpandedHeader.tsx
@@ -151,6 +151,7 @@ const expandedHeaderSectionFields: Fields<ExpandedHeaderProps> = {
           }),
           primaryCTA: YextField(msg("fields.primaryCTA", "Primary CTA"), {
             type: "object",
+            isOptional: true,
             objectFields: {
               label: YextField(msg("fields.label", "Label"), {
                 type: "translatableString",
@@ -178,6 +179,7 @@ const expandedHeaderSectionFields: Fields<ExpandedHeaderProps> = {
           ),
           secondaryCTA: YextField(msg("fields.secondaryCTA", "Secondary CTA"), {
             type: "object",
+            isOptional: true,
             objectFields: {
               label: YextField(msg("fields.label", "Label"), {
                 type: "translatableString",
@@ -793,7 +795,7 @@ const buildComplexImage = (
  * The Expanded Header is a two-tiered component for websites with complex navigation needs. It consists of a primary header for the main logo, navigation links, and calls-to-action, plus an optional secondary "top bar" for utility links (like "Contact Us" or "Log In") and a language selector.
  * Available on Location templates.
  */
-export const ExpandedHeader: ComponentConfig<ExpandedHeaderProps> = {
+export const ExpandedHeader: ComponentConfig<{ props: ExpandedHeaderProps }> = {
   label: msg("components.expandedHeader", "Expanded Header"),
   fields: expandedHeaderSectionFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/header/Header.test.tsx
+++ b/packages/visual-editor/src/components/header/Header.test.tsx
@@ -83,7 +83,7 @@ describe("Header", async () => {
   const puckConfig: Config = {
     components: { Header },
     root: {
-      render: ({ children }) => {
+      render: ({ children }: { children: React.ReactNode }) => {
         return <>{children}</>;
       },
     },

--- a/packages/visual-editor/src/components/header/Header.tsx
+++ b/packages/visual-editor/src/components/header/Header.tsx
@@ -58,6 +58,7 @@ export interface HeaderProps {
 const headerFields: Fields<HeaderProps> = {
   logoWidth: YextField(msg("fields.logoWidth", "Logo Width"), {
     type: "number",
+    isOptional: true,
     min: 0,
   }),
   enableLanguageSelector: YextField(
@@ -85,7 +86,7 @@ const headerFields: Fields<HeaderProps> = {
  * The Header component appears at the top of pages. It serves as the primary navigation and branding element, containing the site logo and optionally a language selector. See [Expanded Header](#expanded-header) for the newest header component.
  * Available on Directory and Locator templates.
  */
-export const Header: ComponentConfig<HeaderProps> = {
+export const Header: ComponentConfig<{ props: HeaderProps }> = {
   label: msg("components.header", "Header"),
   fields: headerFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/layoutBlocks/Flex.tsx
+++ b/packages/visual-editor/src/components/layoutBlocks/Flex.tsx
@@ -109,7 +109,7 @@ const flexContainerFields: Fields<FlexProps> = {
   ),
 };
 
-export const Flex: ComponentConfig<FlexProps> = {
+export const Flex: ComponentConfig<{ props: FlexProps }> = {
   label: "Flex",
   fields: flexContainerFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/layoutBlocks/Grid.test.tsx
+++ b/packages/visual-editor/src/components/layoutBlocks/Grid.test.tsx
@@ -529,7 +529,7 @@ describe("Grid", async () => {
       TextList,
     },
     root: {
-      render: ({ children }) => {
+      render: ({ children }: { children: React.ReactNode }) => {
         return <>{children}</>;
       },
     },

--- a/packages/visual-editor/src/components/layoutBlocks/Grid.tsx
+++ b/packages/visual-editor/src/components/layoutBlocks/Grid.tsx
@@ -73,6 +73,7 @@ const gridSectionFields: Fields<GridProps> = {
     msg("fields.backgroundColor", "Background Color"),
     {
       type: "select",
+      isOptional: true,
       options: "BACKGROUND_COLOR",
     }
   ),
@@ -100,7 +101,7 @@ const gridSectionFields: Fields<GridProps> = {
 /**
  * The Grid Section component presents a series of columns into which a variety of smaller content blocks may be dragged, allowing for a higher degree of customization.
  */
-export const Grid: ComponentConfig<GridProps> = {
+export const Grid: ComponentConfig<{ props: GridProps }> = {
   label: msg("components.gridSection", "Grid Section"),
   fields: gridSectionFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/pageSections/Banner.test.tsx
+++ b/packages/visual-editor/src/components/pageSections/Banner.test.tsx
@@ -138,7 +138,7 @@ describe("BannerSection", async () => {
   const puckConfig: Config = {
     components: { BannerSection },
     root: {
-      render: ({ children }) => {
+      render: ({ children }: { children: React.ReactNode }) => {
         return <>{children}</>;
       },
     },

--- a/packages/visual-editor/src/components/pageSections/Banner.tsx
+++ b/packages/visual-editor/src/components/pageSections/Banner.tsx
@@ -142,7 +142,7 @@ const BannerComponent = ({ data, styles }: BannerSectionProps) => {
  * The Banner Section component displays a single, translatable line of rich text. It's designed to be used as a simple, full-width banner on a page.
  * Available on Location templates.
  */
-export const BannerSection: ComponentConfig<BannerSectionProps> = {
+export const BannerSection: ComponentConfig<{ props: BannerSectionProps }> = {
   label: msg("components.bannerSection", "Banner Section"),
   fields: bannerSectionFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/pageSections/Breadcrumbs.test.tsx
+++ b/packages/visual-editor/src/components/pageSections/Breadcrumbs.test.tsx
@@ -129,7 +129,7 @@ describe("BreadcrumbsSection", async () => {
   const puckConfig: Config = {
     components: { BreadcrumbsSection },
     root: {
-      render: ({ children }) => {
+      render: ({ children }: { children: React.ReactNode }) => {
         return <>{children}</>;
       },
     },

--- a/packages/visual-editor/src/components/pageSections/Breadcrumbs.tsx
+++ b/packages/visual-editor/src/components/pageSections/Breadcrumbs.tsx
@@ -213,7 +213,9 @@ export const BreadcrumbsComponent = ({
  * The Breadcrumbs component automatically generates and displays a navigational hierarchy based on a page's position within a Yext directory structure. It renders a list of links showing the path from the main directory root to the current page, helping users understand their location on the site.
  * Available on Location templates.
  */
-export const BreadcrumbsSection: ComponentConfig<BreadcrumbsSectionProps> = {
+export const BreadcrumbsSection: ComponentConfig<{
+  props: BreadcrumbsSectionProps;
+}> = {
   label: msg("components.breadcrumbs", "Breadcrumbs"),
   fields: breadcrumbsSectionFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/pageSections/CoreInfoSection.test.tsx
+++ b/packages/visual-editor/src/components/pageSections/CoreInfoSection.test.tsx
@@ -758,7 +758,7 @@ describe("CoreInfoSection", async () => {
   const puckConfig: Config = {
     components: { CoreInfoSection },
     root: {
-      render: ({ children }) => {
+      render: ({ children }: { children: React.ReactNode }) => {
         return <>{children}</>;
       },
     },

--- a/packages/visual-editor/src/components/pageSections/CoreInfoSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/CoreInfoSection.tsx
@@ -577,141 +577,142 @@ const CoreInfoSectionWrapper = ({ data, styles }: CoreInfoSectionProps) => {
  * The Core Info Section is a comprehensive component designed to display essential business information in a clear, multi-column layout. It typically includes contact details (address, phone, email), hours of operation, and a list of services, with extensive options for customization.
  * Available on Location templates.
  */
-export const CoreInfoSection: ComponentConfig<CoreInfoSectionProps> = {
-  label: msg("components.coreInfoSection", "Core Info Section"),
-  fields: coreInfoSectionFields,
-  resolveFields: (data, { fields }) => {
-    if (data.props.data.info.emails.constantValueEnabled) {
-      return fields;
-    }
+export const CoreInfoSection: ComponentConfig<{ props: CoreInfoSectionProps }> =
+  {
+    label: msg("components.coreInfoSection", "Core Info Section"),
+    fields: coreInfoSectionFields,
+    resolveFields: (data, { fields }) => {
+      if (data.props.data.info.emails.constantValueEnabled) {
+        return fields;
+      }
 
-    return {
-      ...fields,
-      styles: {
-        ...fields.styles,
-        objectFields: {
-          // @ts-expect-error ts(2339) objectFields exists
-          ...fields.styles.objectFields,
-          info: {
+      return {
+        ...fields,
+        styles: {
+          ...fields.styles,
+          objectFields: {
             // @ts-expect-error ts(2339) objectFields exists
-            ...fields.styles.objectFields.info,
-            objectFields: {
+            ...fields.styles.objectFields,
+            info: {
               // @ts-expect-error ts(2339) objectFields exists
-              ...fields.styles.objectFields.info.objectFields,
-              emailsListLength: YextField(
-                msg("fields.emailsListLength", "Emails List Length"),
-                {
-                  type: "number",
-                  min: 0,
-                  max: 3,
-                }
-              ),
+              ...fields.styles.objectFields.info,
+              objectFields: {
+                // @ts-expect-error ts(2339) objectFields exists
+                ...fields.styles.objectFields.info.objectFields,
+                emailsListLength: YextField(
+                  msg("fields.emailsListLength", "Emails List Length"),
+                  {
+                    type: "number",
+                    min: 0,
+                    max: 3,
+                  }
+                ),
+              },
             },
           },
         },
-      },
-    };
-  },
-  defaultProps: {
-    data: {
-      info: {
-        headingText: {
-          field: "",
-          constantValue: {
-            en: "Information",
-            hasLocalizedValue: "true",
-          },
-          constantValueEnabled: true,
-        },
-        address: {
-          field: "address",
-          constantValue: {
-            line1: "",
-            city: "",
-            postalCode: "",
-            countryCode: "",
-          },
-        },
-        phoneNumbers: [
-          {
-            number: {
-              field: "mainPhone",
-              constantValue: "",
-            },
-            label: {
-              en: "Phone",
+      };
+    },
+    defaultProps: {
+      data: {
+        info: {
+          headingText: {
+            field: "",
+            constantValue: {
+              en: "Information",
               hasLocalizedValue: "true",
             },
+            constantValueEnabled: true,
           },
-        ],
-        emails: {
-          field: "emails",
-          constantValue: [],
-        },
-      },
-      hours: {
-        headingText: {
-          field: "",
-          constantValue: {
-            en: "Hours",
-            hasLocalizedValue: "true",
+          address: {
+            field: "address",
+            constantValue: {
+              line1: "",
+              city: "",
+              postalCode: "",
+              countryCode: "",
+            },
           },
-          constantValueEnabled: true,
+          phoneNumbers: [
+            {
+              number: {
+                field: "mainPhone",
+                constantValue: "",
+              },
+              label: {
+                en: "Phone",
+                hasLocalizedValue: "true",
+              },
+            },
+          ],
+          emails: {
+            field: "emails",
+            constantValue: [],
+          },
         },
         hours: {
-          field: "hours",
-          constantValue: {},
-        },
-      },
-      services: {
-        headingText: {
-          field: "",
-          constantValue: {
-            en: "Services",
-            hasLocalizedValue: "true",
+          headingText: {
+            field: "",
+            constantValue: {
+              en: "Hours",
+              hasLocalizedValue: "true",
+            },
+            constantValueEnabled: true,
           },
-          constantValueEnabled: true,
+          hours: {
+            field: "hours",
+            constantValue: {},
+          },
         },
-        servicesList: {
-          field: "services",
-          constantValue: [],
+        services: {
+          headingText: {
+            field: "",
+            constantValue: {
+              en: "Services",
+              hasLocalizedValue: "true",
+            },
+            constantValueEnabled: true,
+          },
+          servicesList: {
+            field: "services",
+            constantValue: [],
+          },
         },
       },
-    },
-    styles: {
-      heading: {
-        level: 3,
-        align: "left",
+      styles: {
+        heading: {
+          level: 3,
+          align: "left",
+        },
+        backgroundColor: backgroundColors.background1.value,
+        info: {
+          showGetDirectionsLink: true,
+          phoneFormat: "domestic",
+          includePhoneHyperlink: true,
+          emailsListLength: 1,
+          ctaVariant: "link",
+        },
+        hours: {
+          startOfWeek: "today",
+          collapseDays: false,
+          showAdditionalHoursText: true,
+        },
       },
-      backgroundColor: backgroundColors.background1.value,
-      info: {
-        showGetDirectionsLink: true,
-        phoneFormat: "domestic",
-        includePhoneHyperlink: true,
-        emailsListLength: 1,
-        ctaVariant: "link",
+      analytics: {
+        scope: "coreInfoSection",
       },
-      hours: {
-        startOfWeek: "today",
-        collapseDays: false,
-        showAdditionalHoursText: true,
-      },
+      liveVisibility: true,
     },
-    analytics: {
-      scope: "coreInfoSection",
-    },
-    liveVisibility: true,
-  },
-  render: (props) => (
-    <AnalyticsScopeProvider
-      name={`${props.analytics?.scope ?? "coreInfoSection"}${getAnalyticsScopeHash(props.id)}`}
-    >
-      <VisibilityWrapper
-        liveVisibility={props.liveVisibility}
-        isEditing={props.puck.isEditing}
+    render: (props) => (
+      <AnalyticsScopeProvider
+        name={`${props.analytics?.scope ?? "coreInfoSection"}${getAnalyticsScopeHash(props.id)}`}
       >
-        <CoreInfoSectionWrapper {...props} />
-      </VisibilityWrapper>
-    </AnalyticsScopeProvider>
-  ),
-};
+        <VisibilityWrapper
+          liveVisibility={props.liveVisibility}
+          isEditing={props.puck.isEditing}
+        >
+          <CoreInfoSectionWrapper {...props} />
+        </VisibilityWrapper>
+      </AnalyticsScopeProvider>
+    ),
+  };

--- a/packages/visual-editor/src/components/pageSections/EventSection.test.tsx
+++ b/packages/visual-editor/src/components/pageSections/EventSection.test.tsx
@@ -344,7 +344,7 @@ describe("EventSection", async () => {
   const puckConfig: Config = {
     components: { EventSection },
     root: {
-      render: ({ children }) => {
+      render: ({ children }: { children: React.ReactNode }) => {
         return <>{children}</>;
       },
     },

--- a/packages/visual-editor/src/components/pageSections/EventSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/EventSection.tsx
@@ -329,7 +329,7 @@ const EventSectionWrapper: React.FC<EventSectionProps> = (props) => {
  * The Events Section component is designed to display a curated list of events. It features a prominent section heading and renders each event as an individual card, making it ideal for showcasing upcoming activities, workshops, or promotions.
  * Available on Location templates.
  */
-export const EventSection: ComponentConfig<EventSectionProps> = {
+export const EventSection: ComponentConfig<{ props: EventSectionProps }> = {
   label: msg("components.eventsSection", "Events Section"),
   fields: eventSectionFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/pageSections/FAQsSection.test.tsx
+++ b/packages/visual-editor/src/components/pageSections/FAQsSection.test.tsx
@@ -198,7 +198,7 @@ describe("FAQSection", async () => {
   const puckConfig: Config = {
     components: { FAQSection },
     root: {
-      render: ({ children }) => {
+      render: ({ children }: { children: React.ReactNode }) => {
         return <>{children}</>;
       },
     },

--- a/packages/visual-editor/src/components/pageSections/FAQsSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/FAQsSection.tsx
@@ -246,7 +246,7 @@ const FAQsSectionComponent: React.FC<FAQSectionProps> = ({ data, styles }) => {
  * The FAQ Section component displays a list of questions and answers in an organized format. It includes a main heading for the section and typically renders the FAQs as an accordion, where users can click on a question to reveal the answer.
  * Available on Location templates.
  */
-export const FAQSection: ComponentConfig<FAQSectionProps> = {
+export const FAQSection: ComponentConfig<{ props: FAQSectionProps }> = {
   label: msg("components.faqsSection", "FAQs Section"),
   fields: FAQsSectionFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/pageSections/HeroSection.test.tsx
+++ b/packages/visual-editor/src/components/pageSections/HeroSection.test.tsx
@@ -1021,7 +1021,7 @@ describe("HeroSection", async () => {
   const puckConfig: Config = {
     components: { HeroSection },
     root: {
-      render: ({ children }) => {
+      render: ({ children }: { children: React.ReactNode }) => {
         return <>{children}</>;
       },
     },

--- a/packages/visual-editor/src/components/pageSections/HeroSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/HeroSection.tsx
@@ -387,6 +387,7 @@ const heroSectionFields: Fields<HeroSectionProps> = {
     msg("fields.visibleOnLivePage", "Visible on Live Page"),
     {
       type: "radio",
+      isOptional: true,
       options: [
         { label: msg("fields.options.show", "Show"), value: true },
         { label: msg("fields.options.hide", "Hide"), value: false },
@@ -395,7 +396,7 @@ const heroSectionFields: Fields<HeroSectionProps> = {
   ),
 };
 
-export const HeroSection: ComponentConfig<HeroSectionProps> = {
+export const HeroSection: ComponentConfig<{ props: HeroSectionProps }> = {
   label: msg("components.heroSection", "Hero Section"),
   fields: heroSectionFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/pageSections/InsightSection.test.tsx
+++ b/packages/visual-editor/src/components/pageSections/InsightSection.test.tsx
@@ -404,7 +404,7 @@ describe("InsightSection", async () => {
   const puckConfig: Config = {
     components: { InsightSection },
     root: {
-      render: ({ children }) => {
+      render: ({ children }: { children: React.ReactNode }) => {
         return <>{children}</>;
       },
     },

--- a/packages/visual-editor/src/components/pageSections/InsightSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/InsightSection.tsx
@@ -325,7 +325,7 @@ const InsightSectionWrapper = ({ data, styles }: InsightSectionProps) => {
  * The Insight Section is used to display a curated list of content such as articles, blog posts, or other informational blurbs. It features a main section heading and renders each insight as a distinct card, making it an effective way to showcase valuable content.
  * Available on Location templates.
  */
-export const InsightSection: ComponentConfig<InsightSectionProps> = {
+export const InsightSection: ComponentConfig<{ props: InsightSectionProps }> = {
   label: msg("components.insightsSection", "Insights Section"),
   fields: insightSectionFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/pageSections/NearbyLocations.test.tsx
+++ b/packages/visual-editor/src/components/pageSections/NearbyLocations.test.tsx
@@ -228,7 +228,7 @@ describe("NearbyLocationsSection", async () => {
   const puckConfig: Config = {
     components: { NearbyLocationsSection },
     root: {
-      render: ({ children }) => {
+      render: ({ children }: { children: React.ReactNode }) => {
         return <>{children}</>;
       },
     },

--- a/packages/visual-editor/src/components/pageSections/NearbyLocations.tsx
+++ b/packages/visual-editor/src/components/pageSections/NearbyLocations.tsx
@@ -578,61 +578,62 @@ function parseDocument(
  * The Nearby Locations Section dynamically finds and displays a list of business locations within a specified radius of a central point. It's a powerful tool for helping users discover other relevant locations, rendering each result as a detailed card with contact information and business hours.
  * Available on Location templates.
  */
-export const NearbyLocationsSection: ComponentConfig<NearbyLocationsSectionProps> =
-  {
-    label: msg("components.nearbyLocationsSection", "Nearby Locations Section"),
-    fields: nearbyLocationsSectionFields,
-    defaultProps: {
-      data: {
-        heading: {
-          field: "",
-          constantValue: { en: "Nearby Locations", hasLocalizedValue: "true" },
-          constantValueEnabled: true,
-        },
-        coordinate: {
-          field: "yextDisplayCoordinate",
-          constantValue: {
-            latitude: 0,
-            longitude: 0,
-          },
-        },
-        radius: 10,
-        limit: 3,
+export const NearbyLocationsSection: ComponentConfig<{
+  props: NearbyLocationsSectionProps;
+}> = {
+  label: msg("components.nearbyLocationsSection", "Nearby Locations Section"),
+  fields: nearbyLocationsSectionFields,
+  defaultProps: {
+    data: {
+      heading: {
+        field: "",
+        constantValue: { en: "Nearby Locations", hasLocalizedValue: "true" },
+        constantValueEnabled: true,
       },
-      styles: {
-        backgroundColor: backgroundColors.background1.value,
-        heading: {
-          level: 2,
-          align: "left",
+      coordinate: {
+        field: "yextDisplayCoordinate",
+        constantValue: {
+          latitude: 0,
+          longitude: 0,
         },
-        cards: {
-          backgroundColor: backgroundColors.background1.value,
-          headingLevel: 3,
-        },
-        hours: {
-          showCurrentStatus: true,
-          timeFormat: "12h",
-          showDayNames: true,
-          dayOfWeekFormat: "long",
-        },
-        phoneNumberFormat: "domestic",
-        phoneNumberLink: true,
       },
-      analytics: {
-        scope: "nearbyLocationsSection",
-      },
-      liveVisibility: true,
+      radius: 10,
+      limit: 3,
     },
-    render: (props) => (
-      <AnalyticsScopeProvider
-        name={props.analytics?.scope ?? "nearbyLocationsSection"}
+    styles: {
+      backgroundColor: backgroundColors.background1.value,
+      heading: {
+        level: 2,
+        align: "left",
+      },
+      cards: {
+        backgroundColor: backgroundColors.background1.value,
+        headingLevel: 3,
+      },
+      hours: {
+        showCurrentStatus: true,
+        timeFormat: "12h",
+        showDayNames: true,
+        dayOfWeekFormat: "long",
+      },
+      phoneNumberFormat: "domestic",
+      phoneNumberLink: true,
+    },
+    analytics: {
+      scope: "nearbyLocationsSection",
+    },
+    liveVisibility: true,
+  },
+  render: (props) => (
+    <AnalyticsScopeProvider
+      name={props.analytics?.scope ?? "nearbyLocationsSection"}
+    >
+      <VisibilityWrapper
+        liveVisibility={props.liveVisibility}
+        isEditing={props.puck.isEditing}
       >
-        <VisibilityWrapper
-          liveVisibility={props.liveVisibility}
-          isEditing={props.puck.isEditing}
-        >
-          <NearbyLocationsComponent {...props} />
-        </VisibilityWrapper>
-      </AnalyticsScopeProvider>
-    ),
-  };
+        <NearbyLocationsComponent {...props} />
+      </VisibilityWrapper>
+    </AnalyticsScopeProvider>
+  ),
+};

--- a/packages/visual-editor/src/components/pageSections/PhotoGallerySection.test.tsx
+++ b/packages/visual-editor/src/components/pageSections/PhotoGallerySection.test.tsx
@@ -377,7 +377,7 @@ describe("PhotoGallerySection", async () => {
   const puckConfig: Config = {
     components: { PhotoGallerySection },
     root: {
-      render: ({ children }) => {
+      render: ({ children }: { children: React.ReactNode }) => {
         return <>{children}</>;
       },
     },

--- a/packages/visual-editor/src/components/pageSections/PhotoGallerySection.tsx
+++ b/packages/visual-editor/src/components/pageSections/PhotoGallerySection.tsx
@@ -415,7 +415,9 @@ const PhotoGallerySectionComponent = ({
  * The Photo Gallery Section is designed to display a collection of images in a visually appealing format. It consists of a main heading for the section and a flexible grid of images, with options for styling the image presentation.
  * Available on Location templates.
  */
-export const PhotoGallerySection: ComponentConfig<PhotoGallerySectionProps> = {
+export const PhotoGallerySection: ComponentConfig<{
+  props: PhotoGallerySectionProps;
+}> = {
   label: msg("components.photoGallerySection", "Photo Gallery Section"),
   fields: photoGallerySectionFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/pageSections/ProductSection.test.tsx
+++ b/packages/visual-editor/src/components/pageSections/ProductSection.test.tsx
@@ -338,7 +338,7 @@ describe("ProductSection", async () => {
   const puckConfig: Config = {
     components: { ProductSection },
     root: {
-      render: ({ children }) => {
+      render: ({ children }: { children: React.ReactNode }) => {
         return <>{children}</>;
       },
     },

--- a/packages/visual-editor/src/components/pageSections/ProductSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/ProductSection.tsx
@@ -337,7 +337,7 @@ const ProductSectionWrapper = ({ data, styles }: ProductSectionProps) => {
  * The Product Section is used to display a curated list of products in a dedicated section. It features a main heading and renders each product as an individual card, making it ideal for showcasing featured items, new arrivals, or bestsellers.
  * Available on Location templates.
  */
-export const ProductSection: ComponentConfig<ProductSectionProps> = {
+export const ProductSection: ComponentConfig<{ props: ProductSectionProps }> = {
   label: msg("components.productsSection", "Products Section"),
   fields: productSectionFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/pageSections/PromoSection.test.tsx
+++ b/packages/visual-editor/src/components/pageSections/PromoSection.test.tsx
@@ -332,7 +332,7 @@ describe("PromoSection", async () => {
   const puckConfig: Config = {
     components: { PromoSection },
     root: {
-      render: ({ children }) => {
+      render: ({ children }: { children: React.ReactNode }) => {
         return <>{children}</>;
       },
     },

--- a/packages/visual-editor/src/components/pageSections/PromoSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/PromoSection.tsx
@@ -177,6 +177,7 @@ const promoSectionFields: Fields<PromoSectionProps> = {
     msg("fields.visibleOnLivePage", "Visible on Live Page"),
     {
       type: "radio",
+      isOptional: true,
       options: [
         { label: msg("fields.options.show", "Show"), value: true },
         { label: msg("fields.options.hide", "Hide"), value: false },
@@ -315,7 +316,7 @@ const PromoWrapper: React.FC<PromoSectionProps> = ({ data, styles }) => {
  * The Promo Section is a flexible content component designed to highlight a single, specific promotion. It combines an image with a title, description, and a call-to-action button in a customizable, split-column layout, making it perfect for drawing attention to special offers or announcements.
  * Available on Location templates.
  */
-export const PromoSection: ComponentConfig<PromoSectionProps> = {
+export const PromoSection: ComponentConfig<{ props: PromoSectionProps }> = {
   label: msg("components.promoSection", "Promo Section"),
   fields: promoSectionFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/pageSections/ReviewsSection.test.tsx
+++ b/packages/visual-editor/src/components/pageSections/ReviewsSection.test.tsx
@@ -119,7 +119,7 @@ describe("ReviewsSection", async () => {
   const puckConfig: Config = {
     components: { ReviewsSection },
     root: {
-      render: ({ children }) => {
+      render: ({ children }: { children: React.ReactNode }) => {
         return <>{children}</>;
       },
     },

--- a/packages/visual-editor/src/components/pageSections/ReviewsSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/ReviewsSection.tsx
@@ -450,7 +450,7 @@ const ShowMoreButton: React.FC<{
   );
 };
 
-export const ReviewsSection: ComponentConfig<ReviewsSectionProps> = {
+export const ReviewsSection: ComponentConfig<{ props: ReviewsSectionProps }> = {
   fields: reviewsFields,
   label: msg("components.reviewsSection", "Reviews Section"),
   defaultProps: {

--- a/packages/visual-editor/src/components/pageSections/SectionContainer.tsx
+++ b/packages/visual-editor/src/components/pageSections/SectionContainer.tsx
@@ -33,6 +33,7 @@ export type SectionContainerProps = {
 const sectionContainerFields: Fields<SectionContainerProps> = {
   background: YextField(msg("fields.backgroundColor", "Background Color"), {
     type: "select",
+    isOptional: true,
     options: "BACKGROUND_COLOR",
   }),
   sectionHeading: YextField(msg("fields.sectionHeading", "Section Heading"), {
@@ -108,7 +109,9 @@ const SectionContainerComponent: PuckComponent<SectionContainerProps> = (
   );
 };
 
-export const SectionContainer: ComponentConfig<SectionContainerProps> = {
+export const SectionContainer: ComponentConfig<{
+  props: SectionContainerProps;
+}> = {
   label: "Section Container",
   fields: sectionContainerFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/pageSections/StaticMapSection.test.tsx
+++ b/packages/visual-editor/src/components/pageSections/StaticMapSection.test.tsx
@@ -112,7 +112,7 @@ describe("StaticMapSection", async () => {
   const puckConfig: Config = {
     components: { StaticMapSection },
     root: {
-      render: ({ children }) => {
+      render: ({ children }: { children: React.ReactNode }) => {
         return <>{children}</>;
       },
     },

--- a/packages/visual-editor/src/components/pageSections/StaticMapSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/StaticMapSection.tsx
@@ -102,7 +102,9 @@ const StaticMapSectionWrapper = ({ data, styles }: StaticMapSectionProps) => {
  * The Static Map Section displays a non-interactive map image of a business's location. It uses the entity's address or coordinates to generate the map and requires a valid API key from mapbox.
  * Available on Location templates.
  */
-export const StaticMapSection: ComponentConfig<StaticMapSectionProps> = {
+export const StaticMapSection: ComponentConfig<{
+  props: StaticMapSectionProps;
+}> = {
   label: msg("components.staticMapSection", "Static Map Section"),
   fields: staticMapSectionFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/pageSections/TeamSection.test.tsx
+++ b/packages/visual-editor/src/components/pageSections/TeamSection.test.tsx
@@ -345,7 +345,7 @@ describe("TeamSection", async () => {
   const puckConfig: Config = {
     components: { TeamSection },
     root: {
-      render: ({ children }) => {
+      render: ({ children }: { children: React.ReactNode }) => {
         return <>{children}</>;
       },
     },

--- a/packages/visual-editor/src/components/pageSections/TeamSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/TeamSection.tsx
@@ -357,7 +357,7 @@ const TeamSectionWrapper = ({ data, styles }: TeamSectionProps) => {
  * The Team Section is designed to showcase a list of people, such as employees, executives, or other team members. It features a main section heading and renders each person's information—typically a photo, name, and title—as an individual card.
  * Available on Location templates.
  */
-export const TeamSection: ComponentConfig<TeamSectionProps> = {
+export const TeamSection: ComponentConfig<{ props: TeamSectionProps }> = {
   label: msg("components.teamSection", "Team Section"),
   fields: TeamSectionFields,
   defaultProps: {

--- a/packages/visual-editor/src/components/pageSections/TestimonialSection.test.tsx
+++ b/packages/visual-editor/src/components/pageSections/TestimonialSection.test.tsx
@@ -258,7 +258,7 @@ describe("TestimonialSection", async () => {
   const puckConfig: Config = {
     components: { TestimonialSection },
     root: {
-      render: ({ children }) => {
+      render: ({ children }: { children: React.ReactNode }) => {
         return <>{children}</>;
       },
     },

--- a/packages/visual-editor/src/components/pageSections/TestimonialSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/TestimonialSection.tsx
@@ -269,7 +269,9 @@ const TestimonialSectionWrapper = ({
  * The Testimonial Section is used to display a list of customer testimonials or reviews. It features a main section heading and renders each testimonial as an individual card, providing social proof and building trust with visitors.
  * Available on Location templates.
  */
-export const TestimonialSection: ComponentConfig<TestimonialSectionProps> = {
+export const TestimonialSection: ComponentConfig<{
+  props: TestimonialSectionProps;
+}> = {
   label: msg("components.testimonialsSection", "Testimonials Section"),
   fields: testimonialSectionFields,
   defaultProps: {

--- a/packages/visual-editor/src/editor/BasicSelector.tsx
+++ b/packages/visual-editor/src/editor/BasicSelector.tsx
@@ -27,7 +27,7 @@ type BasicSelectorProps = {
     }
 );
 
-export const BasicSelector = (props: BasicSelectorProps): Field => {
+export const BasicSelector = <T,>(props: BasicSelectorProps): Field<T> => {
   const {
     label,
     options = [],

--- a/packages/visual-editor/src/editor/SpacingSelector.tsx
+++ b/packages/visual-editor/src/editor/SpacingSelector.tsx
@@ -78,11 +78,11 @@ const convertDefaultSpacingsToOptions = (
   });
 };
 
-export const SpacingSelector = (
+export const SpacingSelector = <T,>(
   label: string,
   spacingType: "padding" | "gap",
   includeDefault: boolean
-): Field => {
+): Field<T> => {
   return {
     type: "custom",
     render: ({ value, onChange }) => {

--- a/packages/visual-editor/src/editor/YextEntityFieldSelector.tsx
+++ b/packages/visual-editor/src/editor/YextEntityFieldSelector.tsx
@@ -81,7 +81,7 @@ export const TYPE_TO_CONSTANT_CONFIG: Record<string, Field<any>> = {
 const LIST_TYPE_TO_CONSTANT_CONFIG = (): Record<string, Field<any>> => {
   return {
     "type.string": TRANSLATABLE_TEXT_LIST_CONSTANT_CONFIG,
-    "type.image": IMAGE_LIST_CONSTANT_CONFIG(),
+    "type.image": IMAGE_LIST_CONSTANT_CONFIG() as Field<any>,
   };
 };
 

--- a/packages/visual-editor/src/editor/YextField.tsx
+++ b/packages/visual-editor/src/editor/YextField.tsx
@@ -46,11 +46,12 @@ type selectOptions = keyof Omit<typeof ThemeOptions, radioOptions>;
 type YextBaseField = {
   type: string;
   visible?: boolean;
+  isOptional?: boolean;
 };
 
 // YextArrayField has same functionality as Puck's ArrayField
 type YextArrayField<
-  Props extends { [key: string]: any } = { [key: string]: any },
+  Props extends { [key: string]: any }[] = { [key: string]: any }[],
 > = YextBaseField & Omit<ArrayField<Props>, keyof BaseField>;
 
 // YextNumberField has same functionality as Puck's NumberField
@@ -117,7 +118,7 @@ type YextEntitySelectorField<
   };
 
 type YextFieldConfig<Props = any> =
-  | YextArrayField<Props extends Record<string, any> ? Props : any>
+  | YextArrayField<Props extends Record<string, any>[] ? Props : any>
   | YextObjectField<Props extends Record<string, any> ? Props : any>
   | YextNumberField
   | YextTextField
@@ -132,6 +133,11 @@ type YextFieldConfig<Props = any> =
 
 export function YextField<T = any>(
   fieldName: MsgString,
+  config: YextFieldConfig<T> & { isOptional: true }
+): Field<T | undefined>;
+
+export function YextField<T = any>(
+  fieldName: MsgString,
   config: YextFieldConfig<T>
 ): Field<T>;
 
@@ -143,7 +149,7 @@ export function YextField<T extends Record<string, any>, U = any>(
 export function YextField<T, U>(
   fieldName: MsgString,
   config: YextFieldConfig<T>
-): Field<any> {
+): any {
   // use YextEntityFieldSelector
   if (config.type === "entityField") {
     return YextEntityFieldSelector<T extends Record<string, any> ? T : any, U>({

--- a/packages/visual-editor/src/internal/components/InternalLayoutEditor.tsx
+++ b/packages/visual-editor/src/internal/components/InternalLayoutEditor.tsx
@@ -358,16 +358,34 @@ const TranslatePuckFieldLabels = ({
       }
 
       if ("label" in child.props || "title" in child.props) {
+        const newChildren = {
+          ...child.props,
+          children: React.Children.map(child.props.children, replaceText),
+          label: child.props.label ? pt(child.props.label) : undefined,
+          title: child.props.title ? pt(child.props.title) : undefined,
+        };
+
+        // Radio options need to be translated as well
+        if (child.props.field?.type === "radio") {
+          const originalField = child.props.field;
+          const originalOptions = originalField.options || [];
+
+          const translatedOptions = originalOptions.map((option: any) => ({
+            ...option,
+            label: pt(option.label),
+          }));
+
+          newChildren.field = {
+            ...originalField,
+            options: translatedOptions,
+          };
+        }
+
         return React.cloneElement(
           child as React.ReactElement<{
             children?: React.ReactNode;
           }>,
-          {
-            ...child.props,
-            children: React.Children.map(child.props.children, replaceText),
-            label: child.props.label ? pt(child.props.label) : undefined,
-            title: child.props.title ? pt(child.props.title) : undefined,
-          }
+          newChildren
         );
       } else {
         return React.cloneElement(

--- a/packages/visual-editor/src/internal/components/InternalThemeEditor.tsx
+++ b/packages/visual-editor/src/internal/components/InternalThemeEditor.tsx
@@ -186,7 +186,7 @@ export const InternalThemeEditor = ({
             />
           ),
           actionBar: () => <></>,
-          components: () => <></>,
+          drawer: () => <></>,
           fields: fieldsOverride,
           iframe: loadMapboxIntoIframe,
         }}

--- a/packages/visual-editor/src/internal/puck/constant-value-fields/CallToAction.tsx
+++ b/packages/visual-editor/src/internal/puck/constant-value-fields/CallToAction.tsx
@@ -34,16 +34,16 @@ export const linkTypeOptions = () => {
 };
 
 // Fields for TranslatableCTA with labels
-export const translatableCTAFields = (): Field<TranslatableCTA | undefined> => {
+export const translatableCTAFields = (): Field<TranslatableCTA> => {
   const labelField = useMemo(() => {
-    return TranslatableStringField<TranslatableString | undefined>(
+    return TranslatableStringField<TranslatableString>(
       msg("fields.label", "Label"),
       { types: ["type.string"] }
     );
   }, []);
 
   const linkField = useMemo(() => {
-    return TranslatableStringField<TranslatableString | undefined>(
+    return TranslatableStringField<TranslatableString>(
       msg("fields.link", "Link"),
       { types: ["type.string"] },
       true

--- a/packages/visual-editor/src/utils/filterComponents.tsx
+++ b/packages/visual-editor/src/utils/filterComponents.tsx
@@ -1,4 +1,4 @@
-import { DefaultComponentProps, type Config } from "@measured/puck";
+import { type Config } from "@measured/puck";
 
 // The components that are disallowed by default. They are only visible and draggable if a business has the appropriate product features enabled.
 const gatedLayoutComponents: string[] = ["CustomCodeSection"];
@@ -14,11 +14,11 @@ const gatedLayoutCategories: string[] = ["coreInformation"];
  * @param additionalLayoutCategories - An optional list of gated categories to retain.
  * @returns A new configuration object with all gated components removed, except for those listed in `additionalLayoutComponents`.
  */
-export const filterComponentsFromConfig = <T extends DefaultComponentProps>(
-  config: Config<T>,
+export const filterComponentsFromConfig = <C extends Config>(
+  config: C,
   additionalLayoutComponents?: string[],
   additionalLayoutCategories?: string[]
-): Config<T> => {
+): C => {
   // 1. Filter out gated categories unless they are explicitly allowed
   const allowedCategories = Object.entries(config.categories || {}).filter(
     ([categoryKey]) => {
@@ -55,11 +55,7 @@ export const filterComponentsFromConfig = <T extends DefaultComponentProps>(
 
   return {
     ...config,
-    components: Object.fromEntries(
-      allowedComponents
-    ) as Config<T>["components"],
-    categories: Object.fromEntries(
-      allowedCategories
-    ) as Config<T>["categories"],
+    components: Object.fromEntries(allowedComponents) as C["components"],
+    categories: Object.fromEntries(allowedCategories) as C["categories"],
   };
 };

--- a/packages/visual-editor/src/utils/withPropOverrides.ts
+++ b/packages/visual-editor/src/utils/withPropOverrides.ts
@@ -1,9 +1,9 @@
-import { ComponentConfig, DefaultComponentProps } from "@measured/puck";
+import { ComponentConfig } from "@measured/puck";
 
-export function withPropOverrides<P extends DefaultComponentProps>(
-  base: ComponentConfig<P>,
-  overrides: Partial<P>
-): ComponentConfig<P> {
+export function withPropOverrides<C extends ComponentConfig>(
+  base: C,
+  overrides: Partial<typeof base.defaultProps>
+): C {
   return {
     ...base,
     render: (props) => base.render({ ...props, ...overrides }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,8 +83,8 @@ importers:
   packages/visual-editor:
     dependencies:
       "@measured/puck":
-        specifier: 0.19.3
-        version: 0.19.3(@types/react@18.3.23)(immer@9.0.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(use-sync-external-store@1.5.0(react@18.3.1))
+        specifier: 0.20.1
+        version: 0.20.1(@types/react@18.3.23)(immer@9.0.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(use-sync-external-store@1.5.0(react@18.3.1))
       "@microsoft/api-documenter":
         specifier: ^7.26.29
         version: 7.26.30(@types/node@20.19.9)
@@ -366,8 +366,8 @@ importers:
         specifier: ^7.10.1
         version: 7.17.8(react@18.3.1)
       "@measured/puck":
-        specifier: 0.19.3
-        version: 0.19.3(@types/react@18.3.23)(immer@9.0.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(use-sync-external-store@1.5.0(react@18.3.1))
+        specifier: 0.20.1
+        version: 0.20.1(@types/react@18.3.23)(immer@9.0.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(use-sync-external-store@1.5.0(react@18.3.1))
       "@radix-ui/react-accordion":
         specifier: ^1.2.0
         version: 1.2.11(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2144,10 +2144,10 @@ packages:
       }
     engines: { node: ">=6.0.0" }
 
-  "@measured/puck@0.19.3":
+  "@measured/puck@0.20.1":
     resolution:
       {
-        integrity: sha512-gWRiHWFZgnNj/QfeLkapVURSJJoxKEzRth7D+SVcqh9eiuQiXH7txhrAN5YEgKNqw/xzooSAf8PhLm8M9bTKug==,
+        integrity: sha512-qD5nDxDqbm5dEF4nQrgR3cTEnDRSe320HtWDOFaoRe7FpHCQBBPyDqb49maK9YUR0TPy7j8OeG1ymDHnKy05Ow==,
       }
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
@@ -13294,7 +13294,7 @@ snapshots:
 
   "@mapbox/whoots-js@3.1.0": {}
 
-  "@measured/puck@0.19.3(@types/react@18.3.23)(immer@9.0.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(use-sync-external-store@1.5.0(react@18.3.1))":
+  "@measured/puck@0.20.1(@types/react@18.3.23)(immer@9.0.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(use-sync-external-store@1.5.0(react@18.3.1))":
     dependencies:
       "@dnd-kit/helpers": 0.1.18
       "@dnd-kit/react": 0.1.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/starter/package.json
+++ b/starter/package.json
@@ -20,7 +20,7 @@
     "@heroicons/react": "^2.1.5",
     "@mantine/core": "^7.10.1",
     "@mantine/hooks": "^7.10.1",
-    "@measured/puck": "0.19.3",
+    "@measured/puck": "0.20.1",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-alert-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.1.15",


### PR DESCRIPTION
Changes:
- `overrides.components` is replaced with `overrides.drawer`
- `ComponentConfig` now requires prop generic to be passed as `<{props: Props}>` instead of `<Props>`
- Updated various types to comply with more strict typing
- Handle translations for radio options separately