### PR TITLE
fix: use entityPageSetUrlTemplates for resolving locator card urls

### DIFF
--- a/packages/visual-editor/src/utils/resolveUrlTemplate.test.ts
+++ b/packages/visual-editor/src/utils/resolveUrlTemplate.test.ts
@@ -27,7 +27,7 @@ const mockStreamDocument: StreamDocument = {
   }),
 };
 
-const mockDirectoryDocument: StreamDocument = {
+const mockDirectoryMergedDocument: StreamDocument = {
   name: "Yext",
   id: "123",
   locale: "en",
@@ -43,6 +43,27 @@ const mockDirectoryDocument: StreamDocument = {
     entityPageSetUrlTemplates: JSON.stringify({
       primary: "[[address.region]]/page/[[id]]",
       alternate: "[[locale]]/[[address.region]]/page/[[id]]",
+    }),
+  },
+  _pageset: JSON.stringify({}),
+};
+
+const mockLocatorMergedDocument: StreamDocument = {
+  name: "Yext",
+  id: "123",
+  locale: "en",
+  address: {
+    line1: "61 9th Ave",
+    city: "New York",
+    region: "NY",
+    country: "USA",
+  },
+  __: {
+    isPrimaryLocale: true,
+    codeTemplate: "locator",
+    entityPageSetUrlTemplates: JSON.stringify({
+      primary: "[[address.region]]/location/[[id]]",
+      alternate: "[[locale]]/[[address.region]]/location/[[id]]",
     }),
   },
   _pageset: JSON.stringify({}),
@@ -257,19 +278,40 @@ describe("resolveUrlTemplate", () => {
   });
 
   it("handles primary url template on directory pages", () => {
-    expect(resolveUrlTemplate(mockDirectoryDocument, "")).toBe("ny/page/123");
+    expect(resolveUrlTemplate(mockDirectoryMergedDocument, "")).toBe(
+      "ny/page/123"
+    );
   });
 
   it("handles alternate url templates on directory pages", () => {
     expect(
       resolveUrlTemplate(
         {
-          ...mockDirectoryDocument,
-          __: { ...mockDirectoryDocument.__, isPrimaryLocale: false },
+          ...mockDirectoryMergedDocument,
+          __: { ...mockDirectoryMergedDocument.__, isPrimaryLocale: false },
           locale: "es",
         },
         ""
       )
     ).toBe("es/ny/page/123");
+  });
+
+  it("handles primary url template on locator pages", () => {
+    expect(resolveUrlTemplate(mockLocatorMergedDocument, "")).toBe(
+      "ny/location/123"
+    );
+  });
+
+  it("handles alternate url templates on locator pages", () => {
+    expect(
+      resolveUrlTemplate(
+        {
+          ...mockLocatorMergedDocument,
+          __: { ...mockLocatorMergedDocument.__, isPrimaryLocale: false },
+          locale: "es",
+        },
+        ""
+      )
+    ).toBe("es/ny/location/123");
   });
 });

--- a/packages/visual-editor/src/utils/resolveUrlTemplate.ts
+++ b/packages/visual-editor/src/utils/resolveUrlTemplate.ts
@@ -36,7 +36,10 @@ export const resolveUrlTemplate = (
   const isPrimaryLocale = streamDocument.__?.isPrimaryLocale !== false;
 
   let urlTemplates;
-  if (streamDocument?.__?.codeTemplate === "directory") {
+  if (
+    streamDocument?.__?.codeTemplate === "directory" ||
+    streamDocument?.__?.codeTemplate === "locator"
+  ) {
     urlTemplates = JSON.parse(
       streamDocument?.__?.entityPageSetUrlTemplates || "{}"
     );


### PR DESCRIPTION
The locator cards should use the base entity's url templates (currently they are looking at the locator page set's templates which do not exist). This is a change we already made for directory