### PR TITLE
fix: translate select options

### DIFF
--- a/packages/visual-editor/src/internal/components/InternalLayoutEditor.tsx
+++ b/packages/visual-editor/src/internal/components/InternalLayoutEditor.tsx
@@ -365,8 +365,11 @@ const TranslatePuckFieldLabels = ({
           title: child.props.title ? pt(child.props.title) : undefined,
         };
 
-        // Radio options need to be translated as well
-        if (child.props.field?.type === "radio") {
+        // Radio and Select options need to be translated as well
+        if (
+          child.props.field?.type === "radio" ||
+          child.props.field?.type === "select"
+        ) {
           const originalField = child.props.field;
           const originalOptions = originalField.options || [];
 


### PR DESCRIPTION
This ensures that both Radio and Select options are translated in the editor.

<img width="353" height="205" alt="Screenshot 2025-08-28 at 2 39 09 PM" src="https://github.com/user-attachments/assets/66423a09-c08d-4cbb-bbce-b6b81aa8c8ae" />
