### PR TITLE
fix: cannot read properties of null error during editor load

### DIFF
--- a/packages/visual-editor/src/utils/applyTheme.ts
+++ b/packages/visual-editor/src/utils/applyTheme.ts
@@ -121,7 +121,7 @@ export const updateThemeInEditor = async (
       PUCK_PREVIEW_IFRAME_ID
     ) as HTMLIFrameElement;
     const pagePreviewStyleTag =
-      iframe.contentDocument?.getElementById(THEME_STYLE_TAG_ID);
+      iframe?.contentDocument?.getElementById(THEME_STYLE_TAG_ID);
     if (pagePreviewStyleTag) {
       observer.disconnect();
       pagePreviewStyleTag.innerText = newThemeTag;


### PR DESCRIPTION
Confirmed the error no longer occurred when loading the editor in platform