### PR TITLE
feat: add styledImage option for fields

### DIFF
--- a/packages/visual-editor/src/fields/fields.ts
+++ b/packages/visual-editor/src/fields/fields.ts
@@ -39,6 +39,10 @@ import {
   StyledButtonFieldOverride,
 } from "./styledFields/StyledButtonField.tsx";
 import {
+  StyledImageField,
+  StyledImageFieldOverride,
+} from "./styledFields/StyledImageField.tsx";
+import {
   StyledLinkField,
   StyledLinkFieldOverride,
 } from "./styledFields/StyledLinkField.tsx";
@@ -63,6 +67,7 @@ export type YextPuckFields = {
   image: ImageField;
   optionalNumber: OptionalNumberField;
   styledButton: StyledButtonField;
+  styledImage: StyledImageField;
   styledLink: StyledLinkField;
   styledText: StyledTextField;
   translatableString: TranslatableStringField;
@@ -110,6 +115,7 @@ export const YextPuckFieldOverrides = {
   image: ImageFieldOverride,
   optionalNumber: OptionalNumberFieldOverride,
   styledButton: StyledButtonFieldOverride,
+  styledImage: StyledImageFieldOverride,
   styledLink: StyledLinkFieldOverride,
   styledText: StyledTextFieldOverride,
   translatableString: TranslatableStringFieldOverride,

--- a/packages/visual-editor/src/fields/styledFields/StyledImageField.test.tsx
+++ b/packages/visual-editor/src/fields/styledFields/StyledImageField.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { YextAutoField } from "../YextAutoField.tsx";
+import {
+  type StyledImageField,
+  type StyledImageValue,
+} from "./StyledImageField.tsx";
+
+const field: StyledImageField = {
+  type: "styledImage",
+  label: "Styled Image",
+};
+
+const styledImageValue = (
+  overrides: Partial<StyledImageValue> = {}
+): StyledImageValue => ({
+  borderRadius: "default",
+  ...overrides,
+});
+
+const renderField = (value?: StyledImageValue) => {
+  const onChange = vi.fn();
+
+  render(
+    <YextAutoField
+      field={field}
+      id="styled-image"
+      onChange={onChange}
+      value={value}
+    />
+  );
+
+  return { onChange };
+};
+
+describe("StyledImageField", () => {
+  it("renders through YextAutoField as a registered field type", () => {
+    renderField(styledImageValue({ borderRadius: "24px" }));
+
+    expect(screen.getByText("Styled Image")).toBeDefined();
+    expect(screen.getByText("3XL (24px)")).toBeDefined();
+  });
+
+  it("updates border radius while preserving the object shape", () => {
+    const initialValue = styledImageValue({ borderRadius: "4px" });
+    const { onChange } = renderField(initialValue);
+
+    fireEvent.click(screen.getByText("SM (4px)"));
+    fireEvent.click(screen.getByText("LG (8px)"));
+
+    expect(onChange).toHaveBeenCalledWith({
+      borderRadius: "8px",
+    });
+  });
+
+  it("falls back to the default option when value is missing", () => {
+    renderField();
+
+    expect(screen.getByText("Default")).toBeDefined();
+  });
+
+  it("falls back to the default option when value is partial", () => {
+    renderField({} as StyledImageValue);
+
+    expect(screen.getByText("Default")).toBeDefined();
+  });
+});

--- a/packages/visual-editor/src/fields/styledFields/StyledImageField.tsx
+++ b/packages/visual-editor/src/fields/styledFields/StyledImageField.tsx
@@ -2,11 +2,14 @@ import React from "react";
 import { BaseField, FieldLabel, type FieldProps } from "@puckeditor/core";
 import { Combobox } from "../../internal/puck/ui/Combobox.tsx";
 import { pt, type MsgString } from "../../utils/i18n/platform.ts";
-import { ThemeOptions } from "../../utils/themeConfigOptions.ts";
+import {
+  type ImageBorderRadius,
+  ThemeOptions,
+} from "../../utils/themeConfigOptions.ts";
 import { withDefaultOption } from "./baseText.tsx";
 
 export type StyledImageValue = {
-  borderRadius: string;
+  borderRadius: ImageBorderRadius | "default";
 };
 
 export type StyledImageField = BaseField & {

--- a/packages/visual-editor/src/fields/styledFields/StyledImageField.tsx
+++ b/packages/visual-editor/src/fields/styledFields/StyledImageField.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { BaseField, FieldLabel, type FieldProps } from "@puckeditor/core";
+import { Combobox } from "../../internal/puck/ui/Combobox.tsx";
+import { pt, type MsgString } from "../../utils/i18n/platform.ts";
+import { ThemeOptions } from "../../utils/themeConfigOptions.ts";
+import { withDefaultOption } from "./baseText.tsx";
+
+export type StyledImageValue = {
+  borderRadius: string;
+};
+
+export type StyledImageField = BaseField & {
+  type: "styledImage";
+  label?: string | MsgString;
+  visible?: boolean;
+};
+
+type StyledImageFieldProps = FieldProps<StyledImageField, StyledImageValue>;
+
+const defaultStyledImageValue: StyledImageValue = {
+  borderRadius: "default",
+};
+
+export const StyledImageFieldOverride = ({
+  field,
+  value,
+  onChange,
+}: StyledImageFieldProps) => {
+  const currentValue: StyledImageValue = {
+    ...defaultStyledImageValue,
+    ...value,
+  };
+
+  const borderRadiusOptions = withDefaultOption(
+    ThemeOptions.IMAGE_BORDER_RADIUS.map((option) => ({
+      ...option,
+      label: pt(option.label),
+    }))
+  );
+
+  return (
+    <div>
+      {field.label && (
+        <div className="ve-mb-3 ve-text-sm ve-font-medium">
+          {pt(field.label)}
+        </div>
+      )}
+      <div className="ObjectField">
+        <div className="ObjectField-fieldset ve-flex ve-flex-col ve-gap-3">
+          <FieldLabel label={pt("theme.borderRadius", "Border Radius")}>
+            <Combobox
+              selectedOption={
+                borderRadiusOptions.find(
+                  (option) => option.value === currentValue.borderRadius
+                ) ?? borderRadiusOptions[0]
+              }
+              onChange={(nextValue) => onChange({ borderRadius: nextValue })}
+              optionGroups={[{ options: borderRadiusOptions }]}
+              disableSearch
+            />
+          </FieldLabel>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/visual-editor/src/fields/styledFields/index.ts
+++ b/packages/visual-editor/src/fields/styledFields/index.ts
@@ -11,6 +11,12 @@ export {
 } from "./StyledButtonField.tsx";
 
 export {
+  StyledImageFieldOverride,
+  type StyledImageField,
+  type StyledImageValue,
+} from "./StyledImageField.tsx";
+
+export {
   StyledLinkFieldOverride,
   type StyledLinkField,
   type StyledLinkValue,

--- a/packages/visual-editor/src/utils/themeConfigOptions.ts
+++ b/packages/visual-editor/src/utils/themeConfigOptions.ts
@@ -318,6 +318,12 @@ type BorderRadiusOption = {
   value: string;
 };
 
+const defineBorderRadiusOptions = <
+  const T extends readonly BorderRadiusOption[],
+>(
+  options: T
+) => [...options];
+
 const buttonBorderRadiusOptions: BorderRadiusOption[] = [
   { label: msg("theme.options.none", "None"), value: "0px" },
   { label: "XS (2px)", value: "2px" },
@@ -328,7 +334,7 @@ const buttonBorderRadiusOptions: BorderRadiusOption[] = [
   { label: msg("theme.options.pill", "Pill"), value: "9999px" },
 ];
 
-const imageBorderRadiusOptions: BorderRadiusOption[] = [
+const imageBorderRadiusOptions = defineBorderRadiusOptions([
   { label: msg("theme.options.none", "None"), value: "0px" },
   { label: "XS (2px)", value: "2px" },
   { label: "SM (4px)", value: "4px" },
@@ -342,7 +348,10 @@ const imageBorderRadiusOptions: BorderRadiusOption[] = [
     label: msg("theme.options.circle", "Circle"),
     value: "9999px",
   },
-];
+] satisfies readonly BorderRadiusOption[]);
+
+export type ImageBorderRadius =
+  (typeof imageBorderRadiusOptions)[number]["value"];
 
 const ctaVariantOptions = [
   {


### PR DESCRIPTION
This adds a new StyledImageField which has a "Border Radius" option. It is not currently being used anywhere.

I've temporarily added it to HeroImage for testing in the screenshot below.
<img width="1166" height="1114" alt="Screenshot 2026-05-04 at 5 04 23 PM" src="https://github.com/user-attachments/assets/4d520afc-dd18-4325-8e39-4d794c73c057" />
