### PR TITLE
fix: correct German 'open now' translation

### DIFF
--- a/packages/visual-editor/locales/de/visual-editor.json
+++ b/packages/visual-editor/locales/de/visual-editor.json
@@ -414,7 +414,7 @@
   "open24Hours": "24 Stunden geöffnet",
   "openHeaderMenu": "Öffnen Sie das Header -Menü",
   "openMenu": "Öffnen Sie das Menü",
-  "openNow": "Jetzt öffnen",
+  "openNow": "Jetzt offen",
   "opensAt": "Öffnet sich bei",
   "optional": "Optional",
   "outline": "Gliederung",


### PR DESCRIPTION
The current German translation means more like
'open \<this\> now' instead of the intended
'\<things which are\> open now'. This small change
adjusts that.