### PR TITLE
chore: update fonts to match platform

### DIFF
--- a/packages/visual-editor/src/editor/Editor.tsx
+++ b/packages/visual-editor/src/editor/Editor.tsx
@@ -4,7 +4,6 @@ import { ErrorBoundary } from "react-error-boundary";
 import { LoadingScreen } from "../internal/puck/components/LoadingScreen.tsx";
 import { Toaster } from "../internal/puck/ui/Toaster.tsx";
 import { type Config } from "@measured/puck";
-import "@measured/puck/puck.css";
 import { useEntityFields } from "../hooks/useEntityFields.tsx";
 import { DevLogger } from "../utils/devLogger.ts";
 import { ThemeConfig } from "../utils/themeResolver.ts";

--- a/packages/visual-editor/src/editor/index.css
+++ b/packages/visual-editor/src/editor/index.css
@@ -1,6 +1,12 @@
+@import "@measured/puck/no-external.css";
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:root {
+  --puck-font-family:
+    Inter, "SF Pro", "Helvetica Neue", Helvetica, sans-serif !important;
+}
 
 .is-today {
   font-weight: 700;

--- a/starter/src/index.css
+++ b/starter/src/index.css
@@ -1,6 +1,12 @@
+@import "@measured/puck/no-external.css";
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:root {
+  --puck-font-family:
+    Inter, "SF Pro", "Helvetica Neue", Helvetica, sans-serif !important;
+}
 
 .flex-container {
   display: flex;


### PR DESCRIPTION
This updates the `--puck-font-family` variable to use the font stack used in platform. Verified that fonts are updated in both `pages-visual-editor-starter` and `/starter`.

<img width="1954" height="1345" alt="Screenshot 2025-08-28 at 1 00 23 PM" src="https://github.com/user-attachments/assets/32e5a595-4a58-4047-a27c-ac111872709d" />
