### PR TITLE
fix: phoneNumbers in CoreInfoSection bombing out

### DIFF
--- a/packages/visual-editor/src/components/contentBlocks/Phone.tsx
+++ b/packages/visual-editor/src/components/contentBlocks/Phone.tsx
@@ -65,6 +65,17 @@ export const PhoneStyleFields = {
   ),
 };
 
+export const defaultPhoneDataProps: PhoneProps["data"] = {
+  number: {
+    field: "mainPhone",
+    constantValue: "",
+  },
+  label: {
+    en: "Phone",
+    hasLocalizedValue: "true",
+  },
+};
+
 const PhoneFields: Fields<PhoneProps> = {
   data: YextField(msg("fields.data", "Data"), {
     type: "object",
@@ -112,16 +123,7 @@ export const Phone: ComponentConfig<{ props: PhoneProps }> = {
   label: msg("components.phone", "Phone"),
   fields: PhoneFields,
   defaultProps: {
-    data: {
-      number: {
-        field: "mainPhone",
-        constantValue: "",
-      },
-      label: {
-        en: "Phone",
-        hasLocalizedValue: "true",
-      },
-    },
+    data: defaultPhoneDataProps,
     styles: {
       phoneFormat: "domestic",
       includePhoneHyperlink: true,

--- a/packages/visual-editor/src/components/pageSections/CoreInfoSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/CoreInfoSection.tsx
@@ -38,6 +38,7 @@ import {
   AddressStyleFields,
 } from "../contentBlocks/Address.tsx";
 import {
+  defaultPhoneDataProps,
   PhoneDataFields,
   PhoneProps,
   PhoneStyleFields,
@@ -145,6 +146,7 @@ const coreInfoSectionFields: Fields<CoreInfoSectionProps> = {
           phoneNumbers: YextField(msg("fields.phoneNumbers", "Phone Numbers"), {
             type: "array",
             arrayFields: PhoneDataFields,
+            defaultItemProps: defaultPhoneDataProps,
             getItemSummary: (item): string => {
               const { i18n } = usePlatformTranslation();
               const streamDocument = useDocument();


### PR DESCRIPTION
Original steps to reproduce problem: 
1. Drag in the CoreInfoSection
2. Delete the existing phone item in the phone numbers array field
3. Add a new phone item 
4. Attempt to edit or change the phone data 
5. Bombs out b/c the default phone props in the array were invalid 

Tested locally and confirmed is fixed. 