### PR TITLE
fix: infer image, cta, and rtf types in local-editor

### DIFF
--- a/packages/visual-editor/src/vite-plugin/local-editor/data.ts
+++ b/packages/visual-editor/src/vite-plugin/local-editor/data.ts
@@ -112,16 +112,23 @@ export const getLocalEditorDocument = async (
     selectedDocumentEntry.filePath,
     `local editor snapshot ${selectedDocumentEntry.fileName}`
   );
-  // Read all of the template documents to find fields that may be missing in any single entity
+  // Read all of the template documents to find fields that may be missing in
+  // any single entity, but keep going if a sibling snapshot is malformed.
   const templateDocuments = context.documents
     .filter((documentEntry) => {
       return documentEntry.templateId === selectedDocumentEntry.templateId;
     })
-    .map((documentEntry) => {
-      return readJsonFile<Record<string, unknown>>(
-        documentEntry.filePath,
-        `local editor snapshot ${documentEntry.fileName}`
-      );
+    .flatMap((documentEntry) => {
+      try {
+        return [
+          readJsonFile<Record<string, unknown>>(
+            documentEntry.filePath,
+            `local editor snapshot ${documentEntry.fileName}`
+          ),
+        ];
+      } catch {
+        return [];
+      }
     });
   const entityFields = inferEntityFields(
     templateDocuments,

--- a/packages/visual-editor/src/vite-plugin/local-editor/data.ts
+++ b/packages/visual-editor/src/vite-plugin/local-editor/data.ts
@@ -112,8 +112,19 @@ export const getLocalEditorDocument = async (
     selectedDocumentEntry.filePath,
     `local editor snapshot ${selectedDocumentEntry.fileName}`
   );
+  // Read all of the template documents to find fields that may be missing in any single entity
+  const templateDocuments = context.documents
+    .filter((documentEntry) => {
+      return documentEntry.templateId === selectedDocumentEntry.templateId;
+    })
+    .map((documentEntry) => {
+      return readJsonFile<Record<string, unknown>>(
+        documentEntry.filePath,
+        `local editor snapshot ${documentEntry.fileName}`
+      );
+    });
   const entityFields = inferEntityFields(
-    document,
+    templateDocuments,
     context.templateStreams[selectedDocumentEntry.templateId]
   );
 

--- a/packages/visual-editor/src/vite-plugin/local-editor/entityFields.test.ts
+++ b/packages/visual-editor/src/vite-plugin/local-editor/entityFields.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { inferEntityFields } from "./entityFields.ts";
+
+describe("inferEntityFields", () => {
+  it("recognizes structured local-editor rich text, CTA, and image values", () => {
+    const inferred = inferEntityFields({
+      description: {
+        json: {
+          root: {
+            children: [],
+          },
+        },
+      },
+      cta: {
+        label: "Order",
+        link: "/order",
+        linkType: "OTHER",
+      },
+      image: {
+        url: "https://example.com/image.jpg",
+        width: 1200,
+        height: 800,
+        alternateText: "Example",
+      },
+    });
+
+    expect(inferred.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "description",
+          definition: expect.objectContaining({
+            typeRegistryId: "type.rich_text_v2",
+          }),
+        }),
+        expect.objectContaining({
+          name: "cta",
+          definition: expect.objectContaining({
+            typeRegistryId: "type.cta",
+          }),
+        }),
+        expect.objectContaining({
+          name: "image",
+          definition: expect.objectContaining({
+            typeRegistryId: "type.image",
+          }),
+        }),
+      ])
+    );
+  });
+
+  it("recognizes ComplexImage-shaped values as type.image", () => {
+    const inferred = inferEntityFields({
+      heroImage: {
+        image: {
+          url: "https://example.com/hero.jpg",
+          width: 1440,
+          height: 900,
+          alternateText: "Hero",
+        },
+      },
+    });
+
+    expect(inferred.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "heroImage",
+          definition: expect.objectContaining({
+            typeRegistryId: "type.image",
+          }),
+        }),
+      ])
+    );
+  });
+
+  it("merges inferred schema across multiple local snapshots", () => {
+    const inferred = inferEntityFields([
+      {
+        c_featuredProducts: {
+          products: [
+            {
+              name: "Latte",
+              description: {
+                json: {
+                  root: {
+                    children: [],
+                  },
+                },
+              },
+              cta: {
+                label: "Order",
+                link: "/order",
+                linkType: "OTHER",
+              },
+            },
+          ],
+        },
+      },
+      {
+        c_featuredProducts: {
+          products: [
+            {
+              name: "Espresso",
+              image: {
+                url: "https://example.com/product.jpg",
+                width: 1200,
+                height: 800,
+              },
+            },
+          ],
+        },
+      },
+    ]);
+
+    const featuredProductsField = inferred.fields.find(
+      (field) => field.name === "c_featuredProducts"
+    );
+    const productsField = featuredProductsField?.children?.fields.find(
+      (field) => field.name === "products"
+    );
+    const productChildren = productsField?.children?.fields ?? [];
+
+    expect(productsField?.definition.isList).toBe(true);
+    expect(productChildren).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "name",
+          definition: expect.objectContaining({
+            typeRegistryId: "type.string",
+          }),
+        }),
+        expect.objectContaining({
+          name: "description",
+          definition: expect.objectContaining({
+            typeRegistryId: "type.rich_text_v2",
+          }),
+        }),
+        expect.objectContaining({
+          name: "cta",
+          definition: expect.objectContaining({
+            typeRegistryId: "type.cta",
+          }),
+        }),
+        expect.objectContaining({
+          name: "image",
+          definition: expect.objectContaining({
+            typeRegistryId: "type.image",
+          }),
+        }),
+      ])
+    );
+  });
+});

