### PR TITLE
feat: support fonts in layout editor

### DIFF
--- a/packages/visual-editor/src/editor/Editor.tsx
+++ b/packages/visual-editor/src/editor/Editor.tsx
@@ -25,10 +25,6 @@ import {
   createDefaultThemeConfig,
   defaultThemeConfig,
 } from "../components/DefaultThemeConfig.ts";
-import {
-  defaultFonts,
-  loadFontsIntoDOM,
-} from "../utils/fonts/visualEditorFonts.ts";
 import { migrate } from "../utils/migrate.ts";
 import { migrationRegistry } from "../components/migrations/migrationRegistry.ts";
 import { ErrorProvider } from "../contexts/ErrorContext.tsx";
@@ -123,18 +119,6 @@ export const Editor = ({
       }
     }
   }, []);
-
-  // Loads all Google and custom fonts in the theme editor for the font dropdown
-  useEffect(() => {
-    if (typeof window !== "undefined" && templateMetadata?.isThemeMode) {
-      loadFontsIntoDOM(
-        window.document,
-        defaultFonts,
-        templateMetadata?.customFonts ?? {},
-        "visual-editor-default-fonts"
-      );
-    }
-  }, [templateMetadata?.customFonts, templateMetadata?.isThemeMode]);
 
   useEffect(() => {
     // templateMetadata.isDevMode indicates in-platform dev mode

--- a/packages/visual-editor/src/internal/components/InternalLayoutEditor.tsx
+++ b/packages/visual-editor/src/internal/components/InternalLayoutEditor.tsx
@@ -39,6 +39,7 @@ import { useErrorContext } from "../../contexts/ErrorContext.tsx";
 import { clonePuckResolveData } from "../utils/clonePuckResolveData.ts";
 import { YextPuckFieldOverrides } from "../../fields/fieldOverrides.ts";
 import { wrapComponentConfigWithErrorBoundary } from "../utils/wrapConfigWithComponentErrorBoundary.tsx";
+import { updateLayoutWithCustomFontAssets } from "../utils/customFontAssets.ts";
 
 const devLogger = new DevLogger();
 const usePuck = createUsePuck();
@@ -114,6 +115,18 @@ export const InternalLayoutEditor = ({
   const { i18n } = usePlatformTranslation();
   const streamDocument = useDocument();
   const { errorCount, errorSources, errorDetails } = useErrorContext();
+  const withCustomFontAssets = React.useCallback(
+    (data: Data | undefined): Record<string, any> => {
+      if (!data) {
+        return {};
+      }
+      return updateLayoutWithCustomFontAssets({
+        layoutData: data,
+        customFonts: templateMetadata.customFonts,
+      });
+    },
+    [templateMetadata.customFonts]
+  );
 
   /**
    * When the Puck history changes save it to localStorage and send a message
@@ -148,12 +161,14 @@ export const InternalLayoutEditor = ({
           return;
         }
 
+        const dataToSave = withCustomFontAssets(current.state.data);
+
         if (layoutSaveState?.hash !== current.id) {
           if (templateMetadata.isDevMode && !templateMetadata.devOverride) {
             devLogger.logFunc("sendDevSaveStateData");
             sendDevSaveStateData({
               payload: {
-                devSaveStateData: JSON.stringify(current.state.data),
+                devSaveStateData: JSON.stringify(dataToSave),
               },
             });
           } else {
@@ -162,7 +177,7 @@ export const InternalLayoutEditor = ({
               payload: {
                 hash: current.id,
                 history: JSON.stringify({
-                  data: current.state.data,
+                  data: dataToSave,
                   ui: current.state.ui,
                 }),
               },
@@ -176,6 +191,7 @@ export const InternalLayoutEditor = ({
       buildVisualConfigLocalStorageKey,
       layoutSaveState,
       saveLayoutSaveState,
+      withCustomFontAssets,
     ]
   );
 
@@ -186,14 +202,14 @@ export const InternalLayoutEditor = ({
 
   const handlePublishLayout = async (data: Data) => {
     publishLayout({
-      payload: { layoutData: JSON.stringify(data) },
+      payload: { layoutData: JSON.stringify(withCustomFontAssets(data)) },
     });
   };
 
   const handleSendLayoutForApproval = async (data: Data, comment: string) => {
     sendLayoutForApproval({
       payload: {
-        layoutData: JSON.stringify(data),
+        layoutData: JSON.stringify(withCustomFontAssets(data)),
         comment: comment,
       },
     });

--- a/packages/visual-editor/src/internal/components/InternalThemeEditor.tsx
+++ b/packages/visual-editor/src/internal/components/InternalThemeEditor.tsx
@@ -125,7 +125,6 @@ export const InternalThemeEditor = ({
       updateThemeInEditor(
         newThemeValues,
         themeConfig,
-        true,
         templateMetadata.customFonts
       );
       setThemeHistories(newHistory);
@@ -154,7 +153,6 @@ export const InternalThemeEditor = ({
     updateThemeInEditor(
       newThemeValues,
       themeConfig,
-      true,
       templateMetadata.customFonts
     );
     setThemeHistories(newHistory);

--- a/packages/visual-editor/src/internal/components/LayoutEditor.tsx
+++ b/packages/visual-editor/src/internal/components/LayoutEditor.tsx
@@ -104,12 +104,17 @@ export const LayoutEditor = (props: LayoutEditorProps) => {
   };
 
   /**
-   * Apply the themes from Content
+   * Apply the published theme
    */
   useEffect(() => {
     if (!themeConfig) {
       return;
     }
+
+    const histories = puckInitialHistory?.histories;
+    const historyIndex =
+      puckInitialHistory?.index ?? (histories?.length ?? 1) - 1;
+    const previewLayoutData = histories?.[historyIndex]?.state?.data;
 
     // use theme from localStorage when in dev mode
     if (templateMetadata.isDevMode) {
@@ -128,8 +133,8 @@ export const LayoutEditor = (props: LayoutEditorProps) => {
         updateThemeInEditor(
           localThemeData,
           themeConfig,
-          false,
-          templateMetadata.customFonts
+          templateMetadata.customFonts,
+          previewLayoutData
         );
         return;
       }
@@ -139,11 +144,11 @@ export const LayoutEditor = (props: LayoutEditorProps) => {
       updateThemeInEditor(
         themeData as ThemeData,
         themeConfig,
-        false,
-        templateMetadata.customFonts
+        templateMetadata.customFonts,
+        previewLayoutData
       );
     }
-  }, [themeData, themeConfig, templateMetadata]);
+  }, [themeData, themeConfig, templateMetadata, puckInitialHistory]);
 
   /**
    * Determines the initialHistory to send to Puck. It is based on a combination

--- a/packages/visual-editor/src/internal/components/ThemeEditor.tsx
+++ b/packages/visual-editor/src/internal/components/ThemeEditor.tsx
@@ -233,14 +233,25 @@ export const ThemeEditor = (props: ThemeEditorProps) => {
   useEffect(() => {
     devLogger.logData("THEME_HISTORIES", themeHistories);
     if (themeHistories && themeConfig) {
+      const layoutHistories = puckInitialHistory?.histories;
+      const layoutHistoryIndex =
+        puckInitialHistory?.index ?? (layoutHistories?.length ?? 1) - 1;
+      const previewLayoutData =
+        layoutHistories?.[layoutHistoryIndex]?.state?.data;
+
       updateThemeInEditor(
         themeHistories.histories[themeHistories.index]?.data as ThemeData,
         themeConfig,
-        true,
-        templateMetadata.customFonts
+        templateMetadata.customFonts,
+        previewLayoutData
       );
     }
-  }, [themeHistories, themeConfig]);
+  }, [
+    themeHistories,
+    themeConfig,
+    templateMetadata.customFonts,
+    puckInitialHistory,
+  ]);
 
   useEffect(() => {
     if (!themeSaveStateFetched) {

--- a/packages/visual-editor/src/internal/puck/components/FontSelector.tsx
+++ b/packages/visual-editor/src/internal/puck/components/FontSelector.tsx
@@ -4,6 +4,11 @@ import { StyleSelectOption } from "../../../utils/themeResolver.ts";
 import "../ui/puck.css";
 import { Search } from "lucide-react";
 import { pt } from "../../../utils/i18n/platform.ts";
+import {
+  defaultFonts,
+  loadFontsIntoDOM,
+} from "../../../utils/fonts/visualEditorFonts.ts";
+import { useTemplateMetadata } from "../../hooks/useMessageReceivers.ts";
 
 type FontSelectorProps = {
   label: string;
@@ -21,6 +26,7 @@ export const FontSelector = ({
   const [isOpen, setIsOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState<string>("");
   const searchInputRef = React.useRef<HTMLInputElement>(null);
+  const templateMetadata = useTemplateMetadata();
 
   const toggleDropdown = () => {
     setIsOpen(!isOpen);
@@ -41,9 +47,15 @@ export const FontSelector = ({
 
   React.useEffect(() => {
     if (isOpen) {
+      loadFontsIntoDOM(
+        document,
+        defaultFonts,
+        templateMetadata.customFonts ?? {},
+        "visual-editor-default-fonts"
+      );
       searchInputRef.current?.focus();
     }
-  }, [isOpen]);
+  }, [isOpen, templateMetadata.customFonts]);
 
   const filteredOptions = options.filter((option) =>
     option.label.toLowerCase().includes(searchTerm.toLowerCase())

--- a/packages/visual-editor/src/internal/puck/components/FontSelector.tsx
+++ b/packages/visual-editor/src/internal/puck/components/FontSelector.tsx
@@ -26,6 +26,7 @@ export const FontSelector = ({
   const [isOpen, setIsOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState<string>("");
   const searchInputRef = React.useRef<HTMLInputElement>(null);
+  const loadedCustomFontsRef = React.useRef<string>("");
   const templateMetadata = useTemplateMetadata();
 
   const toggleDropdown = () => {
@@ -47,6 +48,13 @@ export const FontSelector = ({
 
   React.useEffect(() => {
     if (isOpen) {
+      const customFontsKey = JSON.stringify(templateMetadata.customFonts ?? {});
+      if (loadedCustomFontsRef.current !== customFontsKey) {
+        document
+          .querySelectorAll('link[id^="visual-editor-default-fonts-"]')
+          .forEach((link) => link.remove());
+        loadedCustomFontsRef.current = customFontsKey;
+      }
       loadFontsIntoDOM(
         document,
         defaultFonts,

--- a/packages/visual-editor/src/internal/puck/components/FontSelector.tsx
+++ b/packages/visual-editor/src/internal/puck/components/FontSelector.tsx
@@ -56,7 +56,6 @@ export const FontSelector = ({
         loadedCustomFontsRef.current = customFontsKey;
       }
       loadFontsIntoDOM(
-        document,
         defaultFonts,
         templateMetadata.customFonts ?? {},
         "visual-editor-default-fonts"

--- a/packages/visual-editor/src/internal/puck/components/ThemeHeader.tsx
+++ b/packages/visual-editor/src/internal/puck/components/ThemeHeader.tsx
@@ -201,7 +201,6 @@ export const ThemeHeader = (props: ThemeHeaderProps) => {
               updateThemeInEditor(
                 themeHistories?.histories?.[0]?.data as ThemeData,
                 themeConfig,
-                true,
                 customFonts
               );
             }

--- a/packages/visual-editor/src/internal/utils/constructThemePuckFields.test.ts
+++ b/packages/visual-editor/src/internal/utils/constructThemePuckFields.test.ts
@@ -7,8 +7,10 @@ import {
   convertStyleToPuckField,
 } from "./constructThemePuckFields.ts";
 
-vi.mock("react", async () => {
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
   return {
+    ...actual,
     useCallback: (fn: any) => fn,
   };
 });

--- a/packages/visual-editor/src/internal/utils/customFontAssets.test.ts
+++ b/packages/visual-editor/src/internal/utils/customFontAssets.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   buildCustomFontAssets,
   buildFontPreloadTags,
+  updateLayoutWithCustomFontAssets,
 } from "./customFontAssets.ts";
 import { ThemeConfig } from "../../utils/themeResolver.ts";
 import { FontRegistry } from "../../utils/fonts/visualEditorFonts.ts";
@@ -497,5 +498,42 @@ describe("buildFontPreloadTags", () => {
     expect(buildFontPreloadTags(["/y-fonts/alpha-regular.bin"], "./")).toEqual(
       '<link rel="preload" href="/y-fonts/alpha-regular.bin" as="font" crossorigin="anonymous">\n'
     );
+  });
+});
+
+describe("layout custom font assets", () => {
+  it("stores layout custom font assets on root props", () => {
+    const layoutData = updateLayoutWithCustomFontAssets({
+      layoutData: {
+        root: { props: {} },
+        content: [
+          {
+            type: "Text",
+            props: {
+              typography: {
+                fontFamily: "'Alpha', 'Alpha Fallback', sans-serif",
+              },
+            },
+          },
+        ],
+        zones: {},
+      },
+      customFonts: {
+        Alpha: {
+          italics: false,
+          weights: [400],
+          fallback: "sans-serif",
+          facePath: "y-fonts/alpha.css",
+          variants: [],
+        },
+      },
+    });
+
+    expect(
+      (layoutData.root.props as Record<string, unknown>).__customFontAssets
+    ).toEqual({
+      stylesheetPaths: ["y-fonts/alpha.css"],
+      preloads: [],
+    });
   });
 });

--- a/packages/visual-editor/src/internal/utils/customFontAssets.ts
+++ b/packages/visual-editor/src/internal/utils/customFontAssets.ts
@@ -1,8 +1,10 @@
+import { Data } from "@puckeditor/core";
 import {
   type FontRegistry,
   type Font,
   type FontVariant,
   getFontFamilyFromThemeValue,
+  extractFontFamiliesFromLayout,
   normalizeAssetPath,
 } from "../../utils/fonts/visualEditorFonts.ts";
 import { ThemeConfig } from "../../utils/themeResolver.ts";
@@ -23,6 +25,10 @@ export type CustomFontAssets = {
   stylesheetPaths: string[];
   preloads: string[];
 };
+
+type LayoutRootProps = NonNullable<NonNullable<Data["root"]>["props"]>;
+type LayoutRootPropsWithCustomFontAssets = LayoutRootProps &
+  Partial<Record<typeof CUSTOM_FONT_ASSETS_KEY, CustomFontAssets>>;
 
 const PRELOAD_MIME_TYPE_BY_EXTENSION: Record<string, string> = {
   woff2: "font/woff2",
@@ -159,38 +165,66 @@ export const updateThemeWithCustomFontAssets = ({
 };
 
 /**
- * Reads the saved custom font assets from theme data.
+ * updateLayoutWithCustomFontAssets scans the layout for custom fonts
+ * and adds the asset information for any fonts that are found to data.root.props.
  */
-export const getCustomFontAssets = (
-  themeValues: ThemeData | undefined
-): CustomFontAssets => {
-  if (!themeValues) {
-    return {
-      stylesheetPaths: [],
-      preloads: [],
-    };
-  }
-
-  const assets = themeValues[CUSTOM_FONT_ASSETS_KEY];
-  if (!assets || typeof assets !== "object") {
-    return {
-      stylesheetPaths: [],
-      preloads: [],
-    };
-  }
-
-  return {
-    stylesheetPaths: Array.isArray((assets as CustomFontAssets).stylesheetPaths)
-      ? (assets as CustomFontAssets).stylesheetPaths.filter(
-          (entry): entry is string => typeof entry === "string"
-        )
-      : [],
-    preloads: Array.isArray((assets as CustomFontAssets).preloads)
-      ? (assets as CustomFontAssets).preloads.filter(
-          (entry): entry is string => typeof entry === "string"
-        )
-      : [],
+export const updateLayoutWithCustomFontAssets = ({
+  layoutData,
+  customFonts,
+}: {
+  layoutData: Data;
+  customFonts?: FontRegistry;
+}): Data => {
+  const rootProps: LayoutRootPropsWithCustomFontAssets = {
+    ...layoutData.root?.props,
   };
+
+  if (!customFonts || Object.keys(customFonts).length === 0) {
+    if (!(CUSTOM_FONT_ASSETS_KEY in rootProps)) {
+      return layoutData;
+    }
+
+    const nextRootProps: LayoutRootPropsWithCustomFontAssets = {
+      ...rootProps,
+    };
+    delete nextRootProps[CUSTOM_FONT_ASSETS_KEY];
+    const nextLayoutData: Data = {
+      ...layoutData,
+      root: {
+        ...layoutData.root,
+        props: nextRootProps,
+      },
+    };
+
+    return nextLayoutData;
+  }
+
+  const stylesheetPaths = new Set<string>();
+
+  for (const fontFamily of extractFontFamiliesFromLayout(layoutData)) {
+    const customFont = customFonts[fontFamily];
+    if (customFont?.facePath) {
+      stylesheetPaths.add(customFont.facePath);
+    }
+  }
+
+  const customFontAssets: CustomFontAssets = {
+    stylesheetPaths: [...stylesheetPaths],
+    preloads: [],
+  };
+  const nextRootProps: LayoutRootPropsWithCustomFontAssets = {
+    ...rootProps,
+    [CUSTOM_FONT_ASSETS_KEY]: customFontAssets,
+  };
+  const nextLayoutData: Data = {
+    ...layoutData,
+    root: {
+      ...layoutData.root,
+      props: nextRootProps,
+    },
+  };
+
+  return nextLayoutData;
 };
 
 /**
@@ -222,4 +256,26 @@ export const buildFontPreloadTags = (
       })
       .join("\n") + "\n"
   );
+};
+
+export const readCustomFontAssets = (value: unknown): CustomFontAssets => {
+  if (!value || typeof value !== "object") {
+    return {
+      stylesheetPaths: [],
+      preloads: [],
+    };
+  }
+
+  const { stylesheetPaths, preloads } = value as Partial<CustomFontAssets>;
+
+  return {
+    stylesheetPaths: Array.isArray(stylesheetPaths)
+      ? stylesheetPaths.filter(
+          (entry): entry is string => typeof entry === "string"
+        )
+      : [],
+    preloads: Array.isArray(preloads)
+      ? preloads.filter((entry): entry is string => typeof entry === "string")
+      : [],
+  };
 };

--- a/packages/visual-editor/src/utils/applyTheme.test.ts
+++ b/packages/visual-editor/src/utils/applyTheme.test.ts
@@ -7,6 +7,14 @@ import {
 import { ThemeConfig } from "./themeResolver.ts";
 import { StreamDocument } from "./types/StreamDocument.ts";
 
+const createPreviewIframe = () => {
+  document.body.replaceChildren();
+  const iframe = document.createElement("iframe");
+  iframe.id = "preview-frame";
+  document.body.appendChild(iframe);
+  return iframe;
+};
+
 describe("buildCssOverridesStyle", () => {
   it("should generate correct CSS with one override in c_theme", () => {
     const streamDocument: StreamDocument = {
@@ -126,6 +134,73 @@ describe("buildCssOverridesStyle", () => {
         "--fontFamily-button-fontFamily:'Adamina', 'Adamina Fallback', serif !important;" +
         "--fontFamily-h2-fontFamily:'Yext Custom', 'Yext Custom Fallback', serif !important" +
         "}</style>"
+    );
+  });
+
+  it("should load Google fonts referenced by layout fontFamily fields", () => {
+    const streamDocument: StreamDocument = {
+      __: {
+        layout: JSON.stringify({
+          root: { props: {} },
+          content: [
+            {
+              type: "Text",
+              props: {
+                typography: {
+                  fontFamily: "'Adamina', 'Adamina Fallback', serif",
+                },
+              },
+            },
+          ],
+          zones: {},
+        }),
+      },
+    };
+
+    const result = applyTheme(streamDocument, "./", themeConfig);
+
+    expect(result).toContain(
+      '<link href="https://fonts.googleapis.com/css2?family=Adamina:wght@400&display=swap" rel="stylesheet">'
+    );
+    expect(result).not.toContain("family=Open+Sans");
+  });
+
+  it("should union theme and layout custom font assets", () => {
+    const streamDocument: StreamDocument = {
+      __: {
+        theme: JSON.stringify({
+          "--fontFamily-h2-fontFamily":
+            "'Yext Custom', 'Yext Custom Fallback', serif",
+          __customFontAssets: {
+            stylesheetPaths: ["y-fonts/theme-font.css"],
+            preloads: ["/y-fonts/theme-font-bold.woff2"],
+          },
+        }),
+        layout: JSON.stringify({
+          root: {
+            props: {
+              __customFontAssets: {
+                stylesheetPaths: ["y-fonts/layout-font.css"],
+                preloads: [],
+              },
+            },
+          },
+          content: [],
+          zones: {},
+        }),
+      },
+    };
+
+    const result = applyTheme(streamDocument, "./", themeConfig);
+
+    expect(result).toContain(
+      '<link href="./y-fonts/theme-font.css" rel="stylesheet">'
+    );
+    expect(result).toContain(
+      '<link href="./y-fonts/layout-font.css" rel="stylesheet">'
+    );
+    expect(result).toContain(
+      '<link rel="preload" href="/y-fonts/theme-font-bold.woff2" as="font" type="font/woff2" crossorigin="anonymous">'
     );
   });
 
@@ -281,8 +356,7 @@ describe("buildCssOverridesStyle", () => {
       {
         "--colors-palette-primary": "#CF0A2C",
       },
-      themeConfig,
-      true
+      themeConfig
     );
 
     const styleTag = document.getElementById(THEME_STYLE_TAG_ID);
@@ -291,6 +365,79 @@ describe("buildCssOverridesStyle", () => {
     expect(styleTag?.textContent).toContain(
       "--colors-palette-primary:#CF0A2C !important"
     );
+  });
+
+  it("loads layout Google fonts when updating the editor preview", async () => {
+    const iframe = createPreviewIframe();
+
+    await updateThemeInEditor(
+      {
+        "--colors-palette-primary": "#CF0A2C",
+      },
+      themeConfig,
+      {},
+      {
+        root: { props: {} },
+        content: [
+          {
+            type: "Text",
+            props: {
+              typography: {
+                fontFamily: "'Adamina', 'Adamina Fallback', serif",
+              },
+            },
+          },
+        ],
+        zones: {},
+      }
+    );
+
+    expect(
+      document.head.querySelector('link[href*="family=Adamina"]')
+    ).not.toBeNull();
+    expect(
+      iframe.contentDocument?.head.querySelector('link[href*="family=Adamina"]')
+    ).not.toBeNull();
+  });
+
+  it("loads custom font stylesheets in the editor from theme data", async () => {
+    const iframe = createPreviewIframe();
+
+    await updateThemeInEditor(
+      {
+        "--fontFamily-body-fontFamily":
+          "'Chillax Variable', 'Chillax Variable Fallback', sans-serif",
+      },
+      themeConfig,
+      {
+        "Chillax Variable": {
+          fallback: "sans-serif",
+          italics: false,
+          facePath: "y-fonts/chillaxvariable.css",
+          minWeight: 200,
+          maxWeight: 700,
+          variants: [
+            {
+              style: "normal",
+              filePath: "y-fonts/chillaxvariable-bold.woff2",
+              minWeight: 200,
+              maxWeight: 700,
+            },
+          ],
+        },
+      }
+    );
+
+    expect(
+      document.head
+        .querySelector('link[href*="chillaxvariable.css"]')
+        ?.getAttribute("href")
+    ).toBe("/y-fonts/chillaxvariable.css");
+    expect(
+      iframe.contentDocument?.head
+        .querySelector('link[href*="chillaxvariable.css"]')
+        ?.getAttribute("href")
+    ).toBe("/y-fonts/chillaxvariable.css");
   });
 });
 

--- a/packages/visual-editor/src/utils/applyTheme.test.ts
+++ b/packages/visual-editor/src/utils/applyTheme.test.ts
@@ -181,7 +181,7 @@ describe("buildCssOverridesStyle", () => {
             props: {
               __customFontAssets: {
                 stylesheetPaths: ["y-fonts/layout-font.css"],
-                preloads: [],
+                preloads: ["/y-fonts/layout-font-regular.woff2"],
               },
             },
           },
@@ -201,6 +201,36 @@ describe("buildCssOverridesStyle", () => {
     );
     expect(result).toContain(
       '<link rel="preload" href="/y-fonts/theme-font-bold.woff2" as="font" type="font/woff2" crossorigin="anonymous">'
+    );
+    expect(result).toContain(
+      '<link rel="preload" href="/y-fonts/layout-font-regular.woff2" as="font" type="font/woff2" crossorigin="anonymous">'
+    );
+  });
+
+  it("should load theme default fonts when theme data is missing", () => {
+    const result = applyTheme(
+      {
+        siteId: 123,
+      } as StreamDocument,
+      "./",
+      {
+        body: {
+          label: "Body",
+          styles: {
+            fontFamily: {
+              label: "Font",
+              plugin: "fontFamily",
+              type: "select",
+              options: [],
+              default: "'Adamina', serif",
+            },
+          },
+        },
+      }
+    );
+
+    expect(result).toContain(
+      '<link href="https://fonts.googleapis.com/css2?family=Adamina:wght@400&display=swap" rel="stylesheet">'
     );
   });
 

--- a/packages/visual-editor/src/utils/applyTheme.ts
+++ b/packages/visual-editor/src/utils/applyTheme.ts
@@ -100,9 +100,7 @@ export const applyTheme = (
     layoutData?.root?.props?.[CUSTOM_FONT_ASSETS_KEY]
   );
 
-  const themeFonts = themeData
-    ? resolveFontsToLoad(themeData, themeConfig)
-    : { inUseGoogleFonts: {} };
+  const themeFonts = resolveFontsToLoad(themeData ?? {}, themeConfig);
 
   const layoutFonts = filterFontRegistries(
     extractFontFamiliesFromLayout(layoutData),
@@ -147,7 +145,12 @@ export const applyTheme = (
 
   if (Object.keys(themeConfig).length > 0) {
     const preloadTags = buildFontPreloadTags(
-      themeCustomFontAssets.preloads,
+      [
+        ...new Set([
+          ...themeCustomFontAssets.preloads,
+          ...layoutCustomFontAssets.preloads,
+        ]),
+      ],
       relativePrefixToRoot
     );
 

--- a/packages/visual-editor/src/utils/applyTheme.ts
+++ b/packages/visual-editor/src/utils/applyTheme.ts
@@ -250,7 +250,7 @@ export const updateThemeInEditor = async (
   newTheme: ThemeData,
   themeConfig: ThemeConfig,
   customFonts: FontRegistry = {},
-  layoutData?: unknown
+  layoutData?: Record<string, any>
 ) => {
   devLogger.logFunc("updateThemeInEditor");
   pendingObserver?.disconnect();

--- a/packages/visual-editor/src/utils/applyTheme.ts
+++ b/packages/visual-editor/src/utils/applyTheme.ts
@@ -1,3 +1,4 @@
+import { Data } from "@puckeditor/core";
 import { ThemeData } from "../internal/types/themeData.ts";
 import {
   internalThemeResolver,
@@ -6,17 +7,21 @@ import {
 import { DevLogger } from "./devLogger.ts";
 import {
   defaultFonts,
-  filterInUseFontRegistries,
+  filterFontRegistries,
   createFontLinkElements,
   generateGoogleFontLinkData,
   fontLinkDataToHTML,
   type FontRegistry,
   type FontLinkData,
   generateCustomFontLinkData,
+  extractFontFamiliesFromLayout,
+  extractFontFamiliesFromTheme,
 } from "./fonts/visualEditorFonts.ts";
 import {
   buildFontPreloadTags,
-  getCustomFontAssets,
+  CUSTOM_FONT_ASSETS_KEY,
+  readCustomFontAssets,
+  type CustomFontAssets,
 } from "../internal/utils/customFontAssets.ts";
 import { ThemeConfig } from "./themeResolver.ts";
 import { getContrastingColor } from "./colors.ts";
@@ -36,8 +41,8 @@ const resolveFontsToLoad = (
     ...generateCssVariablesFromThemeConfig(themeConfig),
     ...themeValues,
   };
-  const { inUseGoogleFonts, inUseCustomFonts } = filterInUseFontRegistries(
-    mergedThemeData,
+  const { inUseGoogleFonts, inUseCustomFonts } = filterFontRegistries(
+    extractFontFamiliesFromTheme(mergedThemeData),
     defaultFonts,
     customFonts
   );
@@ -61,64 +66,92 @@ export const applyTheme = (
   devLogger.logFunc("applyTheme");
 
   const publishedTheme = document?.__?.theme;
-
-  let overrides: ThemeData | undefined;
+  const publishedLayout = document?.__?.layout;
+  let themeData: ThemeData | undefined;
+  let layoutData:
+    | Data<any, { [CUSTOM_FONT_ASSETS_KEY]?: CustomFontAssets }>
+    | undefined;
 
   if (publishedTheme) {
     try {
-      overrides = JSON.parse(publishedTheme);
+      themeData = JSON.parse(publishedTheme);
 
-      devLogger.logData("THEME_DATA", overrides);
+      devLogger.logData("THEME_DATA", themeData);
     } catch (error) {
       console.warn("Failed to parse published theme data:", error);
     }
   }
 
-  // Load only fonts that are actually used in the theme
+  if (publishedLayout) {
+    try {
+      layoutData = JSON.parse(publishedLayout);
+    } catch (error) {
+      console.warn("Failed to parse published layout data:", error);
+    }
+  }
+
   let fontLinkData: FontLinkData[];
   const fallbackFontFaceDefinitions: string[] = [];
-  const customFontAssets = getCustomFontAssets(overrides);
-  if (!overrides) {
-    // No theme overrides, use only Open Sans (the default font)
-    fontLinkData = generateGoogleFontLinkData({
-      "Open Sans": defaultFonts["Open Sans"],
-    });
-  } else {
-    const { inUseGoogleFonts, googleFontsToLoad } = resolveFontsToLoad(
-      overrides,
-      themeConfig
-    );
 
-    fontLinkData = generateGoogleFontLinkData(googleFontsToLoad);
-    fontLinkData = [
-      ...generateCustomFontLinkData(
-        customFontAssets.stylesheetPaths,
-        relativePrefixToRoot
-      ),
-      ...fontLinkData,
-    ];
+  const themeCustomFontAssets = readCustomFontAssets(
+    themeData?.[CUSTOM_FONT_ASSETS_KEY]
+  );
+  const layoutCustomFontAssets = readCustomFontAssets(
+    layoutData?.root?.props?.[CUSTOM_FONT_ASSETS_KEY]
+  );
 
-    // For each in-use Google Font, look up the corresponding fallback fonts and add to the head
-    Object.keys(inUseGoogleFonts).forEach((fontFamily) => {
-      if (fontFamily in fontFallbackTransformations) {
-        fallbackFontFaceDefinitions.push(
-          (fontFallbackTransformations as Record<string, string[]>)[
-            fontFamily
-          ].join("\n")
-        );
-      }
-    });
-  }
+  const themeFonts = themeData
+    ? resolveFontsToLoad(themeData, themeConfig)
+    : { inUseGoogleFonts: {} };
+
+  const layoutFonts = filterFontRegistries(
+    extractFontFamiliesFromLayout(layoutData),
+    defaultFonts
+  );
+
+  const googleFontsToLoad =
+    Object.keys(themeFonts.inUseGoogleFonts).length > 0 ||
+    Object.keys(layoutFonts.inUseGoogleFonts).length > 0
+      ? {
+          ...themeFonts.inUseGoogleFonts,
+          ...layoutFonts.inUseGoogleFonts,
+        }
+      : { "Open Sans": defaultFonts["Open Sans"] };
+
+  fontLinkData = generateGoogleFontLinkData(googleFontsToLoad);
+  fontLinkData = [
+    ...generateCustomFontLinkData(
+      [
+        ...new Set([
+          ...themeCustomFontAssets.stylesheetPaths,
+          ...layoutCustomFontAssets.stylesheetPaths,
+        ]),
+      ],
+      relativePrefixToRoot
+    ),
+    ...fontLinkData,
+  ];
+
+  // For each in-use Google Font, look up the corresponding fallback fonts and add to the head
+  Object.keys(googleFontsToLoad).forEach((fontFamily) => {
+    if (fontFamily in fontFallbackTransformations) {
+      fallbackFontFaceDefinitions.push(
+        (fontFallbackTransformations as Record<string, string[]>)[
+          fontFamily
+        ].join("\n")
+      );
+    }
+  });
 
   const fontLinkTags = fontLinkDataToHTML(fontLinkData);
 
   if (Object.keys(themeConfig).length > 0) {
     const preloadTags = buildFontPreloadTags(
-      customFontAssets.preloads,
+      themeCustomFontAssets.preloads,
       relativePrefixToRoot
     );
 
-    return `${base ?? ""}${preloadTags}${fontLinkTags}<style type="text/css">${fallbackFontFaceDefinitions.join("\n")}</style><style id="${THEME_STYLE_TAG_ID}" type="text/css">${internalApplyTheme(overrides ?? {}, themeConfig)}</style>`;
+    return `${base ?? ""}${preloadTags}${fontLinkTags}<style type="text/css">${fallbackFontFaceDefinitions.join("\n")}</style><style id="${THEME_STYLE_TAG_ID}" type="text/css">${internalApplyTheme(themeData ?? {}, themeConfig)}</style>`;
   }
   return base ?? "";
 };
@@ -187,7 +220,7 @@ const updateFontLinksInDocument = (
   existingLinks.forEach((link) => link.remove());
 
   if (Object.keys(fonts).length + Object.keys(customFonts).length > 0) {
-    const links = createFontLinkElements(fonts, customFonts);
+    const links = createFontLinkElements(document, fonts, customFonts);
     links.forEach((link) => {
       document.head.appendChild(link);
     });
@@ -213,52 +246,73 @@ let pendingObserver: MutationObserver | null = null;
 export const updateThemeInEditor = async (
   newTheme: ThemeData,
   themeConfig: ThemeConfig,
-  isThemeMode: boolean,
-  customFonts: FontRegistry = {}
+  customFonts: FontRegistry = {},
+  layoutData?: unknown
 ) => {
   devLogger.logFunc("updateThemeInEditor");
   pendingObserver?.disconnect();
 
-  const { inUseCustomFonts, googleFontsToLoad } = resolveFontsToLoad(
-    newTheme,
-    themeConfig,
+  const themeFonts = resolveFontsToLoad(newTheme, themeConfig, customFonts);
+  const layoutFonts = filterFontRegistries(
+    extractFontFamiliesFromLayout(layoutData),
+    defaultFonts,
     customFonts
   );
 
+  const googleFontsToLoad =
+    Object.keys(themeFonts.inUseGoogleFonts).length > 0 ||
+    Object.keys(layoutFonts.inUseGoogleFonts).length > 0
+      ? {
+          ...themeFonts.inUseGoogleFonts,
+          ...layoutFonts.inUseGoogleFonts,
+        }
+      : themeFonts.googleFontsToLoad;
+  const customFontsToLoad = {
+    ...themeFonts.inUseCustomFonts,
+    ...layoutFonts.inUseCustomFonts,
+  };
+
   const newThemeTag = internalApplyTheme(newTheme, themeConfig);
   getOrCreateThemeStyleTag(window.document).textContent = newThemeTag;
+  updateFontLinksInDocument(
+    window.document,
+    googleFontsToLoad,
+    customFontsToLoad
+  );
 
-  // In the theme editor, all fonts are already loaded
-  // In the layout editor, we need to load the in-use fonts after the Puck iframe has loaded
-  if (!isThemeMode) {
+  const syncIframeTheme = () => {
+    const iframe = document.getElementById(
+      PUCK_PREVIEW_IFRAME_ID
+    ) as HTMLIFrameElement;
+    const iframeDocument = iframe?.contentDocument;
+    if (!iframeDocument) {
+      return false;
+    }
+
+    getOrCreateThemeStyleTag(iframeDocument).textContent = newThemeTag;
     updateFontLinksInDocument(
-      window.document,
+      iframeDocument,
       googleFontsToLoad,
-      inUseCustomFonts
+      customFontsToLoad
     );
+    return true;
+  };
 
-    const observer = new MutationObserver(() => {
-      const iframe = document.getElementById(
-        PUCK_PREVIEW_IFRAME_ID
-      ) as HTMLIFrameElement;
-      const iframeDocument = iframe?.contentDocument;
-      if (iframeDocument) {
-        observer.disconnect();
-        pendingObserver = null;
-
-        getOrCreateThemeStyleTag(iframeDocument).textContent = newThemeTag;
-        updateFontLinksInDocument(
-          iframeDocument,
-          googleFontsToLoad,
-          inUseCustomFonts
-        );
-      }
-    });
-
-    pendingObserver = observer;
-    observer.observe(document, {
-      childList: true,
-      subtree: true,
-    });
+  if (syncIframeTheme()) {
+    pendingObserver = null;
+    return;
   }
+
+  const observer = new MutationObserver(() => {
+    if (syncIframeTheme()) {
+      observer.disconnect();
+      pendingObserver = null;
+    }
+  });
+
+  pendingObserver = observer;
+  observer.observe(document, {
+    childList: true,
+    subtree: true,
+  });
 };

--- a/packages/visual-editor/src/utils/fonts/visualEditorFonts.test.ts
+++ b/packages/visual-editor/src/utils/fonts/visualEditorFonts.test.ts
@@ -2,16 +2,19 @@ import { describe, it, expect } from "vitest";
 import { ThemeData } from "../../internal/types/themeData.ts";
 import {
   constructFontSelectOptions,
-  filterInUseFontRegistries,
+  extractFontFamiliesFromTheme,
+  filterFontRegistries,
   type FontRegistry,
   defaultFonts,
   constructGoogleFontLinkTags,
+  extractFontFamiliesFromLayout,
   generateCustomFontLinkData,
   getFacePathsFromFonts,
   getFontStyleOptions,
+  createFontLinkElements,
 } from "./visualEditorFonts.ts";
 
-describe("filterInUseFontRegistries", () => {
+describe("filterFontRegistries", () => {
   it("returns the specifications for all built-in fonts used in the theme", () => {
     const themeData: ThemeData = {
       "--fontFamily-h1-fontFamily": "'Oi', sans-serif",
@@ -31,8 +34,8 @@ describe("filterInUseFontRegistries", () => {
       },
     };
 
-    const { inUseGoogleFonts, inUseCustomFonts } = filterInUseFontRegistries(
-      themeData,
+    const { inUseGoogleFonts, inUseCustomFonts } = filterFontRegistries(
+      extractFontFamiliesFromTheme(themeData),
       defaultFonts
     );
     expect(inUseGoogleFonts).toEqual(expected);
@@ -40,7 +43,7 @@ describe("filterInUseFontRegistries", () => {
   });
 
   it("returns empty registries when theme data is empty", () => {
-    expect(filterInUseFontRegistries({}, defaultFonts)).toEqual({
+    expect(filterFontRegistries([], defaultFonts)).toEqual({
       inUseGoogleFonts: {},
       inUseCustomFonts: {},
     });
@@ -52,8 +55,8 @@ describe("filterInUseFontRegistries", () => {
       "--fontSize-h1-fontSize": "48px",
     };
 
-    const { inUseGoogleFonts, inUseCustomFonts } = filterInUseFontRegistries(
-      themeData,
+    const { inUseGoogleFonts, inUseCustomFonts } = filterFontRegistries(
+      extractFontFamiliesFromTheme(themeData),
       defaultFonts
     );
     expect(inUseGoogleFonts).toEqual({});
@@ -65,8 +68,8 @@ describe("filterInUseFontRegistries", () => {
       "--fontFamily-h1-fontFamily": "'Open Sans', sans-serif",
     };
 
-    const { inUseGoogleFonts, inUseCustomFonts } = filterInUseFontRegistries(
-      themeData,
+    const { inUseGoogleFonts, inUseCustomFonts } = filterFontRegistries(
+      extractFontFamiliesFromTheme(themeData),
       {}
     );
     expect(inUseGoogleFonts).toEqual({});
@@ -80,8 +83,8 @@ describe("filterInUseFontRegistries", () => {
       "--fontFamily-button-fontFamily": "'Adamina', serif",
     };
 
-    const { inUseGoogleFonts, inUseCustomFonts } = filterInUseFontRegistries(
-      themeData,
+    const { inUseGoogleFonts, inUseCustomFonts } = filterFontRegistries(
+      extractFontFamiliesFromTheme(themeData),
       defaultFonts
     );
     expect(inUseGoogleFonts).toEqual({
@@ -101,8 +104,8 @@ describe("filterInUseFontRegistries", () => {
       "--fontFamily-body-fontFamily": "'Open Sans', sans-serif",
     };
 
-    const { inUseGoogleFonts, inUseCustomFonts } = filterInUseFontRegistries(
-      themeData,
+    const { inUseGoogleFonts, inUseCustomFonts } = filterFontRegistries(
+      extractFontFamiliesFromTheme(themeData),
       defaultFonts
     );
     expect(inUseGoogleFonts).toEqual({
@@ -131,8 +134,8 @@ describe("filterInUseFontRegistries", () => {
       },
     };
 
-    const { inUseGoogleFonts, inUseCustomFonts } = filterInUseFontRegistries(
-      themeData,
+    const { inUseGoogleFonts, inUseCustomFonts } = filterFontRegistries(
+      extractFontFamiliesFromTheme(themeData),
       defaultFonts,
       customFonts
     );
@@ -153,8 +156,8 @@ describe("filterInUseFontRegistries", () => {
       "--fontFamily-h1-fontFamily": "var(--fontFamily-headers-defaultFont)",
     };
 
-    const { inUseGoogleFonts, inUseCustomFonts } = filterInUseFontRegistries(
-      themeData,
+    const { inUseGoogleFonts, inUseCustomFonts } = filterFontRegistries(
+      extractFontFamiliesFromTheme(themeData),
       defaultFonts
     );
     expect(inUseGoogleFonts).toEqual({
@@ -170,6 +173,34 @@ describe("filterInUseFontRegistries", () => {
 });
 
 describe("custom font helpers", () => {
+  it("extracts font families from layout fontFamily fields", () => {
+    expect(
+      extractFontFamiliesFromLayout({
+        root: {
+          props: {
+            fontFamily: "default",
+          },
+        },
+        content: [
+          {
+            props: {
+              typography: {
+                fontFamily: "'Adamina', 'Adamina Fallback', serif",
+              },
+            },
+          },
+          {
+            props: {
+              styles: {
+                fontFamily: "'Open Sans', sans-serif",
+              },
+            },
+          },
+        ],
+      })
+    ).toEqual(["Adamina", "Open Sans"]);
+  });
+
   it("builds font select options from family names", () => {
     const customFonts: FontRegistry = {
       EBB_Melvyn_Regular: {
@@ -233,6 +264,27 @@ describe("custom font helpers", () => {
         rel: "stylesheet",
       },
     ]);
+  });
+
+  it("creates editor custom font links with root-relative hrefs by default", () => {
+    const [customFontLink] = createFontLinkElements(
+      document,
+      {},
+      {
+        "Chillax Variable": {
+          italics: false,
+          minWeight: 200,
+          maxWeight: 700,
+          fallback: "sans-serif",
+          facePath: "y-fonts/chillaxvariable.css",
+          variants: [],
+        },
+      }
+    );
+
+    expect(customFontLink?.getAttribute("href")).toBe(
+      "/y-fonts/chillaxvariable.css"
+    );
   });
 });
 

--- a/packages/visual-editor/src/utils/fonts/visualEditorFonts.ts
+++ b/packages/visual-editor/src/utils/fonts/visualEditorFonts.ts
@@ -201,7 +201,6 @@ export const createFontLinkElements = (
  * to avoid appending duplicate font tags across rerenders.
  */
 export const loadFontsIntoDOM = (
-  document: Document,
   googleFonts: FontRegistry,
   customFonts: FontRegistry,
   idPrefix: string = "visual-editor-fonts"
@@ -528,10 +527,12 @@ export const extractFontFamiliesFromTheme = (data: ThemeData): string[] => {
 /**
  * Extracts and parses the font family names from the LayoutData.
  */
-export const extractFontFamiliesFromLayout = (data: unknown): string[] => {
+export const extractFontFamiliesFromLayout = (
+  data: Record<string, any> | undefined
+): string[] => {
   const fontFamilies = new Set<string>();
 
-  const visit = (value: unknown) => {
+  const visit = (value: Record<string, any> | undefined) => {
     if (!value || typeof value !== "object") {
       return;
     }

--- a/packages/visual-editor/src/utils/fonts/visualEditorFonts.ts
+++ b/packages/visual-editor/src/utils/fonts/visualEditorFonts.ts
@@ -175,13 +175,14 @@ export const googleFontLinkTags = fontLinkDataToHTML(
  * they can be appended directly into a document.
  */
 export const createFontLinkElements = (
+  document: Document,
   googleFonts: FontRegistry,
   customFonts: FontRegistry
 ): HTMLLinkElement[] => {
   const googleFontLinkData = generateGoogleFontLinkData(googleFonts);
   const customFontLinkData = generateCustomFontLinkData(
     getFacePathsFromFonts(customFonts),
-    "./"
+    "/"
   );
 
   return [...customFontLinkData, ...googleFontLinkData].map((link) => {
@@ -206,7 +207,7 @@ export const loadFontsIntoDOM = (
   idPrefix: string = "visual-editor-fonts"
 ) => {
   if (!document.getElementById(`${idPrefix}-0`)) {
-    const links = createFontLinkElements(googleFonts, customFonts);
+    const links = createFontLinkElements(document, googleFonts, customFonts);
 
     links.forEach((link, index) => {
       link.id = `${idPrefix}-${index}`;
@@ -525,17 +526,43 @@ export const extractFontFamiliesFromTheme = (data: ThemeData): string[] => {
 };
 
 /**
- * Filters the available fonts and custom fonts to only include those actually referenced by the theme.
- * Custom fonts are optional. If provided, the filtered custom fonts are returned.
- *
- * @param data the ThemeData
- * @param availableFonts built-in Google fonts from the repository
- * @param customFonts custom fonts from FontAPIServer
- * @return An object containing two font registries: inUseGoogleFonts and inUseCustomFonts.
+ * Extracts and parses the font family names from the LayoutData.
  */
-export const filterInUseFontRegistries = (
-  data: ThemeData,
-  availableFonts: FontRegistry,
+export const extractFontFamiliesFromLayout = (data: unknown): string[] => {
+  const fontFamilies = new Set<string>();
+
+  const visit = (value: unknown) => {
+    if (!value || typeof value !== "object") {
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      value.forEach(visit);
+      return;
+    }
+
+    Object.entries(value).forEach(([key, nestedValue]) => {
+      if (
+        key === "fontFamily" &&
+        typeof nestedValue === "string" &&
+        nestedValue.length > 0 &&
+        nestedValue !== "default"
+      ) {
+        fontFamilies.add(extractFontFamilyName(nestedValue));
+      }
+
+      visit(nestedValue);
+    });
+  };
+
+  visit(data);
+
+  return [...fontFamilies];
+};
+
+export const filterFontRegistries = (
+  fontFamilies: string[],
+  googleFonts: FontRegistry,
   customFonts: FontRegistry = {}
 ): {
   inUseGoogleFonts: FontRegistry;
@@ -544,9 +571,8 @@ export const filterInUseFontRegistries = (
   const inUseGoogleFonts: FontRegistry = {};
   const inUseCustomFonts: FontRegistry = {};
 
-  // For each unique font family found, look it up in the availableFonts map.
-  for (const fontName of extractFontFamiliesFromTheme(data)) {
-    const font = availableFonts[fontName];
+  for (const fontName of fontFamilies) {
+    const font = googleFonts[fontName];
     if (font) {
       inUseGoogleFonts[fontName] = font;
       continue;


### PR DESCRIPTION
Our templates have font selectors in the layout editor, however this has some issues:
1. On the live page, we only load the fonts that are published in the theme (not the layout)
2. In the platform editor, only the published fonts load, so the font dropdown is unstyled
3. In the local editor, no fonts load, so you cannot test this locally

This PR addresses these issues by
1. When running applyTheme, recursively scanning the layoutData for `fontFamily` and injecting any fonts found (in addition to fonts published in the theme
2. Loading all the fonts whenever the FontSelector is mounted, regardless of whether the editor is platform/local, layout/theme

Tested by generating a template artifact with a custom pack. Confirmed the fonts loaded as expected in the editors and live page. https://qa.yext.com/s/4116399/yextsites/273779/pagesets

