### PR TITLE
fix: load fonts in font selector

### DIFF
--- a/packages/visual-editor/src/internal/hooks/useMessageReceivers.ts
+++ b/packages/visual-editor/src/internal/hooks/useMessageReceivers.ts
@@ -12,6 +12,7 @@ import { ThemeData } from "../types/themeData.ts";
 import { migrate } from "../../utils/migrate.ts";
 import { migrationRegistry } from "../../components/migrations/migrationRegistry.ts";
 import { filterComponentsFromConfig } from "../../utils/filterComponents.ts";
+import { googleFontLinkTags } from "../../utils/visualEditorFonts.ts";
 
 const devLogger = new DevLogger();
 
@@ -21,9 +22,20 @@ export const useCommonMessageReceivers = (
 ) => {
   const { iFrameLoaded } = useCommonMessageSenders();
 
-  // Trigger data flow from parent
+  // Trigger data flow from parent and load initial fonts
   useEffect(() => {
     iFrameLoaded({ payload: { message: "iFrame is loaded" } });
+
+    // Load default Google Fonts for the font selector dropdown
+    if (!document.getElementById("visual-editor-default-fonts")) {
+      const tempDiv = document.createElement("div");
+      tempDiv.innerHTML = googleFontLinkTags;
+      const links = tempDiv.querySelectorAll("link");
+      links.forEach((link) => {
+        link.id = "visual-editor-default-fonts";
+        document.head.appendChild(link);
+      });
+    }
   }, []);
 
   // Base Template Info

--- a/packages/visual-editor/src/internal/utils/loadMapboxIntoIframe.tsx
+++ b/packages/visual-editor/src/internal/utils/loadMapboxIntoIframe.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useEffect } from "react";
 import mapboxPackageJson from "mapbox-gl/package.json";
-import { googleFontLinkTags } from "../../../utils/visualEditorFonts.ts";
+import { googleFontLinkTags } from "../../utils/visualEditorFonts.ts";
 
 /**
  * For use in Puck's iframe override. Loads the Mapbox script and stylesheet into the iframe document.

--- a/packages/visual-editor/src/internal/utils/loadMapboxIntoIframe.tsx
+++ b/packages/visual-editor/src/internal/utils/loadMapboxIntoIframe.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useEffect } from "react";
 import mapboxPackageJson from "mapbox-gl/package.json";
+import { googleFontLinkTags } from "../../../utils/visualEditorFonts.ts";
 
 /**
  * For use in Puck's iframe override. Loads the Mapbox script and stylesheet into the iframe document.
@@ -31,6 +32,17 @@ export const loadMapboxIntoIframe = ({
       link.href = `https://api.mapbox.com/mapbox-gl-js/v${mapboxPackageJson.version}/mapbox-gl.css`;
       link.rel = "stylesheet";
       document.body.appendChild(link);
+    }
+
+    // Load default Google Fonts for the font selector dropdown
+    if (!document.getElementById("visual-editor-default-fonts")) {
+      const tempDiv = document.createElement("div");
+      tempDiv.innerHTML = googleFontLinkTags;
+      const links = tempDiv.querySelectorAll("link");
+      links.forEach((link) => {
+        link.id = "visual-editor-default-fonts";
+        document.head.appendChild(link);
+      });
     }
   }, [document]);
   return <>{children}</>;

--- a/packages/visual-editor/src/utils/applyTheme.ts
+++ b/packages/visual-editor/src/utils/applyTheme.ts
@@ -140,7 +140,6 @@ const updateFontLinksInDocument = (
   document: Document,
   fontLinkTags: string
 ) => {
-  // Remove only theme-specific font links, preserve default fonts
   const existingLinks = document.querySelectorAll(
     'link[href*="fonts.googleapis.com"]:not([id="visual-editor-default-fonts"])'
   );

--- a/packages/visual-editor/src/utils/applyTheme.ts
+++ b/packages/visual-editor/src/utils/applyTheme.ts
@@ -140,8 +140,9 @@ const updateFontLinksInDocument = (
   document: Document,
   fontLinkTags: string
 ) => {
+  // Remove only theme-specific font links, preserve default fonts
   const existingLinks = document.querySelectorAll(
-    'link[href*="fonts.googleapis.com"]'
+    'link[href*="fonts.googleapis.com"]:not([id="visual-editor-default-fonts"])'
   );
   existingLinks.forEach((link) => link.remove());
 


### PR DESCRIPTION
<img width="550" height="332" alt="Screenshot 2025-10-01 at 4 45 11 PM" src="https://github.com/user-attachments/assets/11927759-652c-49d1-a1b4-85d57ce97bda" />

The problem was when the editor first loaded no google fonts were loaded (only theme-specific fonts), fixed by loading the fonts on initial load. Verified in local dev that the fonts loaded in the editor on the page and in the selector.