--- a/packages/visual-editor/src/vite-plugin/local-editor/entityFields.test.ts
+++ b/packages/visual-editor/src/vite-plugin/local-editor/entityFields.test.ts
@@ -73,6 +73,27 @@ describe("inferEntityFields", () => {
     );
   });
 
+  it("does not classify unrelated json-shaped objects as rich text", () => {
+    const inferred = inferEntityFields({
+      analyticsPayload: {
+        json: {
+          foo: "bar",
+        },
+      },
+    });
+
+    expect(inferred.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "analyticsPayload",
+          definition: expect.objectContaining({
+            typeRegistryId: "type.object",
+          }),
+        }),
+      ])
+    );
+  });
+
   it("merges inferred schema across multiple local snapshots", () => {
     const inferred = inferEntityFields([
       {
@@ -146,6 +167,32 @@ describe("inferEntityFields", () => {
           definition: expect.objectContaining({
             typeRegistryId: "type.image",
           }),
+        }),
+      ])
+    );
+  });
+
+  it("strips c_ from each path segment when building display names", () => {
+    const inferred = inferEntityFields({
+      c_parentField: {
+        c_childField: "value",
+      },
+    });
+
+    expect(inferred.displayNames).toEqual({});
+    expect(inferred.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "c_parentField",
+          displayName: "Parent Field",
+          children: {
+            fields: [
+              expect.objectContaining({
+                name: "c_childField",
+                displayName: "Parent Field > Child Field",
+              }),
+            ],
+          },
         }),
       ])
     );

