### PR TITLE
fix: cannot convert undefined or null to object sentry

### DIFF
--- a/packages/visual-editor/src/internal/utils/getFilteredEntityFields.ts
+++ b/packages/visual-editor/src/internal/utils/getFilteredEntityFields.ts
@@ -122,7 +122,8 @@ const getTypeFromSchemaField = (schemaField: YextSchemaField) => {
   return (
     schemaField.definition.typeName ||
     schemaField.definition.typeRegistryId ||
-    Object.entries(schemaField.definition.type)[0][1]
+    (schemaField.definition.type &&
+      Object.entries(schemaField.definition.type)[0][1])
   );
 };
 


### PR DESCRIPTION
https://yext-engineering.sentry.io/issues/6903316812

The trace is to `e.definition.typeName||e.definition.typeRegistryId||Object.entries(e.definition.type)[0][1];function lJ(e,t,n){const r=e.get(t)||[];return r` and the error is what happens when you can `Object.entries` with null/undefined.

Both callers of `getTypeFromSchemaField` can accept false as a return value.