### PR TITLE
fix: photo gallery css and update component tests

### DIFF
--- a/packages/visual-editor/src/components/styles.css
+++ b/packages/visual-editor/src/components/styles.css
@@ -1,2 +1,3 @@
+@import "pure-react-carousel/dist/react-carousel.es.css";
 @import "./atoms/hours.css";
 @import "./atoms/maybeRTF.css";

--- a/packages/visual-editor/src/components/testing/componentTests.css
+++ b/packages/visual-editor/src/components/testing/componentTests.css
@@ -1,4 +1,4 @@
-@config "./componentTests.tailwind.config.ts"
+@config "./componentTests.tailwind.config.ts";
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/packages/visual-editor/src/components/testing/componentTests.setup.ts
+++ b/packages/visual-editor/src/components/testing/componentTests.setup.ts
@@ -2,6 +2,8 @@ import { configureAxe } from "jest-axe";
 import { defaultThemeConfig, applyTheme } from "@yext/visual-editor";
 // Applies the theme tailwind classes
 import "./componentTests.css";
+// Applies the build css that is applied to the page templates
+import "../../../dist/style.css";
 // Enabled expect().toHaveNoViolations()
 import "jest-axe/extend-expect";
 import { expect, vi } from "vitest";


### PR DESCRIPTION
Fixes the photo gallery css

Updates the screenshot tests to only use the built style.css file (instead of vite resolving each css import individually) to match how the css is applied to the page templates. Confirmed that the screenshot included the photo gallery bug before adding the import to styles.css