### PR TITLE
chore: page section translations and pass document in metadata

### DIFF
--- a/packages/visual-editor/src/components/configs/directoryConfig.tsx
+++ b/packages/visual-editor/src/components/configs/directoryConfig.tsx
@@ -1,5 +1,5 @@
 import { Config, DropZone } from "@measured/puck";
-import { msg } from "@yext/visual-editor";
+import { pt } from "@yext/visual-editor";
 import {
   DeprecatedCategory,
   DeprecatedCategoryComponents,
@@ -30,7 +30,7 @@ export const directoryConfig: Config<DirectoryConfigProps> = {
   },
   categories: {
     directoryComponents: {
-      title: msg("categories.directory", "Directory"),
+      title: pt("categories.directory", "Directory"),
       components: [...DirectoryCategory, ...OtherCategory],
     },
     // deprecated components are hidden in the sidebar but still render if used in the page

--- a/packages/visual-editor/src/components/configs/locatorConfig.tsx
+++ b/packages/visual-editor/src/components/configs/locatorConfig.tsx
@@ -1,5 +1,5 @@
 import { Config, DropZone } from "@measured/puck";
-import { msg } from "@yext/visual-editor";
+import { pt } from "@yext/visual-editor";
 import {
   DeprecatedCategory,
   DeprecatedCategoryComponents,
@@ -30,7 +30,7 @@ export const locatorConfig: Config<LocatorConfigProps> = {
   },
   categories: {
     locatorComponents: {
-      title: msg("categories.locator", "Locator"),
+      title: pt("categories.locator", "Locator"),
       components: [...LocatorCategory, ...OtherCategory],
     },
     // deprecated components are hidden in the sidebar but still render if used in the page

--- a/packages/visual-editor/src/components/configs/mainConfig.tsx
+++ b/packages/visual-editor/src/components/configs/mainConfig.tsx
@@ -1,5 +1,5 @@
 import { DropZone, Config } from "@measured/puck";
-import { msg } from "@yext/visual-editor";
+import { pt } from "@yext/visual-editor";
 import {
   DeprecatedCategory,
   DeprecatedCategoryComponents,
@@ -46,15 +46,15 @@ export const mainConfig: Config<MainConfigProps> = {
   components,
   categories: {
     pageSections: {
-      title: msg("categories.pageSections", "Page Sections"),
+      title: pt("categories.pageSections", "Page Sections"),
       components: PageSectionCategory,
     },
     coreInformation: {
-      title: msg("categories.coreInformation", "Core Information"),
+      title: pt("categories.coreInformation", "Core Information"),
       components: AdvancedCoreInfoCategory,
     },
     other: {
-      title: msg("categories.other", "Other"),
+      title: pt("categories.other", "Other"),
       components: OtherCategory,
     },
     slots: {

--- a/packages/visual-editor/src/editor/Editor.tsx
+++ b/packages/visual-editor/src/editor/Editor.tsx
@@ -36,6 +36,8 @@ export interface Metadata {
     locale: string,
     relativePrefixToRoot: string
   ) => string;
+  // The stream document for the current page
+  streamDocument?: any;
 }
 
 export type EditorProps = {
@@ -153,7 +155,7 @@ export const Editor = ({
               themeData={themeData!}
               themeConfig={themeConfig}
               localDev={!!localDev}
-              metadata={metadata}
+              metadata={{ ...metadata, streamDocument: document }}
             />
           ) : (
             <LayoutEditor
@@ -163,7 +165,7 @@ export const Editor = ({
               themeData={themeData!}
               themeConfig={themeConfig}
               localDev={!!localDev}
-              metadata={metadata}
+              metadata={{ ...metadata, streamDocument: document }}
             />
           )
         ) : (

--- a/packages/visual-editor/src/vite-plugin/templates/directory.tsx
+++ b/packages/visual-editor/src/vite-plugin/templates/directory.tsx
@@ -106,6 +106,7 @@ const Directory: Template<TemplateRenderProps> = (props) => {
             migrationRegistry,
             directoryConfig
           )}
+          metadata={{ streamDocument: document }}
         />
       </VisualEditorProvider>
     </AnalyticsProvider>

--- a/packages/visual-editor/src/vite-plugin/templates/locator.tsx
+++ b/packages/visual-editor/src/vite-plugin/templates/locator.tsx
@@ -111,6 +111,7 @@ const Locator: Template<TemplateRenderProps> = (props) => {
           <Render
             config={locatorConfig}
             data={JSON.parse(document.__.layout)}
+            metadata={{ streamDocument: document }}
           />
         </VisualEditorProvider>
       </AnalyticsProvider>

--- a/packages/visual-editor/src/vite-plugin/templates/main.tsx
+++ b/packages/visual-editor/src/vite-plugin/templates/main.tsx
@@ -108,6 +108,7 @@ const Location: Template<TemplateRenderProps> = (props) => {
             migrationRegistry,
             filteredConfig
           )}
+          metadata={{ streamDocument: document }}
         />
       </VisualEditorProvider>
     </AnalyticsProvider>


### PR DESCRIPTION
I messed up in the other pr, should've used pt instead of msg for the category names

Added the streamDocument to Puck metadata to make it available in resolveFields/resolveData, will be used in future slot PRs