### PR TITLE
fix: footer logo migration

### DIFF
--- a/packages/visual-editor/src/components/migrations/0075_normalize_footer_logo_image.ts
+++ b/packages/visual-editor/src/components/migrations/0075_normalize_footer_logo_image.ts
@@ -15,11 +15,13 @@ const normalizeFooterLogoImage = (image: unknown) => {
 
   const { field, constantValue, constantValueEnabled, ...localizedImage } =
     image;
+  const hasActiveEntityField =
+    typeof field === "string" && field !== "" && constantValueEnabled === false;
 
   return {
-    field: typeof field === "string" ? field : "",
+    field: hasActiveEntityField ? field : "",
     constantValue: constantValue ?? localizedImage,
-    constantValueEnabled: constantValueEnabled ?? true,
+    constantValueEnabled: hasActiveEntityField ? false : true,
   };
 };
 

--- a/packages/visual-editor/src/components/migrations/0075_normalize_footer_logo_image.ts
+++ b/packages/visual-editor/src/components/migrations/0075_normalize_footer_logo_image.ts
@@ -1,0 +1,91 @@
+import { Migration } from "../../utils/migrate.ts";
+
+const isRecord = (value: unknown): value is Record<string, any> => {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+};
+
+const isLocalizedImageShape = (value: Record<string, any>) => {
+  return value.hasLocalizedValue === "true" || "defaultValue" in value;
+};
+
+const normalizeFooterLogoImage = (image: unknown) => {
+  if (!isRecord(image) || !isLocalizedImageShape(image)) {
+    return image;
+  }
+
+  const { field, constantValue, constantValueEnabled, ...localizedImage } =
+    image;
+
+  return {
+    field: typeof field === "string" ? field : "",
+    constantValue: constantValue ?? localizedImage,
+    constantValueEnabled: constantValueEnabled ?? true,
+  };
+};
+
+type MigrationProps = { id: string } & Record<string, any>;
+
+const normalizeFooterLogoSlotProps = (
+  props: MigrationProps
+): MigrationProps => {
+  const image = props.data?.image;
+  const normalizedImage = normalizeFooterLogoImage(image);
+
+  if (normalizedImage === image) {
+    return props;
+  }
+
+  return {
+    ...props,
+    data: {
+      ...props.data,
+      image: normalizedImage,
+    },
+  };
+};
+
+export const normalizeFooterLogoImageMigration: Migration = {
+  ExpandedFooter: {
+    action: "updated",
+    propTransformation: (props) => {
+      const logoSlot = props.slots?.LogoSlot;
+      if (!Array.isArray(logoSlot)) {
+        return props;
+      }
+
+      let changed = false;
+      const normalizedLogoSlot = logoSlot.map((slot) => {
+        if (slot?.type !== "FooterLogoSlot" || !isRecord(slot.props)) {
+          return slot;
+        }
+
+        const normalizedProps = normalizeFooterLogoSlotProps(slot.props);
+        if (normalizedProps === slot.props) {
+          return slot;
+        }
+
+        changed = true;
+        return {
+          ...slot,
+          props: normalizedProps,
+        };
+      });
+
+      if (!changed) {
+        return props;
+      }
+
+      return {
+        ...props,
+        slots: {
+          ...props.slots,
+          LogoSlot: normalizedLogoSlot,
+        },
+      };
+    },
+  },
+  FooterLogoSlot: {
+    action: "updated",
+    propTransformation: normalizeFooterLogoSlotProps,
+  },
+};

--- a/packages/visual-editor/src/components/migrations/0075_normalize_footer_logo_image.ts
+++ b/packages/visual-editor/src/components/migrations/0075_normalize_footer_logo_image.ts
@@ -47,45 +47,6 @@ const normalizeFooterLogoSlotProps = (
 };
 
 export const normalizeFooterLogoImageMigration: Migration = {
-  ExpandedFooter: {
-    action: "updated",
-    propTransformation: (props) => {
-      const logoSlot = props.slots?.LogoSlot;
-      if (!Array.isArray(logoSlot)) {
-        return props;
-      }
-
-      let changed = false;
-      const normalizedLogoSlot = logoSlot.map((slot) => {
-        if (slot?.type !== "FooterLogoSlot" || !isRecord(slot.props)) {
-          return slot;
-        }
-
-        const normalizedProps = normalizeFooterLogoSlotProps(slot.props);
-        if (normalizedProps === slot.props) {
-          return slot;
-        }
-
-        changed = true;
-        return {
-          ...slot,
-          props: normalizedProps,
-        };
-      });
-
-      if (!changed) {
-        return props;
-      }
-
-      return {
-        ...props,
-        slots: {
-          ...props.slots,
-          LogoSlot: normalizedLogoSlot,
-        },
-      };
-    },
-  },
   FooterLogoSlot: {
     action: "updated",
     propTransformation: normalizeFooterLogoSlotProps,

--- a/packages/visual-editor/src/components/migrations/migrationRegistry.ts
+++ b/packages/visual-editor/src/components/migrations/migrationRegistry.ts
@@ -73,6 +73,7 @@ import { themeColorPropertyKeyMigration } from "./0071_theme_color_property_keys
 import { footerAlignmentAndVisibilityPropsMigration } from "./0072_footer_alignment_and_visibility_props.ts";
 import { mainContentWrapperMigration } from "./0073_main_content_wrapper.ts";
 import { flattenLocatorResultCardSingleSelectFields } from "./0074_flatten_locator_result_card_single_select_fields.ts";
+import { normalizeFooterLogoImageMigration } from "./0075_normalize_footer_logo_image.ts";
 
 // To add a migration:
 // Create a new file in this directory that exports a Migration
@@ -154,4 +155,5 @@ export const migrationRegistry: MigrationRegistry = [
   footerAlignmentAndVisibilityPropsMigration,
   mainContentWrapperMigration,
   flattenLocatorResultCardSingleSelectFields,
+  normalizeFooterLogoImageMigration,
 ];

--- a/packages/visual-editor/src/utils/migrate.test.ts
+++ b/packages/visual-editor/src/utils/migrate.test.ts
@@ -574,6 +574,103 @@ describe("migrate", () => {
     });
   });
 
