### PR TITLE
fix: comprehensive cta qa

### DIFF
--- a/packages/visual-editor/src/components/atoms/cta.tsx
+++ b/packages/visual-editor/src/components/atoms/cta.tsx
@@ -455,7 +455,7 @@ export const CTA = (props: CTAProps) => {
         }}
       >
         {linkContent}
-        {openInNewTab && (
+        {openInNewTab && ctaType !== "presetImage" && (
           <FaExternalLinkAlt
             aria-hidden="true"
             className="inline-block ml-1 w-3 h-3 align-middle relative -top-px"

--- a/packages/visual-editor/src/components/contentBlocks/ComprehensiveCTA.tsx
+++ b/packages/visual-editor/src/components/contentBlocks/ComprehensiveCTA.tsx
@@ -302,7 +302,7 @@ export const ComprehensiveCTA = ({
       id={actionType === "button" ? currentValue.data.customId : undefined}
       label={effectiveLabel}
       link={
-        actionType === "link" && resolvedCta
+        actionType === "link" && ctaType !== "getDirections" && resolvedCta
           ? resolveComponentData(resolvedCta.link, locale, streamDocument)
           : undefined
       }


### PR DESCRIPTION
1. Don't show the "open in new tab" icon when using a presetImage
2. Don't use the link from the Puck fields when using getDirections