--- a/packages/visual-editor/src/vite-plugin/local-editor/entityFields.test.ts
+++ b/packages/visual-editor/src/vite-plugin/local-editor/entityFields.test.ts
@@ -6,11 +6,7 @@ describe("inferEntityFields", () => {
   it("recognizes structured local-editor rich text, CTA, and image values", () => {
     const inferred = inferEntityFields({
       description: {
-        json: {
-          root: {
-            children: [],
-          },
-        },
+        html: "",
       },
       cta: {
         label: "Order",
@@ -102,11 +98,7 @@ describe("inferEntityFields", () => {
             {
               name: "Latte",
               description: {
-                json: {
-                  root: {
-                    children: [],
-                  },
-                },
+                html: "",
               },
               cta: {
                 label: "Order",

--- a/packages/visual-editor/src/vite-plugin/local-editor/entityFields.ts
+++ b/packages/visual-editor/src/vite-plugin/local-editor/entityFields.ts
@@ -18,7 +18,7 @@ type MutableFieldNode = {
  * data.
  */
 export const inferEntityFields = (
-  document: Record<string, unknown>,
+  document: Record<string, unknown> | Record<string, unknown>[],
   stream?: LocalEditorStreamDefinition
 ): {
   fields: YextSchemaField[];
@@ -27,12 +27,14 @@ export const inferEntityFields = (
   const configuredDisplayNames = buildConfiguredDisplayNames(stream);
   const rootNodes = new Map<string, MutableFieldNode>();
 
-  for (const [key, value] of Object.entries(document)) {
-    if (shouldSkipField(key)) {
-      continue;
-    }
+  for (const documentEntry of Array.isArray(document) ? document : [document]) {
+    for (const [key, value] of Object.entries(documentEntry)) {
+      if (shouldSkipField(key)) {
+        continue;
+      }
 
-    mergeFieldNode(rootNodes, inferFieldNode(key, value));
+      mergeFieldNode(rootNodes, inferFieldNode(key, value));
+    }
   }
 
   const fields = Array.from(rootNodes.values())
@@ -82,6 +84,15 @@ const inferFieldNode = (name: string, value: unknown): MutableFieldNode => {
   }
 
   if (isPlainObject(value)) {
+    const inferredStructuredType = inferStructuredObjectType(value);
+    if (inferredStructuredType) {
+      return {
+        name,
+        typeRegistryId: inferredStructuredType,
+        children: new Map(),
+      };
+    }
+
     return {
       name,
       typeRegistryId: "type.object",
@@ -189,6 +200,51 @@ const shouldSkipField = (fieldName: string): boolean => {
   return fieldName.startsWith("_");
 };
 
+const inferStructuredObjectType = (
+  value: Record<string, unknown>
+): string | undefined => {
+  if (isRichTextValue(value)) {
+    return "type.rich_text_v2";
+  }
+  if (isImageValue(value)) {
+    return "type.image";
+  }
+  if (isCtaValue(value)) {
+    return "type.cta";
+  }
+  return undefined;
+};
+
+const isRichTextValue = (value: Record<string, unknown>): boolean => {
+  return (
+    ("json" in value &&
+      (typeof value.json === "string" || isPlainObject(value.json))) ||
+    ("html" in value && typeof value.html === "string")
+  );
+};
+
+const isImageValue = (value: Record<string, unknown>): boolean => {
+  const nestedImage = value.image;
+  if (isPlainObject(nestedImage) && isImageValue(nestedImage)) {
+    return true;
+  }
+
+  return (
+    typeof value.url === "string" &&
+    (typeof value.alternateText === "string" ||
+      typeof value.width === "number" ||
+      typeof value.height === "number")
+  );
+};
+
+const isCtaValue = (value: Record<string, unknown>): boolean => {
+  return (
+    typeof value.label === "string" &&
+    typeof value.link === "string" &&
+    typeof value.linkType === "string"
+  );
+};
+
 const inferScalarType = (value: unknown): string => {
   if (typeof value === "boolean") {
     return "type.boolean";
@@ -220,6 +276,7 @@ const pickPreferredType = (
 
 const toDisplayName = (pathName: string): string => {
   return pathName
+    .replace("c_", "")
     .split(".")
     .map((segment) => {
       return segment

--- a/packages/visual-editor/src/vite-plugin/local-editor/entityFields.ts
+++ b/packages/visual-editor/src/vite-plugin/local-editor/entityFields.ts
@@ -216,11 +216,29 @@ const inferStructuredObjectType = (
 };
 
 const isRichTextValue = (value: Record<string, unknown>): boolean => {
-  return (
-    ("json" in value &&
-      (typeof value.json === "string" || isPlainObject(value.json))) ||
-    ("html" in value && typeof value.html === "string")
-  );
+  if ("html" in value && typeof value.html === "string") {
+    return true;
+  }
+
+  if (!("json" in value)) {
+    return false;
+  }
+
+  const { json } = value;
+  if (isPlainObject(json)) {
+    return isPlainObject(json.root);
+  }
+
+  if (typeof json !== "string") {
+    return false;
+  }
+
+  try {
+    const parsedJson = JSON.parse(json);
+    return isPlainObject(parsedJson) && isPlainObject(parsedJson.root);
+  } catch {
+    return false;
+  }
 };
 
 const isImageValue = (value: Record<string, unknown>): boolean => {
@@ -276,10 +294,10 @@ const pickPreferredType = (
 
 const toDisplayName = (pathName: string): string => {
   return pathName
-    .replace("c_", "")
     .split(".")
     .map((segment) => {
       return segment
+        .replace(/^c_/, "")
         .replace(/[_-]+/g, " ")
         .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
         .replace(/\b\w/g, (character) => character.toUpperCase());

--- a/packages/visual-editor/src/vite-plugin/local-editor/entityFields.ts
+++ b/packages/visual-editor/src/vite-plugin/local-editor/entityFields.ts
@@ -232,8 +232,7 @@ const isImageValue = (value: Record<string, unknown>): boolean => {
 
 const isCtaValue = (value: Record<string, unknown>): boolean => {
   return (
-    typeof value.label === "string" &&
-    typeof value.link === "string" &&
+    (typeof value.label === "string" || typeof value.link === "string") &&
     typeof value.linkType === "string"
   );
 };

--- a/packages/visual-editor/src/vite-plugin/local-editor/entityFields.ts
+++ b/packages/visual-editor/src/vite-plugin/local-editor/entityFields.ts
@@ -231,7 +231,11 @@ const isImageValue = (value: Record<string, unknown>): boolean => {
 };
 
 const isCtaValue = (value: Record<string, unknown>): boolean => {
-  return typeof value.label === "string" && typeof value.link === "string";
+  return (
+    typeof value.label === "string" &&
+    typeof value.link === "string" &&
+    typeof value.linkType === "string"
+  );
 };
 
 const inferScalarType = (value: unknown): string => {

--- a/packages/visual-editor/src/vite-plugin/local-editor/entityFields.ts
+++ b/packages/visual-editor/src/vite-plugin/local-editor/entityFields.ts
@@ -1,4 +1,5 @@
 import type { YextSchemaField } from "../../types/entityFields.ts";
+import { isRichText } from "../../utils/plainText.ts";
 import type { LocalEditorStreamDefinition } from "./types.ts";
 import { isPlainObject } from "./utils.ts";
 
@@ -203,7 +204,7 @@ const shouldSkipField = (fieldName: string): boolean => {
 const inferStructuredObjectType = (
   value: Record<string, unknown>
 ): string | undefined => {
-  if (isRichTextValue(value)) {
+  if (isRichText(value)) {
     return "type.rich_text_v2";
   }
   if (isImageValue(value)) {
@@ -213,32 +214,6 @@ const inferStructuredObjectType = (
     return "type.cta";
   }
   return undefined;
-};
-
-const isRichTextValue = (value: Record<string, unknown>): boolean => {
-  if ("html" in value && typeof value.html === "string") {
-    return true;
-  }
-
-  if (!("json" in value)) {
-    return false;
-  }
-
-  const { json } = value;
-  if (isPlainObject(json)) {
-    return isPlainObject(json.root);
-  }
-
-  if (typeof json !== "string") {
-    return false;
-  }
-
-  try {
-    const parsedJson = JSON.parse(json);
-    return isPlainObject(parsedJson) && isPlainObject(parsedJson.root);
-  } catch {
-    return false;
-  }
 };
 
 const isImageValue = (value: Record<string, unknown>): boolean => {

--- a/packages/visual-editor/src/vite-plugin/local-editor/entityFields.ts
+++ b/packages/visual-editor/src/vite-plugin/local-editor/entityFields.ts
@@ -256,11 +256,7 @@ const isImageValue = (value: Record<string, unknown>): boolean => {
 };
 
 const isCtaValue = (value: Record<string, unknown>): boolean => {
-  return (
-    typeof value.label === "string" &&
-    typeof value.link === "string" &&
-    typeof value.linkType === "string"
-  );
+  return typeof value.label === "string" && typeof value.link === "string";
 };
 
 const inferScalarType = (value: unknown): string => {


### PR DESCRIPTION
We infer the types of entity document fields in the local-editor, but RTF, Image, and CTA fields were just being picked up as generic objects. This means that they wouldn't show up in the correct dropdowns (particularly for createItemSource). This checks for their subfields and narrows the type if there's a match.

Also removes the `c_` prefix when generating the display name.