+  it("preserves active ExpandedFooter logo slot entity image data while removing stale localized data", async () => {
+    const migratedData = migrate(
+      {
+        root: {
+          props: {
+            version: 0,
+          },
+        },
+        content: [
+          {
+            type: "ExpandedFooter",
+            props: {
+              id: "ExpandedFooter-test",
+              slots: {
+                LogoSlot: [
+                  {
+                    type: "FooterLogoSlot",
+                    props: {
+                      id: "FooterLogoSlot-test",
+                      data: {
+                        image: {
+                          en: {
+                            url: "https://example.com/stale.png",
+                            height: 100,
+                            width: 100,
+                          },
+                          hasLocalizedValue: "true",
+                          field: "logo",
+                          constantValueEnabled: false,
+                          constantValue: {
+                            en: {
+                              url: "https://example.com/fallback.png",
+                              height: 200,
+                              width: 200,
+                            },
+                            hasLocalizedValue: "true",
+                          },
+                        },
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+        zones: {},
+      },
+      [normalizeFooterLogoImageMigration],
+      {
+        components: {},
+      },
+      {}
+    );
+
+    expect(migratedData).toEqual({
+      root: {
+        props: {
+          version: 1,
+        },
+      },
+      content: [
+        {
+          type: "ExpandedFooter",
+          props: {
+            id: "ExpandedFooter-test",
+            slots: {
+              LogoSlot: [
+                {
+                  type: "FooterLogoSlot",
+                  props: {
+                    id: "FooterLogoSlot-test",
+                    data: {
+                      image: {
+                        field: "logo",
+                        constantValueEnabled: false,
+                        constantValue: {
+                          en: {
+                            url: "https://example.com/fallback.png",
+                            height: 200,
+                            width: 200,
+                          },
+                          hasLocalizedValue: "true",
+                        },
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+      zones: {},
+    });
+  });
+
   it("wraps legacy ExpandedFooter logo slot localized image data as a constant value", async () => {
     const migratedData = migrate(
       {

--- a/packages/visual-editor/src/utils/migrate.test.ts
+++ b/packages/visual-editor/src/utils/migrate.test.ts
@@ -4,6 +4,7 @@ import { addIdToSchema } from "../components/migrations/0023_add_id_to_schema.ts
 import { updateSchemaIdAnchorFormat } from "../components/migrations/0069_update_schema_id_anchor_format.ts";
 import { themeColorPropertyKeyMigration } from "../components/migrations/0071_theme_color_property_keys.ts";
 import { mainContentWrapperMigration } from "../components/migrations/0073_main_content_wrapper.ts";
+import { normalizeFooterLogoImageMigration } from "../components/migrations/0075_normalize_footer_logo_image.ts";
 
 describe("migrate", () => {
   it("successfully applies a migration", async () => {
@@ -475,6 +476,189 @@ describe("migrate", () => {
     expect((migratedData.root.props as Record<string, any>)?.schemaMarkup).toBe(
       schemaMarkup
     );
+  });
+
+  it("normalizes malformed ExpandedFooter logo slot localized image data", async () => {
+    const migratedData = migrate(
+      {
+        root: {
+          props: {
+            version: 0,
+          },
+        },
+        content: [
+          {
+            type: "ExpandedFooter",
+            props: {
+              id: "ExpandedFooter-test",
+              slots: {
+                LogoSlot: [
+                  {
+                    type: "FooterLogoSlot",
+                    props: {
+                      id: "FooterLogoSlot-test",
+                      data: {
+                        image: {
+                          en: {
+                            url: "https://example.com/stale.png",
+                            height: 100,
+                            width: 100,
+                          },
+                          hasLocalizedValue: "true",
+                          constantValueEnabled: true,
+                          constantValue: {
+                            en: {
+                              url: "https://example.com/current.png",
+                              height: 200,
+                              width: 200,
+                            },
+                            hasLocalizedValue: "true",
+                          },
+                        },
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+        zones: {},
+      },
+      [normalizeFooterLogoImageMigration],
+      {
+        components: {},
+      },
+      {}
+    );
+
+    expect(migratedData).toEqual({
+      root: {
+        props: {
+          version: 1,
+        },
+      },
+      content: [
+        {
+          type: "ExpandedFooter",
+          props: {
+            id: "ExpandedFooter-test",
+            slots: {
+              LogoSlot: [
+                {
+                  type: "FooterLogoSlot",
+                  props: {
+                    id: "FooterLogoSlot-test",
+                    data: {
+                      image: {
+                        field: "",
+                        constantValueEnabled: true,
+                        constantValue: {
+                          en: {
+                            url: "https://example.com/current.png",
+                            height: 200,
+                            width: 200,
+                          },
+                          hasLocalizedValue: "true",
+                        },
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+      zones: {},
+    });
+  });
+
+  it("wraps legacy ExpandedFooter logo slot localized image data as a constant value", async () => {
+    const migratedData = migrate(
+      {
+        root: {
+          props: {
+            version: 0,
+          },
+        },
+        content: [
+          {
+            type: "ExpandedFooter",
+            props: {
+              id: "ExpandedFooter-test",
+              slots: {
+                LogoSlot: [
+                  {
+                    type: "FooterLogoSlot",
+                    props: {
+                      id: "FooterLogoSlot-test",
+                      data: {
+                        image: {
+                          en: {
+                            url: "https://example.com/legacy.png",
+                            height: 100,
+                            width: 100,
+                          },
+                          hasLocalizedValue: "true",
+                        },
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+        zones: {},
+      },
+      [normalizeFooterLogoImageMigration],
+      {
+        components: {},
+      },
+      {}
+    );
+
+    expect(migratedData).toEqual({
+      root: {
+        props: {
+          version: 1,
+        },
+      },
+      content: [
+        {
+          type: "ExpandedFooter",
+          props: {
+            id: "ExpandedFooter-test",
+            slots: {
+              LogoSlot: [
+                {
+                  type: "FooterLogoSlot",
+                  props: {
+                    id: "FooterLogoSlot-test",
+                    data: {
+                      image: {
+                        field: "",
+                        constantValue: {
+                          en: {
+                            url: "https://example.com/legacy.png",
+                            height: 100,
+                            width: 100,
+                          },
+                          hasLocalizedValue: "true",
+                        },
+                        constantValueEnabled: true,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+      zones: {},
+    });
   });
 });
 

--- a/packages/visual-editor/src/utils/migrate.test.ts
+++ b/packages/visual-editor/src/utils/migrate.test.ts
@@ -526,9 +526,7 @@ describe("migrate", () => {
         zones: {},
       },
       [normalizeFooterLogoImageMigration],
-      {
-        components: {},
-      },
+      footerLogoSlotMigrationConfig,
       {}
     );
 
@@ -623,9 +621,7 @@ describe("migrate", () => {
         zones: {},
       },
       [normalizeFooterLogoImageMigration],
-      {
-        components: {},
-      },
+      footerLogoSlotMigrationConfig,
       {}
     );
 
@@ -710,9 +706,7 @@ describe("migrate", () => {
         zones: {},
       },
       [normalizeFooterLogoImageMigration],
-      {
-        components: {},
-      },
+      footerLogoSlotMigrationConfig,
       {}
     );
 
@@ -788,6 +782,24 @@ export const migrationRegistry: MigrationRegistry = [
   alreadyAppliedMigration,
   migration,
 ];
+
+const footerLogoSlotMigrationConfig = {
+  components: {
+    ExpandedFooter: {
+      fields: {
+        slots: {
+          type: "object",
+          objectFields: {
+            LogoSlot: { type: "slot" },
+          },
+        },
+      },
+    },
+    FooterLogoSlot: {
+      fields: {},
+    },
+  },
+} as any;
 
 const exampleDataBefore = {
   root: {


### PR DESCRIPTION
Prior to #1034, the Footer Logo's prop type was an image YextEntityFieldSelector but the field used was AssetImage (no entity field). #1034 fixed this, but should've included a migration to fix any mismatched data. 

Unfortunately, the resolver happens to pick the old data path if both exist ([thread](https://yext.slack.com/archives/C02UVSE7P6W/p1777559499279649))

This migration:
- moves data from the old path to the new path, if nothing in the new path exists
- removes data from the old path, if data exists in the new path