### PR TITLE
feat: image url support for image fields in local editor

### DIFF
--- a/packages/visual-editor/src/components/contentBlocks/image/EmptyImageState.tsx
+++ b/packages/visual-editor/src/components/contentBlocks/image/EmptyImageState.tsx
@@ -11,7 +11,7 @@ import {
   useReceiveMessage,
 } from "../../../internal/hooks/useMessage.ts";
 import { type ImagePayload } from "../../../fields/ImageField.tsx";
-import { isLocalDev } from "../../../utils/isFakeStarterLocalDev.ts";
+import { isLocalDev } from "../../../utils/isLocalDev.ts";
 
 let pendingEmptyImageSession:
   | { messageId: string; apply: (payload: ImagePayload) => void }

--- a/packages/visual-editor/src/components/contentBlocks/image/EmptyImageState.tsx
+++ b/packages/visual-editor/src/components/contentBlocks/image/EmptyImageState.tsx
@@ -11,7 +11,10 @@ import {
   useReceiveMessage,
 } from "../../../internal/hooks/useMessage.ts";
 import { type ImagePayload } from "../../../fields/ImageField.tsx";
-import { isFakeStarterLocalDev } from "../../../utils/isFakeStarterLocalDev.ts";
+import {
+  isFakeStarterLocalDev,
+  isLocalEditorRoute,
+} from "../../../utils/isFakeStarterLocalDev.ts";
 
 let pendingEmptyImageSession:
   | { messageId: string; apply: (payload: ImagePayload) => void }
