### PR TITLE
fix: resolve data on entity switch

### DIFF
--- a/packages/visual-editor/src/components/contentBlocks/CtaWrapper.tsx
+++ b/packages/visual-editor/src/components/contentBlocks/CtaWrapper.tsx
@@ -67,7 +67,8 @@ export interface CTAWrapperProps {
 
   /** @internal Controlled style from the parent section */
   parentStyles?: {
-    classNameFn?: (variant: CTAVariant) => string;
+    className?: string;
+    classNameByVariant?: Partial<Record<NonNullable<CTAVariant>, string>>;
   };
 
   /** @internal Event name to be used for click analytics */
@@ -189,13 +190,16 @@ const CTAWrapperComponent: PuckComponent<CTAWrapperProps> = (props) => {
       ? getCTAType(data.entityField)
       : { ctaType: undefined };
 
-  let combinedClassName = className;
-  if (parentStyles?.classNameFn) {
-    combinedClassName = themeManagerCn(
-      parentStyles.classNameFn(styles.variant),
-      className
-    );
-  }
+  const variantClassName =
+    styles.variant && parentStyles?.classNameByVariant
+      ? parentStyles.classNameByVariant[styles.variant]
+      : undefined;
+
+  const combinedClassName = themeManagerCn(
+    parentStyles?.className,
+    variantClassName,
+    className
+  );
 
   let resolvedLinkLabel =
     cta && resolveComponentData(cta.label, i18n.language, streamDocument);

--- a/packages/visual-editor/src/components/pageSections/HeroSection.tsx
+++ b/packages/visual-editor/src/components/pageSections/HeroSection.tsx
@@ -18,7 +18,6 @@ import { msg } from "../../utils/i18n/platform.ts";
 import { getAnalyticsScopeHash } from "../../utils/applyAnalytics.ts";
 import { YextEntityField } from "../../editor/YextEntityFieldSelector.tsx";
 import { themeManagerCn } from "../../utils/cn.ts";
-import { CTAVariant } from "../atoms/cta.tsx";
 import { HeadingTextProps } from "../contentBlocks/HeadingText.tsx";
 import { HoursStatusProps } from "../contentBlocks/HoursStatus.tsx";
 import { ImageWrapperProps } from "../contentBlocks/image/Image.tsx";
@@ -539,30 +538,22 @@ export const HeroSection: ComponentConfig<{ props: HeroSectionProps }> = {
       data.props.styles.variant
     );
 
-    const ctaClassNameFn = (variant: CTAVariant): string => {
-      switch (variant) {
-        case "link":
-          return (
-            "py-3 border-2 border-transparent w-fit " +
-            (data.props.styles.mobileContentAlignment === "center"
-              ? " mx-auto sm:m-0"
-              : "")
-          );
-        default:
-          return "";
-      }
-    };
+    const ctaLinkClassName =
+      "py-3 border-2 border-transparent w-fit " +
+      (data.props.styles.mobileContentAlignment === "center"
+        ? " mx-auto sm:m-0"
+        : "");
 
     data = setDeep(
       data,
-      "props.slots.PrimaryCTASlot[0].props.parentStyles.classNameFn",
-      ctaClassNameFn
+      "props.slots.PrimaryCTASlot[0].props.parentStyles.classNameByVariant",
+      { link: ctaLinkClassName }
     );
 
     data = setDeep(
       data,
-      "props.slots.SecondaryCTASlot[0].props.parentStyles.classNameFn",
-      ctaClassNameFn
+      "props.slots.SecondaryCTASlot[0].props.parentStyles.classNameByVariant",
+      { link: ctaLinkClassName }
     );
 
     const geomodifierLevel =


### PR DESCRIPTION
#1093 introduced a structuredClone of the appState data before re-resolving, so that the following isDeepEqual check works as expected.

However, structuredClone cannot clone functions, so entity page sets with hero sections would fail to re-resolve data when the entity changed in-editor. 

This change replaces the ctaClassNameFn with an object so that it is serializable and can be cloned. There did not seem to be any other places in the components where this would be an issue.