### PR TITLE
fix: apply template name directly to config

### DIFF
--- a/packages/visual-editor/src/vite-plugin/routing/editorRoute.test.ts
+++ b/packages/visual-editor/src/vite-plugin/routing/editorRoute.test.ts
@@ -122,13 +122,16 @@ describe("injectEditorTemplateInfo", () => {
     expect(
       injectEditorTemplateInfo(
         `const editPath = "${EDIT_PATH_PLACEHOLDER}";
-const editTemplateName = "${EDIT_TEMPLATE_NAME_PLACEHOLDER}";`,
+export const config = { name: "${EDIT_TEMPLATE_NAME_PLACEHOLDER}" };
+export const getHeadConfig = () => ({ title: "${EDIT_TEMPLATE_NAME_PLACEHOLDER}" });`,
         {
           path: "edit",
           configName: "edit",
         }
       )
-    ).toBe('const editPath = "edit";\nconst editTemplateName = "edit";');
+    ).toBe(`const editPath = "edit";
+export const config = { name: "edit" };
+export const getHeadConfig = () => ({ title: "edit" });`);
   });
 
   it("replaces all occurrences of both placeholders", () => {
@@ -136,8 +139,9 @@ const editTemplateName = "${EDIT_TEMPLATE_NAME_PLACEHOLDER}";`,
       injectEditorTemplateInfo(
         `const editPath = "${EDIT_PATH_PLACEHOLDER}";
 const duplicateEditPath = "${EDIT_PATH_PLACEHOLDER}";
-const editTemplateName = "${EDIT_TEMPLATE_NAME_PLACEHOLDER}";
-const duplicateEditTemplateName = "${EDIT_TEMPLATE_NAME_PLACEHOLDER}";`,
+export const config = { name: "${EDIT_TEMPLATE_NAME_PLACEHOLDER}" };
+export const duplicateConfig = { name: "${EDIT_TEMPLATE_NAME_PLACEHOLDER}" };
+export const getHeadConfig = () => ({ title: "${EDIT_TEMPLATE_NAME_PLACEHOLDER}" });`,
         {
           path: "edit/demo-shop",
           configName: "edit-demo-shop",
@@ -145,8 +149,9 @@ const duplicateEditTemplateName = "${EDIT_TEMPLATE_NAME_PLACEHOLDER}";`,
       )
     ).toBe(`const editPath = "edit/demo-shop";
 const duplicateEditPath = "edit/demo-shop";
-const editTemplateName = "edit-demo-shop";
-const duplicateEditTemplateName = "edit-demo-shop";`);
+export const config = { name: "edit-demo-shop" };
+export const duplicateConfig = { name: "edit-demo-shop" };
+export const getHeadConfig = () => ({ title: "edit-demo-shop" });`);
   });
 
   it("throws when the path placeholder is missing", () => {
@@ -162,7 +167,7 @@ const duplicateEditTemplateName = "edit-demo-shop";`);
     expect(() =>
       injectEditorTemplateInfo(
         `const editPath = "${EDIT_PATH_PLACEHOLDER}";
-const editTemplateName = "edit";`,
+export const config = { name: "edit" };`,
         {
           path: "edit/demo-shop",
           configName: "edit-demo-shop",

--- a/packages/visual-editor/src/vite-plugin/templates/edit.tsx
+++ b/packages/visual-editor/src/vite-plugin/templates/edit.tsx
@@ -33,7 +33,6 @@ const componentRegistry: Record<string, Config<any>> = {
 };
 
 const editPath = "__YEXT_VISUAL_EDITOR_PATH__";
-const editTemplateName = "__YEXT_VISUAL_EDITOR_TEMPLATE_NAME__";
 const previewModeParam = "preview";
 const previewStorageKeyParam = "previewStorageKey";
 const localEditorApiBasePath = "/__yext_visual_editor/local-editor";
@@ -44,14 +43,14 @@ export const getPath: GetPath<TemplateProps> = () => {
 };
 
 export const config: TemplateConfig = {
-  name: editTemplateName,
+  name: "__YEXT_VISUAL_EDITOR_TEMPLATE_NAME__",
 };
 
 export const getHeadConfig: GetHeadConfig<TemplateRenderProps> = ({
   document,
 }): HeadConfig => {
   return {
-    title: editTemplateName,
+    title: "__YEXT_VISUAL_EDITOR_TEMPLATE_NAME__",
     other: fullStorySnippet + applyTheme(document, "./", defaultThemeConfig),
   };
 };


### PR DESCRIPTION
Sometimes, the minified js for the template puts the `editTemplateName` const below the `config` const, which makes the editor fail when `config` tries to find a variable that hasn't been assigned yet. This seems to be a bit sporadic, as some templates have had no issues while others break entirely. Assigning the `__YEXT_VISUAL_EDITOR_TEMPLATE_NAME__` directly in the two places it is used should be a safer way to handle this.

This screenshot shows a snippet from the minified `edit-[templateName]` template from a recent attempt at a template push. `Q` appears to be `config` ,and `H` appears to be `editTemplateName`, which has not yet been assigned when `Q` uses it.

<img width="377" height="261" alt="Screenshot 2026-06-09 at 4 44 26 PM" src="https://github.com/user-attachments/assets/a5f406ff-8f08-455e-b28d-00c98ac8ba0a" />
