### PR TITLE
fix: prevent HeroSection image flickering

### DIFF
--- a/packages/visual-editor/src/components/pageSections/HeroSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/HeroSection.tsx
@@ -165,6 +165,13 @@ export interface HeroSectionProps {
 
 export type HeroVariantProps = Pick<HeroSectionProps, "data" | "styles">;
 
+export type HeroImageProps = {
+  className: string;
+  resolvedHero: HeroSectionType | undefined;
+  styles: HeroStyles;
+  data: HeroData;
+};
+
 const heroSectionFields: Fields<HeroSectionProps> = {
   data: YextField(msg("fields.data", "Data"), {
     type: "object",

--- a/packages/visual-editor/src/components/pageSections/heroVariants/ClassicHero.tsx
+++ b/packages/visual-editor/src/components/pageSections/heroVariants/ClassicHero.tsx
@@ -8,8 +8,41 @@ import {
   resolveYextStructField,
 } from "@yext/visual-editor";
 import { useTranslation } from "react-i18next";
-import { HeroVariantProps } from "../HeroSection";
+import { HeroVariantProps, HeroImageProps } from "../HeroSection";
 import { HeroContent, heroContentParentCn } from "./HeroContent";
+
+const ClassicHeroImage = ({
+  className,
+  resolvedHero,
+  styles,
+  data,
+}: HeroImageProps) => {
+  const { t } = useTranslation();
+
+  return (
+    resolvedHero?.image &&
+    styles.showImage && (
+      <div
+        className={themeManagerCn("w-full my-auto", className)}
+        role="region"
+        aria-label={t("heroImage", "Hero Image")}
+      >
+        <EntityField
+          displayName={pt("fields.image", "Image")}
+          fieldId={data.hero.field}
+          constantValueEnabled={data.hero.constantValueOverride.image}
+        >
+          <Image
+            image={resolvedHero?.image}
+            aspectRatio={styles.image.aspectRatio}
+            width={styles.image.width}
+            className="max-w-full sm:max-w-initial md:max-w-[350px] lg:max-w-none rounded-image-borderRadius"
+          />
+        </EntityField>
+      </div>
+    )
+  );
+};
 
 export const ClassicHero: React.FC<HeroVariantProps> = ({ data, styles }) => {
   const { t, i18n } = useTranslation();
@@ -20,32 +53,6 @@ export const ClassicHero: React.FC<HeroVariantProps> = ({ data, styles }) => {
     data?.hero,
     locale
   );
-
-  const ClassicHeroImage = ({ className }: { className: string }) => {
-    return (
-      resolvedHero?.image &&
-      styles.showImage && (
-        <div
-          className={themeManagerCn("w-full my-auto", className)}
-          role="region"
-          aria-label={t("heroImage", "Hero Image")}
-        >
-          <EntityField
-            displayName={pt("fields.image", "Image")}
-            fieldId={data.hero.field}
-            constantValueEnabled={data.hero.constantValueOverride.image}
-          >
-            <Image
-              image={resolvedHero?.image}
-              aspectRatio={styles.image.aspectRatio}
-              width={styles.image.width}
-              className="max-w-full sm:max-w-initial md:max-w-[350px] lg:max-w-none rounded-image-borderRadius"
-            />
-          </EntityField>
-        </div>
-      )
-    );
-  };
 
   return (
     <PageSection
@@ -59,6 +66,9 @@ export const ClassicHero: React.FC<HeroVariantProps> = ({ data, styles }) => {
           styles.mobileImagePosition === "bottom" && "hidden sm:block",
           styles.desktopImagePosition === "right" && "sm:hidden"
         )}
+        resolvedHero={resolvedHero}
+        styles={styles}
+        data={data}
       />
 
       <div
@@ -75,6 +85,9 @@ export const ClassicHero: React.FC<HeroVariantProps> = ({ data, styles }) => {
           styles.mobileImagePosition === "top" && "hidden sm:block",
           styles.desktopImagePosition === "left" && "sm:hidden"
         )}
+        resolvedHero={resolvedHero}
+        styles={styles}
+        data={data}
       />
     </PageSection>
   );

--- a/packages/visual-editor/src/components/pageSections/heroVariants/CompactHero.tsx
+++ b/packages/visual-editor/src/components/pageSections/heroVariants/CompactHero.tsx
@@ -9,11 +9,46 @@ import {
   Background,
   resolveYextStructField,
 } from "@yext/visual-editor";
-import { HeroVariantProps } from "../HeroSection";
+import { HeroVariantProps, HeroImageProps } from "../HeroSection";
 import { HeroContent, heroContentParentCn } from "./HeroContent";
 
+const CompactHeroImage = ({
+  className,
+  resolvedHero,
+  styles,
+  data,
+}: HeroImageProps) => {
+  const { t } = useTranslation();
+
+  return resolvedHero?.image && styles.showImage ? (
+    <div
+      className={themeManagerCn("w-full", className)}
+      role="region"
+      aria-label={t("heroImage", "Hero Image")}
+    >
+      <EntityField
+        displayName={pt("fields.image", "Image")}
+        fieldId={data.hero.field}
+        constantValueEnabled={data.hero.constantValueOverride.image}
+        fullHeight
+      >
+        <Image
+          image={resolvedHero.image}
+          aspectRatio={styles.image.aspectRatio}
+          className={themeManagerCn(
+            "w-full sm:w-fit h-full",
+            styles.desktopImagePosition === "left" ? "mr-auto" : "ml-auto"
+          )}
+        />
+      </EntityField>
+    </div>
+  ) : (
+    <div className="w-full"></div>
+  );
+};
+
 export const CompactHero: React.FC<HeroVariantProps> = ({ data, styles }) => {
-  const { t, i18n } = useTranslation();
+  const { i18n } = useTranslation();
   const locale = i18n.language;
   const streamDocument = useDocument();
   const resolvedHero = resolveYextStructField(
@@ -21,34 +56,6 @@ export const CompactHero: React.FC<HeroVariantProps> = ({ data, styles }) => {
     data?.hero,
     locale
   );
-
-  const CompactHeroImage = ({ className }: { className: string }) => {
-    return resolvedHero?.image && styles.showImage ? (
-      <div
-        className={themeManagerCn("w-full", className)}
-        role="region"
-        aria-label={t("heroImage", "Hero Image")}
-      >
-        <EntityField
-          displayName={pt("fields.image", "Image")}
-          fieldId={data.hero.field}
-          constantValueEnabled={data.hero.constantValueOverride.image}
-          fullHeight
-        >
-          <Image
-            image={resolvedHero.image}
-            aspectRatio={styles.image.aspectRatio}
-            className={themeManagerCn(
-              "w-full sm:w-fit h-full",
-              styles.desktopImagePosition === "left" ? "mr-auto" : "ml-auto"
-            )}
-          />
-        </EntityField>
-      </div>
-    ) : (
-      <div className="w-full"></div>
-    );
-  };
 
   return (
     <Background
@@ -61,6 +68,9 @@ export const CompactHero: React.FC<HeroVariantProps> = ({ data, styles }) => {
           styles.mobileImagePosition === "bottom" && "hidden sm:block",
           styles.desktopImagePosition === "right" && "sm:hidden"
         )}
+        resolvedHero={resolvedHero}
+        styles={styles}
+        data={data}
       />
 
       {/* Mobile container styles */}
@@ -104,6 +114,9 @@ export const CompactHero: React.FC<HeroVariantProps> = ({ data, styles }) => {
           styles.mobileImagePosition === "top" && "hidden sm:block",
           styles.desktopImagePosition === "left" && "sm:hidden"
         )}
+        resolvedHero={resolvedHero}
+        styles={styles}
+        data={data}
       />
     </Background>
   );


### PR DESCRIPTION
Defining the Image components inside the Hero components was causing the image on the HeroSection to flicker as it got re-defined every re-render. Verified manually that the image no longer flickers when hovering over it.

https://github.com/user-attachments/assets/c395d076-9f03-472c-b774-b54cd4e6770b