@@ -64,7 +67,10 @@ export const EmptyImageState: React.FC<EmptyImageStateProps> = ({
 
   const handleImageSelection = React.useCallback(() => {
     if (!hasParentData && constantValueEnabled && isEditing) {
-      if (isFakeStarterLocalDev()) {
+      if (
+        isFakeStarterLocalDev() ||
+        (typeof window !== "undefined" && isLocalEditorRoute(window.location))
+      ) {
         const userInput = prompt("Enter Image URL:");
         if (!userInput) {
           return;

--- a/packages/visual-editor/src/components/contentBlocks/image/EmptyImageState.tsx
+++ b/packages/visual-editor/src/components/contentBlocks/image/EmptyImageState.tsx
@@ -11,10 +11,7 @@ import {
   useReceiveMessage,
 } from "../../../internal/hooks/useMessage.ts";
 import { type ImagePayload } from "../../../fields/ImageField.tsx";
-import {
-  isFakeStarterLocalDev,
-  isLocalEditorRoute,
-} from "../../../utils/isFakeStarterLocalDev.ts";
+import { isLocalDev } from "../../../utils/isFakeStarterLocalDev.ts";
 
 let pendingEmptyImageSession:
   | { messageId: string; apply: (payload: ImagePayload) => void }
@@ -67,10 +64,7 @@ export const EmptyImageState: React.FC<EmptyImageStateProps> = ({
 
   const handleImageSelection = React.useCallback(() => {
     if (!hasParentData && constantValueEnabled && isEditing) {
-      if (
-        isFakeStarterLocalDev() ||
-        (typeof window !== "undefined" && isLocalEditorRoute(window.location))
-      ) {
+      if (isLocalDev()) {
         const userInput = prompt("Enter Image URL:");
         if (!userInput) {
           return;

--- a/packages/visual-editor/src/editor/TranslatableRichTextField.test.tsx
+++ b/packages/visual-editor/src/editor/TranslatableRichTextField.test.tsx
@@ -30,7 +30,7 @@ vi.mock("../internal/hooks/useMessage.ts", () => ({
 }));
 
 vi.mock("../utils/isFakeStarterLocalDev.ts", () => ({
-  isFakeStarterLocalDev: () => false,
+  isLocalDev: () => false,
 }));
 
 vi.mock("../internal/utils/shouldUseStandaloneLocalPrompt.ts", () => ({

--- a/packages/visual-editor/src/editor/TranslatableRichTextField.test.tsx
+++ b/packages/visual-editor/src/editor/TranslatableRichTextField.test.tsx
@@ -29,7 +29,7 @@ vi.mock("../internal/hooks/useMessage.ts", () => ({
   }),
 }));
 
-vi.mock("../utils/isFakeStarterLocalDev.ts", () => ({
+vi.mock("../utils/isLocalDev.ts", () => ({
   isLocalDev: () => false,
 }));
 

--- a/packages/visual-editor/src/fields/CodeField.tsx
+++ b/packages/visual-editor/src/fields/CodeField.tsx
@@ -6,7 +6,7 @@ import {
   useSendMessageToParent,
 } from "../internal/hooks/useMessage.ts";
 import { pt, type MsgString } from "../utils/i18n/platform.ts";
-import { isLocalDev } from "../utils/isFakeStarterLocalDev.ts";
+import { isLocalDev } from "../utils/isLocalDev.ts";
 
 let pendingCodeSession:
   | { messageId: string; apply: (payload: any) => void }

--- a/packages/visual-editor/src/fields/CodeField.tsx
+++ b/packages/visual-editor/src/fields/CodeField.tsx
@@ -6,7 +6,7 @@ import {
   useSendMessageToParent,
 } from "../internal/hooks/useMessage.ts";
 import { pt, type MsgString } from "../utils/i18n/platform.ts";
-import { isFakeStarterLocalDev } from "../utils/isFakeStarterLocalDev.ts";
+import { isLocalDev } from "../utils/isFakeStarterLocalDev.ts";
 
 let pendingCodeSession:
   | { messageId: string; apply: (payload: any) => void }
@@ -79,7 +79,7 @@ export const CodeFieldOverride = ({
     });
 
     /** Handles local development testing outside of storm */
-    if (isFakeStarterLocalDev()) {
+    if (isLocalDev()) {
       const userInput = prompt("Enter Code:");
       onChange(userInput ?? "");
       if (pendingCodeSession?.messageId === messageId) {

--- a/packages/visual-editor/src/fields/ImageField.test.tsx
+++ b/packages/visual-editor/src/fields/ImageField.test.tsx
@@ -5,10 +5,11 @@ import { TemplatePropsContext } from "../hooks/useDocument.tsx";
 import { YextAutoField } from "./YextAutoField.tsx";
 import { type ImageField } from "./ImageField.tsx";
 
-const { sendToParentMock, translatableStringFieldMock } = vi.hoisted(() => ({
+const { sendToParentMock } = vi.hoisted(() => ({
   sendToParentMock: vi.fn(),
-  translatableStringFieldMock: vi.fn(),
 }));
+
+const initialUrl = window.location.href;
 
 vi.mock("react-i18next", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react-i18next")>();
@@ -29,34 +30,19 @@ vi.mock("../internal/hooks/useMessage.ts", () => ({
   }),
 }));
 
-vi.mock("../internal/hooks/useMessageReceivers.ts", () => ({
-  useTemplateMetadata: () => ({
-    locatorDisplayFields: {
-      c_title: {
-        field_type_id: "type.string",
-        field_name: "Title",
-      },
-      c_photo: {
-        field_type_id: "type.image",
-        field_name: "Photo",
-      },
-    },
-  }),
-}));
-
-vi.mock("./TranslatableStringField.tsx", async (importOriginal) => {
+vi.mock("../internal/hooks/useMessageReceivers.ts", async (importOriginal) => {
   const actual =
-    await importOriginal<typeof import("./TranslatableStringField.tsx")>();
+    await importOriginal<
+      typeof import("../internal/hooks/useMessageReceivers.ts")
+    >();
 
   return {
     ...actual,
-    TranslatableStringField: translatableStringFieldMock,
+    useTemplateMetadata: () => ({
+      locatorDisplayFields: {},
+    }),
   };
 });
-
-vi.mock("../utils/isFakeStarterLocalDev.ts", () => ({
-  isFakeStarterLocalDev: () => true,
-}));
 
 const renderImageField = (
   field: ImageField = {
@@ -66,11 +52,6 @@ const renderImageField = (
   value?: unknown
 ) => {
   const onChange = vi.fn();
-
-  translatableStringFieldMock.mockImplementation((label: string) => ({
-    type: "text",
-    label,
-  }));
 
   render(
     <TemplatePropsContext.Provider value={{ document: { locale: "en" } }}>
@@ -89,11 +70,13 @@ const renderImageField = (
 describe("ImageField", () => {
   afterEach(() => {
     vi.restoreAllMocks();
-    translatableStringFieldMock.mockReset();
     sendToParentMock.mockReset();
+    window.history.replaceState({}, "", initialUrl);
   });
 
-  it("renders through YextAutoField as a registered field type", () => {
+  it("prompts for an image URL in fake starter local dev", () => {
+    window.history.replaceState({}, "", "/dev-location/example");
+
     const promptSpy = vi
       .spyOn(window, "prompt")
       .mockReturnValue("https://example.com/image.jpg");
@@ -115,43 +98,25 @@ describe("ImageField", () => {
     });
   });
 
-  it("passes locator alt text options into the alt text field", () => {
-    const getAltTextOptions = vi.fn((templateMetadata) => [
-      {
-        label: templateMetadata.locatorDisplayFields?.c_title?.field_name ?? "",
-        value: "c_title",
-      },
-    ]);
+  it("prompts for an image URL in local-editor", () => {
+    window.history.replaceState({}, "", "/local-editor");
 
-    renderImageField(
-      {
-        type: "image",
-        label: "Image",
-        getAltTextOptions,
-      },
-      {
-        en: {
-          alternateText: "",
-          url: "https://example.com/image.jpg",
-          height: 1,
-          width: 1,
-        },
-        hasLocalizedValue: "true",
-      }
-    );
+    const promptSpy = vi
+      .spyOn(window, "prompt")
+      .mockReturnValue("https://example.com/local-editor-image.jpg");
+    const { onChange } = renderImageField();
 
-    expect(getAltTextOptions).toHaveBeenCalledWith({
-      locatorDisplayFields: {
-        c_title: {
-          field_type_id: "type.string",
-          field_name: "Title",
-        },
-        c_photo: {
-          field_type_id: "type.image",
-          field_name: "Photo",
-        },
+    fireEvent.click(screen.getByRole("button", { name: "Choose Image" }));
+
+    expect(promptSpy).toHaveBeenCalledWith("Enter Image URL:");
+    expect(onChange).toHaveBeenCalledWith({
+      en: {
+        alternateText: "",
+        url: "https://example.com/local-editor-image.jpg",
+        height: 1,
+        width: 1,
       },
+      hasLocalizedValue: "true",
     });
-    expect(screen.getByText("Alt Text (en)")).toBeDefined();
   });
 });

--- a/packages/visual-editor/src/fields/ImageField.tsx
+++ b/packages/visual-editor/src/fields/ImageField.tsx
@@ -25,7 +25,10 @@ import {
   TemplateMetadata,
 } from "../internal/types/templateMetadata.ts";
 import { useTemplateMetadata } from "../internal/hooks/useMessageReceivers.ts";
-import { isFakeStarterLocalDev } from "../utils/isFakeStarterLocalDev.ts";
+import {
+  isFakeStarterLocalDev,
+  isLocalEditorRoute,
+} from "../utils/isFakeStarterLocalDev.ts";
 import { YextAutoField } from "./YextAutoField.tsx";
 import { type EmbeddedStringOption } from "../editor/EmbeddedFieldStringInput.tsx";
 
@@ -110,7 +113,10 @@ export const ImageFieldOverride = ({
     e.preventDefault();
 
     /** Handles local development testing outside of Storm */
-    if (isFakeStarterLocalDev()) {
+    if (
+      isFakeStarterLocalDev() ||
+      (typeof window !== "undefined" && isLocalEditorRoute(window.location))
+    ) {
       const userInput = prompt("Enter Image URL:");
       if (!userInput) {
         return;

--- a/packages/visual-editor/src/fields/ImageField.tsx
+++ b/packages/visual-editor/src/fields/ImageField.tsx
@@ -25,10 +25,7 @@ import {
   TemplateMetadata,
 } from "../internal/types/templateMetadata.ts";
 import { useTemplateMetadata } from "../internal/hooks/useMessageReceivers.ts";
-import {
-  isFakeStarterLocalDev,
-  isLocalEditorRoute,
-} from "../utils/isFakeStarterLocalDev.ts";
+import { isLocalDev } from "../utils/isFakeStarterLocalDev.ts";
 import { YextAutoField } from "./YextAutoField.tsx";
 import { type EmbeddedStringOption } from "../editor/EmbeddedFieldStringInput.tsx";
 
@@ -113,10 +110,7 @@ export const ImageFieldOverride = ({
     e.preventDefault();
 
     /** Handles local development testing outside of Storm */
-    if (
-      isFakeStarterLocalDev() ||
-      (typeof window !== "undefined" && isLocalEditorRoute(window.location))
-    ) {
+    if (isLocalDev()) {
       const userInput = prompt("Enter Image URL:");
       if (!userInput) {
         return;

--- a/packages/visual-editor/src/fields/ImageField.tsx
+++ b/packages/visual-editor/src/fields/ImageField.tsx
@@ -25,7 +25,7 @@ import {
   TemplateMetadata,
 } from "../internal/types/templateMetadata.ts";
 import { useTemplateMetadata } from "../internal/hooks/useMessageReceivers.ts";
-import { isLocalDev } from "../utils/isFakeStarterLocalDev.ts";
+import { isLocalDev } from "../utils/isLocalDev.ts";
 import { YextAutoField } from "./YextAutoField.tsx";
 import { type EmbeddedStringOption } from "../editor/EmbeddedFieldStringInput.tsx";
 

--- a/packages/visual-editor/src/fields/VideoField.tsx
+++ b/packages/visual-editor/src/fields/VideoField.tsx
@@ -8,7 +8,7 @@ import {
 import { Button } from "../internal/puck/ui/button.tsx";
 import { type AssetVideo } from "../types/videos.ts";
 import { pt, type MsgString } from "../utils/i18n/platform.ts";
-import { isFakeStarterLocalDev } from "../utils/isFakeStarterLocalDev.ts";
+import { isLocalDev } from "../utils/isFakeStarterLocalDev.ts";
 
 export type VideoField = BaseField & {
   type: "video";
@@ -56,7 +56,7 @@ export const VideoFieldOverride = ({
     e.preventDefault();
 
     /** Handles local development testing outside of Storm */
-    if (isFakeStarterLocalDev()) {
+    if (isLocalDev()) {
       const userInput = prompt("Enter Video URL:");
       if (!userInput) {
         return;

--- a/packages/visual-editor/src/fields/VideoField.tsx
+++ b/packages/visual-editor/src/fields/VideoField.tsx
@@ -8,7 +8,7 @@ import {
 import { Button } from "../internal/puck/ui/button.tsx";
 import { type AssetVideo } from "../types/videos.ts";
 import { pt, type MsgString } from "../utils/i18n/platform.ts";
-import { isLocalDev } from "../utils/isFakeStarterLocalDev.ts";
+import { isLocalDev } from "../utils/isLocalDev.ts";
 
 export type VideoField = BaseField & {
   type: "video";

--- a/packages/visual-editor/src/internal/components/AdvancedSettings.tsx
+++ b/packages/visual-editor/src/internal/components/AdvancedSettings.tsx
@@ -9,7 +9,7 @@ import {
   TARGET_ORIGINS,
 } from "../hooks/useMessage.ts";
 import { getSchemaTemplate } from "../../utils/schema/defaultSchemas.ts";
-import { isFakeStarterLocalDev } from "../../utils/isFakeStarterLocalDev.ts";
+import { isLocalDev } from "../../utils/isFakeStarterLocalDev.ts";
 import { YextComponentConfig, YextFields } from "../../fields/fields.ts";
 
 let pendingSchemaMarkupSession:
@@ -67,7 +67,7 @@ const SCHEMA_MARKUP_FIELD: CustomField<string> = {
       e.preventDefault();
 
       /** Handles local development testing outside of Storm */
-      if (isFakeStarterLocalDev()) {
+      if (isLocalDev()) {
         const userInput = prompt("Enter Schema Markup:", schema);
         if (userInput !== null) {
           onChange(userInput);

--- a/packages/visual-editor/src/internal/components/AdvancedSettings.tsx
+++ b/packages/visual-editor/src/internal/components/AdvancedSettings.tsx
@@ -9,7 +9,7 @@ import {
   TARGET_ORIGINS,
 } from "../hooks/useMessage.ts";
 import { getSchemaTemplate } from "../../utils/schema/defaultSchemas.ts";
-import { isLocalDev } from "../../utils/isFakeStarterLocalDev.ts";
+import { isLocalDev } from "../../utils/isLocalDev.ts";
 import { YextComponentConfig, YextFields } from "../../fields/fields.ts";
 
 let pendingSchemaMarkupSession:

--- a/packages/visual-editor/src/internal/hooks/useMessage.ts
+++ b/packages/visual-editor/src/internal/hooks/useMessage.ts
@@ -8,7 +8,7 @@ import {
   Dispatch,
   SetStateAction,
 } from "react";
-import { isFakeStarterLocalDev } from "../../utils/isFakeStarterLocalDev.ts";
+import { isLocalDev } from "../../utils/isFakeStarterLocalDev.ts";
 
 export type Payload = Record<string, any>;
 export type Status = "success" | "error";
@@ -199,7 +199,7 @@ export const getOriginsForSending = (targetOrigins: string[]): string[] => {
   // Initialize the global tracker to ensure we capture the parent origin early
   initializeGlobalOriginTracker();
 
-  if (typeof window !== "undefined" && isFakeStarterLocalDev()) {
+  if (isLocalDev()) {
     return [window.location.origin];
   }
 

--- a/packages/visual-editor/src/internal/hooks/useMessage.ts
+++ b/packages/visual-editor/src/internal/hooks/useMessage.ts
@@ -8,7 +8,7 @@ import {
   Dispatch,
   SetStateAction,
 } from "react";
-import { isLocalDev } from "../../utils/isFakeStarterLocalDev.ts";
+import { isLocalDev } from "../../utils/isLocalDev.ts";
 
 export type Payload = Record<string, any>;
 export type Status = "success" | "error";

--- a/packages/visual-editor/src/utils/isFakeStarterLocalDev.test.ts
+++ b/packages/visual-editor/src/utils/isFakeStarterLocalDev.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   isFakeStarterLocalDev,
   isFakeStarterLocalDevRoute,
+  isLocalEditorRoute,
 } from "./isFakeStarterLocalDev.ts";
 
 const initialUrl = window.location.href;
@@ -23,6 +24,18 @@ describe("isFakeStarterLocalDevRoute", () => {
       false
     );
     expect(isFakeStarterLocalDevRoute("/locator/example")).toBe(false);
+  });
+});
+
+describe("isLocalEditorRoute", () => {
+  it("matches the local editor route", () => {
+    expect(isLocalEditorRoute("http://localhost:5173/local-editor")).toBe(true);
+    expect(isLocalEditorRoute("/local-editor")).toBe(true);
+  });
+
+  it("does not match other routes", () => {
+    expect(isLocalEditorRoute("http://localhost:5173/edit")).toBe(false);
+    expect(isLocalEditorRoute("/dev-location/example")).toBe(false);
   });
 });
 

--- a/packages/visual-editor/src/utils/isFakeStarterLocalDev.test.ts
+++ b/packages/visual-editor/src/utils/isFakeStarterLocalDev.test.ts
@@ -1,8 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
-  isFakeStarterLocalDev,
+  isLocalDev,
   isFakeStarterLocalDevRoute,
-  isLocalEditorRoute,
 } from "./isFakeStarterLocalDev.ts";
 
 const initialUrl = window.location.href;
@@ -27,24 +26,18 @@ describe("isFakeStarterLocalDevRoute", () => {
   });
 });
 
-describe("isLocalEditorRoute", () => {
-  it("matches the local editor route", () => {
-    expect(isLocalEditorRoute("http://localhost:5173/local-editor")).toBe(true);
-    expect(isLocalEditorRoute("/local-editor")).toBe(true);
-  });
-
-  it("does not match other routes", () => {
-    expect(isLocalEditorRoute("http://localhost:5173/edit")).toBe(false);
-    expect(isLocalEditorRoute("/dev-location/example")).toBe(false);
-  });
-});
-
-describe("isFakeStarterLocalDev", () => {
+describe("isLocalDev", () => {
   it("checks the current window location", () => {
-    window.history.replaceState({}, "", "/dev-locator/locator-slug");
-    expect(isFakeStarterLocalDev()).toBe(true);
+    window.history.replaceState({}, "", "/local-editor");
+    expect(isLocalDev()).toBe(true);
 
     window.history.replaceState({}, "", "/edit");
-    expect(isFakeStarterLocalDev()).toBe(false);
+    expect(isLocalDev()).toBe(false);
+
+    window.history.replaceState({}, "", "/dev-locator/locator-slug");
+    expect(isLocalDev()).toBe(true);
+
+    window.history.replaceState({}, "", "/edit");
+    expect(isLocalDev()).toBe(false);
   });
 });

--- a/packages/visual-editor/src/utils/isFakeStarterLocalDev.ts
+++ b/packages/visual-editor/src/utils/isFakeStarterLocalDev.ts
@@ -1,29 +1,26 @@
 type LocationLike = string | URL | { pathname: string };
 
-const getPathname = (locationLike: LocationLike) => {
+export const isFakeStarterLocalDevRoute = (locationLike: LocationLike) => {
   if (typeof locationLike === "string") {
-    return new URL(locationLike, "http://localhost").pathname;
+    return new URL(locationLike, "http://localhost").pathname.startsWith(
+      "/dev-"
+    );
   }
 
   if (locationLike instanceof URL) {
-    return locationLike.pathname;
+    return locationLike.pathname.startsWith("/dev-");
   }
 
-  return locationLike.pathname;
+  return locationLike.pathname.startsWith("/dev-");
 };
 
-export const isFakeStarterLocalDevRoute = (locationLike: LocationLike) => {
-  return getPathname(locationLike).startsWith("/dev-");
-};
-
-export const isLocalEditorRoute = (locationLike: LocationLike) => {
-  return getPathname(locationLike) === "/local-editor";
-};
-
-export const isFakeStarterLocalDev = () => {
+export const isLocalDev = () => {
   if (typeof window === "undefined") {
     return false;
   }
 
-  return isFakeStarterLocalDevRoute(window.location);
+  return (
+    isFakeStarterLocalDevRoute(window.location) ||
+    window.location.pathname === "/local-editor"
+  );
 };

--- a/packages/visual-editor/src/utils/isFakeStarterLocalDev.ts
+++ b/packages/visual-editor/src/utils/isFakeStarterLocalDev.ts
@@ -16,6 +16,10 @@ export const isFakeStarterLocalDevRoute = (locationLike: LocationLike) => {
   return getPathname(locationLike).startsWith("/dev-");
 };
 
+export const isLocalEditorRoute = (locationLike: LocationLike) => {
+  return getPathname(locationLike) === "/local-editor";
+};
+
 export const isFakeStarterLocalDev = () => {
   if (typeof window === "undefined") {
     return false;

--- a/packages/visual-editor/src/utils/isLocalDev.test.ts
+++ b/packages/visual-editor/src/utils/isLocalDev.test.ts
@@ -1,8 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import {
-  isLocalDev,
-  isFakeStarterLocalDevRoute,
-} from "./isFakeStarterLocalDev.ts";
+import { isLocalDev, isFakeStarterLocalDevRoute } from "./isLocalDev.ts";
 
 const initialUrl = window.location.href;
 

--- a/packages/visual-editor/src/utils/isLocalDev.test.ts
+++ b/packages/visual-editor/src/utils/isLocalDev.test.ts
@@ -1,26 +1,10 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { isLocalDev, isFakeStarterLocalDevRoute } from "./isLocalDev.ts";
+import { isLocalDev } from "./isLocalDev.ts";
 
 const initialUrl = window.location.href;
 
 afterEach(() => {
   window.history.replaceState({}, "", initialUrl);
-});
-
-describe("isFakeStarterLocalDevRoute", () => {
-  it("matches fake starter dev routes", () => {
-    expect(
-      isFakeStarterLocalDevRoute("http://localhost:5173/dev-locator/example")
-    ).toBe(true);
-    expect(isFakeStarterLocalDevRoute("/dev-location/example")).toBe(true);
-  });
-
-  it("does not match non-fake-starter routes", () => {
-    expect(isFakeStarterLocalDevRoute("http://localhost:5173/edit")).toBe(
-      false
-    );
-    expect(isFakeStarterLocalDevRoute("/locator/example")).toBe(false);
-  });
 });
 
 describe("isLocalDev", () => {

--- a/packages/visual-editor/src/utils/isLocalDev.ts
+++ b/packages/visual-editor/src/utils/isLocalDev.ts
@@ -1,19 +1,3 @@
-type LocationLike = string | URL | { pathname: string };
-
-export const isFakeStarterLocalDevRoute = (locationLike: LocationLike) => {
-  if (typeof locationLike === "string") {
-    return new URL(locationLike, "http://localhost").pathname.startsWith(
-      "/dev-"
-    );
-  }
-
-  if (locationLike instanceof URL) {
-    return locationLike.pathname.startsWith("/dev-");
-  }
-
-  return locationLike.pathname.startsWith("/dev-");
-};
-
 export const isLocalDev = () => {
   if (typeof window === "undefined") {
     return false;
@@ -22,6 +6,6 @@ export const isLocalDev = () => {
   // `/local-editor` should use the same local-only fallbacks as the fake starter.
   return (
     window.location.pathname === "/local-editor" ||
-    isFakeStarterLocalDevRoute(window.location)
+    window.location.pathname.startsWith("/dev-")
   );
 };

--- a/packages/visual-editor/src/utils/isLocalDev.ts
+++ b/packages/visual-editor/src/utils/isLocalDev.ts
@@ -19,8 +19,9 @@ export const isLocalDev = () => {
     return false;
   }
 
+  // `/local-editor` should use the same local-only fallbacks as the fake starter.
   return (
-    isFakeStarterLocalDevRoute(window.location) ||
-    window.location.pathname === "/local-editor"
+    window.location.pathname === "/local-editor" ||
+    isFakeStarterLocalDevRoute(window.location)
   );
 };


### PR DESCRIPTION
This allows users of the local-editor to update image fields using a publicly-hosted image URL, like in the fake starter.

Demo:

https://github.com/user-attachments/assets/b3562003-9163-441a-a0eb-8c1dd01d3b67

