### PR TITLE
feat: provide default schema to parent window

### DIFF
--- a/packages/visual-editor/src/internal/components/AdvancedSettings.tsx
+++ b/packages/visual-editor/src/internal/components/AdvancedSettings.tsx
@@ -45,9 +45,11 @@ const SCHEMA_MARKUP_FIELD: CustomField<string> = {
       }
     );
 
+    const defaultSchema = getSchemaTemplate(entityTypeId);
+    const cleanDefaultSchema = defaultSchema.replace(/\n\s*/g, " ").trim();
+
     // Use the schema value from root, or default schema if not set
-    const displayValue =
-      value || (entityTypeId ? getSchemaTemplate(entityTypeId) : "");
+    const displayValue = value || (entityTypeId ? defaultSchema : "");
 
     const codeField = YextField(msg("schemaMarkup", "Schema Markup"), {
       type: "code",
@@ -75,6 +77,7 @@ const SCHEMA_MARKUP_FIELD: CustomField<string> = {
         const payload = {
           type: "SchemaMarkup",
           value: cleanSchemaValue,
+          defaultValue: cleanDefaultSchema,
           id: messageId,
         };
 

--- a/packages/visual-editor/src/internal/components/AdvancedSettings.tsx
+++ b/packages/visual-editor/src/internal/components/AdvancedSettings.tsx
@@ -50,7 +50,7 @@ const SCHEMA_MARKUP_FIELD: CustomField<string> = {
     const compactDefaultSchema = defaultSchema.replace(/\n\s*/g, " ").trim();
 
     // Use the schema value from root, or default schema if not set
-    const schema = value || (entityTypeId ? defaultSchema : "");
+    const schema = value || defaultSchema;
     // Compact the schema to remove newlines and extra whitespace
     const compactSchema = schema.replace(/\n\s*/g, " ").trim();
 

--- a/packages/visual-editor/src/internal/components/AdvancedSettings.tsx
+++ b/packages/visual-editor/src/internal/components/AdvancedSettings.tsx
@@ -46,10 +46,13 @@ const SCHEMA_MARKUP_FIELD: CustomField<string> = {
     );
 
     const defaultSchema = getSchemaTemplate(entityTypeId);
-    const cleanDefaultSchema = defaultSchema.replace(/\n\s*/g, " ").trim();
+    // Compact the default schema to remove newlines and extra whitespace
+    const compactDefaultSchema = defaultSchema.replace(/\n\s*/g, " ").trim();
 
     // Use the schema value from root, or default schema if not set
-    const displayValue = value || (entityTypeId ? defaultSchema : "");
+    const schema = value || (entityTypeId ? defaultSchema : "");
+    // Compact the schema to remove newlines and extra whitespace
+    const compactSchema = schema.replace(/\n\s*/g, " ").trim();
 
     const codeField = YextField(msg("schemaMarkup", "Schema Markup"), {
       type: "code",
@@ -60,12 +63,9 @@ const SCHEMA_MARKUP_FIELD: CustomField<string> = {
       e.stopPropagation();
       e.preventDefault();
 
-      // Clean the schema value to remove newlines and extra whitespace
-      const cleanSchemaValue = displayValue.replace(/\n\s*/g, " ").trim();
-
       /** Handles local development testing outside of Storm */
       if (window.location.href.includes("http://localhost:5173/dev-location")) {
-        const userInput = prompt("Enter Schema Markup:", displayValue);
+        const userInput = prompt("Enter Schema Markup:", schema);
         if (userInput !== null) {
           onChange(userInput);
         }
@@ -76,8 +76,8 @@ const SCHEMA_MARKUP_FIELD: CustomField<string> = {
 
         const payload = {
           type: "SchemaMarkup",
-          value: cleanSchemaValue,
-          defaultValue: cleanDefaultSchema,
+          value: compactSchema,
+          defaultValue: compactDefaultSchema,
           id: messageId,
         };
 
@@ -103,7 +103,7 @@ const SCHEMA_MARKUP_FIELD: CustomField<string> = {
             onChange: (newValue: string | number) => {
               onChange(String(newValue));
             },
-            value: displayValue,
+            value: schema,
             field: codeField,
             name: "schemaMarkup",
             id: "schemaMarkup",

--- a/packages/visual-editor/src/internal/components/AdvancedSettings.tsx
+++ b/packages/visual-editor/src/internal/components/AdvancedSettings.tsx
@@ -46,13 +46,9 @@ const SCHEMA_MARKUP_FIELD: CustomField<string> = {
     );
 
     const defaultSchema = getSchemaTemplate(entityTypeId);
-    // Compact the default schema to remove newlines and extra whitespace
-    const compactDefaultSchema = defaultSchema.replace(/\n\s*/g, " ").trim();
 
     // Use the schema value from root, or default schema if not set
     const schema = value || defaultSchema;
-    // Compact the schema to remove newlines and extra whitespace
-    const compactSchema = schema.replace(/\n\s*/g, " ").trim();
 
     const codeField = YextField(msg("schemaMarkup", "Schema Markup"), {
       type: "code",
@@ -76,8 +72,8 @@ const SCHEMA_MARKUP_FIELD: CustomField<string> = {
 
         const payload = {
           type: "SchemaMarkup",
-          value: compactSchema,
-          defaultValue: compactDefaultSchema,
+          value: schema,
+          defaultValue: defaultSchema,
           id: messageId,
         };
 

--- a/packages/visual-editor/src/utils/getSchema.ts
+++ b/packages/visual-editor/src/utils/getSchema.ts
@@ -79,7 +79,7 @@ const FALLBACK_SCHEMA = `{
 // Function to get the appropriate schema template based on entity type
 export const getSchemaTemplate = (entityTypeId?: string): string => {
   if (!entityTypeId) {
-    return FALLBACK_SCHEMA;
+    return FALLBACK_SCHEMA.replace(/\n\s*/g, " ").trim();
   }
 
   if (
@@ -87,7 +87,7 @@ export const getSchemaTemplate = (entityTypeId?: string): string => {
     entityTypeId === "financialProfessional" ||
     entityTypeId === "healthcareProfessional"
   ) {
-    return LOCAL_BUSINESS_SCHEMA;
+    return LOCAL_BUSINESS_SCHEMA.replace(/\n\s*/g, " ").trim();
   } else if (entityTypeId.startsWith("dm_")) {
     // Determine position based on entity type
     let position = 1; // default for dm_root
@@ -104,8 +104,10 @@ export const getSchemaTemplate = (entityTypeId?: string): string => {
     return DIRECTORY_LIST_ITEM_SCHEMA.replace(
       "[[position]]",
       position.toString()
-    );
+    )
+      .replace(/\n\s*/g, " ")
+      .trim();
   } else {
-    return FALLBACK_SCHEMA;
+    return FALLBACK_SCHEMA.replace(/\n\s*/g, " ").trim();
   }
 };

--- a/packages/visual-editor/src/utils/getSchema.ts
+++ b/packages/visual-editor/src/utils/getSchema.ts
@@ -32,6 +32,8 @@ const getDefaultSchema = (
   }
 };
 
+const schemaWhitespaceRegex = /\n\s*/g;
+
 const LOCAL_BUSINESS_SCHEMA = `{
   "@context": "https://schema.org",
   "@type": "LocalBusiness",
@@ -50,7 +52,9 @@ const LOCAL_BUSINESS_SCHEMA = `{
   "telephone": "[[mainPhone]]",
   "paymentAccepted": "[[paymentOptions]]",
   "hasOfferCatalog": "[[services]]"
-}`;
+}`
+  .replace(schemaWhitespaceRegex, " ")
+  .trim();
 
 const DIRECTORY_LIST_ITEM_SCHEMA = `{
   "@type": "ListItem",
@@ -67,19 +71,23 @@ const DIRECTORY_LIST_ITEM_SCHEMA = `{
       "addressCountry": "[[address.countryCode]]"
     }
   }
-}`;
+}`
+  .replace(schemaWhitespaceRegex, " ")
+  .trim();
 
 const FALLBACK_SCHEMA = `{
   "@context": "https://schema.org",
   "@type": "Thing",
   "name": "[[name]]",
   "description": "[[description]]",
-}`;
+}`
+  .replace(schemaWhitespaceRegex, " ")
+  .trim();
 
 // Function to get the appropriate schema template based on entity type
 export const getSchemaTemplate = (entityTypeId?: string): string => {
   if (!entityTypeId) {
-    return FALLBACK_SCHEMA.replace(/\n\s*/g, " ").trim();
+    return FALLBACK_SCHEMA;
   }
 
   if (
@@ -87,7 +95,7 @@ export const getSchemaTemplate = (entityTypeId?: string): string => {
     entityTypeId === "financialProfessional" ||
     entityTypeId === "healthcareProfessional"
   ) {
-    return LOCAL_BUSINESS_SCHEMA.replace(/\n\s*/g, " ").trim();
+    return LOCAL_BUSINESS_SCHEMA;
   } else if (entityTypeId.startsWith("dm_")) {
     // Determine position based on entity type
     let position = 1; // default for dm_root
@@ -108,6 +116,6 @@ export const getSchemaTemplate = (entityTypeId?: string): string => {
       .replace(/\n\s*/g, " ")
       .trim();
   } else {
-    return FALLBACK_SCHEMA.replace(/\n\s*/g, " ").trim();
+    return FALLBACK_SCHEMA;
   }
 };


### PR DESCRIPTION
When sending the user's schema to the parent to allow for editing, we now also send the default schema. A new option in the UI will allow the user to restore the default schema and clear any edits they've made.

Ran everything locally and logged the payload that was sent to the front-end, confirming that it included the new defaultValue field.