### PR TITLE
fix: embedded field conversion

### DIFF
--- a/packages/visual-editor/src/editor/YextEntityFieldSelector.tsx
+++ b/packages/visual-editor/src/editor/YextEntityFieldSelector.tsx
@@ -340,8 +340,12 @@ export const ConstantValueInput = <T extends Record<string, any>>({
           onChange({
             ...value,
             constantValue: {
-              ...value?.constantValue,
+              ...(typeof value?.constantValue === "object" &&
+              !Array.isArray(value?.constantValue)
+                ? value?.constantValue
+                : {}),
               [locale]: newInputValue,
+              hasLocalizedValue: "true",
             },
           });
         }}


### PR DESCRIPTION
This mirrors logic in `packages/visual-editor/src/editor/TranslatableStringField.tsx` that converts old-style basic strings into TranslatableStrings