### PR TITLE
fix: resolve base entity url templates in directory pages

### DIFF
--- a/packages/visual-editor/src/utils/applyTheme.ts
+++ b/packages/visual-editor/src/utils/applyTheme.ts
@@ -23,6 +23,7 @@ export type StreamDocument = {
     name?: string;
     visualEditorConfig?: string;
     isPrimaryLocale?: boolean;
+    entityPageSetUrlTemplates?: string;
   };
 };
 

--- a/packages/visual-editor/src/utils/resolveUrlTemplate.test.ts
+++ b/packages/visual-editor/src/utils/resolveUrlTemplate.test.ts
@@ -27,6 +27,27 @@ const mockStreamDocument: StreamDocument = {
   }),
 };
 
+const mockDirectoryDocument: StreamDocument = {
+  name: "Yext",
+  id: "123",
+  locale: "en",
+  address: {
+    line1: "61 9th Ave",
+    city: "New York",
+    region: "NY",
+    country: "USA",
+  },
+  __: {
+    isPrimaryLocale: true,
+    codeTemplate: "directory",
+    entityPageSetUrlTemplates: JSON.stringify({
+      primary: "[[address.region]]/page/[[id]]",
+      alternate: "[[locale]]/[[address.region]]/page/[[id]]",
+    }),
+  },
+  _pageset: JSON.stringify({}),
+};
+
 describe("resolveUrlTemplate", () => {
   it("resolves primary template for primary locale", () => {
     const result = resolveUrlTemplate(mockStreamDocument, "");
@@ -233,5 +254,22 @@ describe("resolveUrlTemplate", () => {
       __: { isPrimaryLocale: false },
     };
     expect(() => resolveUrlTemplate(alternateLocaleDoc, "")).toThrowError();
+  });
+
+  it("handles primary url template on directory pages", () => {
+    expect(resolveUrlTemplate(mockDirectoryDocument, "")).toBe("ny/page/123");
+  });
+
+  it("handles alternate url templates on directory pages", () => {
+    expect(
+      resolveUrlTemplate(
+        {
+          ...mockDirectoryDocument,
+          __: { ...mockDirectoryDocument.__, isPrimaryLocale: false },
+          locale: "es",
+        },
+        ""
+      )
+    ).toBe("es/ny/page/123");
   });
 });

--- a/packages/visual-editor/src/utils/resolveUrlTemplate.ts
+++ b/packages/visual-editor/src/utils/resolveUrlTemplate.ts
@@ -35,8 +35,15 @@ export const resolveUrlTemplate = (
 
   const isPrimaryLocale = streamDocument.__?.isPrimaryLocale !== false;
 
-  const pagesetJson = JSON.parse(streamDocument?._pageset || "{}");
-  const urlTemplates = pagesetJson?.config?.urlTemplate || {};
+  let urlTemplates;
+  if (streamDocument?.__?.codeTemplate === "directory") {
+    urlTemplates = JSON.parse(
+      streamDocument?.__?.entityPageSetUrlTemplates || "{}"
+    );
+  } else {
+    const pagesetJson = JSON.parse(streamDocument?._pageset || "{}");
+    urlTemplates = pagesetJson?.config?.urlTemplate || {};
+  }
 
   let urlTemplate: string | undefined;
   if (isPrimaryLocale && urlTemplates.primary) {


### PR DESCRIPTION
For directory pages, Spruce has added the base entity's url template under `__.entityPageSetUrlTemplates`