### PR TITLE
fix: fonts not loading in editor

### DIFF
--- a/packages/visual-editor/src/utils/applyTheme.ts
+++ b/packages/visual-editor/src/utils/applyTheme.ts
@@ -135,41 +135,22 @@ const generateContrastingColors = (themeData: ThemeData) => {
   return contrastingColors;
 };
 
-// Helper function to update font links in the editor document
-const updateFontLinksInEditor = (fontLinkTags: string) => {
-  const existingLinks = window.document.querySelectorAll(
-    'link[href*="fonts.googleapis.com"]'
-  );
-  existingLinks.forEach((link) => link.remove());
-
-  if (fontLinkTags) {
-    const tempDiv = document.createElement("div");
-    tempDiv.innerHTML = fontLinkTags;
-    const links = tempDiv.querySelectorAll("link");
-    links.forEach((link) => {
-      window.document.head.appendChild(link);
-    });
-  }
-};
-
-const updateFontLinksInIframe = (
-  iframe: HTMLIFrameElement,
+// Helper function to update font links in a document
+const updateFontLinksInDocument = (
+  document: Document,
   fontLinkTags: string
 ) => {
-  if (!iframe.contentDocument) {
-    return;
-  }
-
-  const existingLinks = iframe.contentDocument.querySelectorAll(
+  const existingLinks = document.querySelectorAll(
     'link[href*="fonts.googleapis.com"]'
   );
   existingLinks.forEach((link) => link.remove());
+
   if (fontLinkTags) {
     const tempDiv = document.createElement("div");
     tempDiv.innerHTML = fontLinkTags;
     const links = tempDiv.querySelectorAll("link");
     links.forEach((link) => {
-      iframe.contentDocument!.head.appendChild(link);
+      document.head.appendChild(link);
     });
   }
 };
@@ -199,7 +180,7 @@ export const updateThemeInEditor = async (
     editorStyleTag.innerText = newThemeTag;
   }
 
-  updateFontLinksInEditor(fontLinkTags);
+  updateFontLinksInDocument(window.document, fontLinkTags);
 
   const observer = new MutationObserver(() => {
     const iframe = document.getElementById(
@@ -210,7 +191,7 @@ export const updateThemeInEditor = async (
     if (pagePreviewStyleTag) {
       observer.disconnect();
       pagePreviewStyleTag.innerText = newThemeTag;
-      updateFontLinksInIframe(iframe, fontLinkTags);
+      updateFontLinksInDocument(iframe.contentDocument!, fontLinkTags);
     }
   });
 


### PR DESCRIPTION
<img width="1221" height="999" alt="Screenshot 2025-10-01 at 1 59 29 PM" src="https://github.com/user-attachments/assets/80cdc2f4-da2f-413b-ad1d-6ac4ba5263d1" />
Confirmed that fonts now load correctly in both the Theme and Layout Editor and match the live page. 

The problem was that the live page used applyTheme but the editor was only using updateThemeInEditor, so when the font was changed in the editor, the new styles were applied but the actual font files weren't loaded, leading to the editor falling back to defaults. The fix was essentially to just use the applyTheme logic in the editor as well.

Test Site: https://www.yext.com/s/4259018/yextsites/160744/theme#themeId=font-test-2&pageSetId=font-test-2&locale=en&entityId=1095527849