### PR TITLE
fix: improve color contrast handling

### DIFF
--- a/packages/visual-editor/src/utils/applyTheme.test.ts
+++ b/packages/visual-editor/src/utils/applyTheme.test.ts
@@ -134,7 +134,10 @@ describe("buildCssOverridesStyle", () => {
   it("should generate contrasting palette colors", () => {
     const streamDocument: StreamDocument = {
       __: {
-        theme: JSON.stringify({ "--colors-palette-primary": "#7ED321" }),
+        theme: JSON.stringify({
+          "--colors-palette-primary": "#7ED321",
+          "--colors-palette-secondary": "#305af3",
+        }),
       },
     };
     const result = applyTheme(streamDocument, {
@@ -143,6 +146,12 @@ describe("buildCssOverridesStyle", () => {
         styles: {
           primary: {
             label: "Primary",
+            plugin: "colors",
+            type: "color",
+            default: "#000000",
+          },
+          secondary: {
+            label: "Secondary",
             plugin: "colors",
             type: "color",
             default: "#000000",
@@ -156,9 +165,12 @@ describe("buildCssOverridesStyle", () => {
     expect(result).toContain(
       '<style id="visual-editor-theme" type="text/css">.components{'
     );
-    expect(result).toContain("--colors-palette-primary:#7ED321 !important;");
+    expect(result).toContain("--colors-palette-primary:#7ED321 !important");
     expect(result).toContain(
-      "--colors-palette-primary-contrast:#FFFFFF !important"
+      "--colors-palette-primary-contrast:#000000 !important"
+    );
+    expect(result).toContain(
+      "--colors-palette-secondary-contrast:#FFFFFF !important"
     );
   });
 });

--- a/packages/visual-editor/src/utils/applyTheme.ts
+++ b/packages/visual-editor/src/utils/applyTheme.ts
@@ -14,7 +14,7 @@ import {
   type FontLinkData,
 } from "./visualEditorFonts.ts";
 import { ThemeConfig } from "./themeResolver.ts";
-import { hexToHSL } from "./colors.ts";
+import { getContrastingColor } from "./colors.ts";
 
 export type StreamDocument = {
   [key: string]: any;
@@ -106,8 +106,8 @@ const internalApplyTheme = (
   }
 
   const themeValuesToApply = {
-    ...mergedThemeValues,
     ...generateContrastingColors(mergedThemeValues),
+    ...mergedThemeValues,
   };
 
   devLogger.logData("THEME_VALUES_TO_APPLY", themeValuesToApply);
@@ -129,13 +129,14 @@ const internalApplyTheme = (
 const generateContrastingColors = (themeData: ThemeData) => {
   const contrastingColors: Record<string, string> = {};
   Object.entries(themeData).forEach(([cssVariableName, value]) => {
-    if (cssVariableName.includes("--colors")) {
-      const hsl = hexToHSL(value);
-      if (hsl && hsl[2] >= 50) {
-        contrastingColors[cssVariableName + "-contrast"] = "#000000";
-      } else if (hsl) {
-        contrastingColors[cssVariableName + "-contrast"] = "#FFFFFF";
-      }
+    if (
+      cssVariableName.includes("--colors") &&
+      !themeData[cssVariableName + "-contrast"] &&
+      value.startsWith("#") &&
+      (value.length === 7 || value.length === 4)
+    ) {
+      const contrastColor = getContrastingColor(value, 12, 400);
+      contrastingColors[cssVariableName + "-contrast"] = contrastColor;
     }
   });
   return contrastingColors;

--- a/packages/visual-editor/src/utils/colors.test.ts
+++ b/packages/visual-editor/src/utils/colors.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from "vitest";
 import {
   getContrastingColor,
   hexToRGB,
-  hexToHSL,
   luminanceFromRGB,
   isColorContrastWcagCompliant,
   convertComputedStyleColorToHex,
@@ -48,21 +47,6 @@ describe("hexToRGB", () => {
     expect(hexToRGB("123456")).toBeUndefined();
     expect(hexToRGB("#123456789")).toBeUndefined();
     expect(hexToRGB("#16")).toBeUndefined();
-  });
-});
-
-describe("hexToHSL", () => {
-  it("should correctly calculate HSL", () => {
-    expect(hexToHSL("#000000")).toStrictEqual([0, 0, 0]);
-    expect(hexToHSL("#FFF")).toStrictEqual([0, 0, 100]);
-    expect(hexToHSL("#11544d")).toStrictEqual([174, 66.3, 19.8]);
-    expect(hexToHSL("#777")).toStrictEqual([0, 0, 46.7]);
-  });
-
-  it("should return undefined if hex argument is invalid", () => {
-    expect(hexToHSL("123456")).toBeUndefined();
-    expect(hexToHSL("#123456789")).toBeUndefined();
-    expect(hexToHSL("#16")).toBeUndefined();
   });
 });
 

--- a/packages/visual-editor/src/utils/colors.ts
+++ b/packages/visual-editor/src/utils/colors.ts
@@ -25,47 +25,6 @@ export const hexToRGB = (H: string): number[] | undefined => {
 };
 
 /**
- * hexToHSL converts a hex color to hsl
- * @param H hex string beginning with '#'
- * @returns {number[] | undefined} [h, s, l] if conversion succeeds
- */
-export const hexToHSL = (H: string): number[] | undefined => {
-  // Based on https://css-tricks.com/converting-color-spaces-in-javascript/
-  // Convert hex to RGB first
-  const rgb = hexToRGB(H);
-  if (!rgb || rgb.length !== 3) {
-    return;
-  }
-
-  const r = rgb[0] / 255;
-  const g = rgb[1] / 255;
-  const b = rgb[2] / 255;
-  const cmin = Math.min(r, g, b),
-    cmax = Math.max(r, g, b),
-    delta = cmax - cmin;
-
-  let h = 0,
-    s = 0,
-    l = 0;
-
-  if (delta == 0) h = 0;
-  else if (cmax == r) h = ((g - b) / delta) % 6;
-  else if (cmax == g) h = (b - r) / delta + 2;
-  else h = (r - g) / delta + 4;
-
-  h = Math.round(h * 60);
-
-  if (h < 0) h += 360;
-
-  l = (cmax + cmin) / 2;
-  s = delta == 0 ? 0 : delta / (1 - Math.abs(2 * l - 1));
-  s = +(s * 100).toFixed(1);
-  l = +(l * 100).toFixed(1);
-
-  return [h, s, l];
-};
-
-/**
  * Converts a color string returned by window.getComputedStyle to a hex color string.
  * getComputedStyle can return a variety of color values.
  * @param colorString The computed style color string (e.g., "rgb(255, 0, 0)").


### PR DESCRIPTION
From Paige's spreadsheet: the color 305af3 (dark blue) was being displayed with black text. 

The issue was that we updated to a better contrast algorithm in the theme editor but the old algorithm was still being used as a backup in applyTheme. I think the recent changes to applyTheme changed how those two values were resolved and the old algorithm was being preferred. 

This change fully swaps to the better algorithm and gives saved db contrast colors precedence over the fallback calculation.