### PR TITLE
fix: comprehensiveCta in resolveItemValue

### DIFF
--- a/packages/visual-editor/src/utils/itemSource/createItemSource.test.ts
+++ b/packages/visual-editor/src/utils/itemSource/createItemSource.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  type EnhancedTranslatableCTA,
   type TranslatableRichText,
   type TranslatableString,
 } from "../../types/types.ts";
@@ -45,6 +46,49 @@ const articleSource = createItemSource<ArticleItemProps>({
       type: "entityField",
       label: "Secondary Title",
       filter: { types: ["type.string"] },
+    },
+  },
+});
+
+type CTAItemProps = {
+  title: {
+    field: string;
+    constantValueEnabled?: boolean;
+    constantValue: TranslatableString;
+  };
+  cta: {
+    data: {
+      actionType: "link" | "button";
+      cta: {
+        field: string;
+        constantValueEnabled?: boolean;
+        constantValue?: EnhancedTranslatableCTA;
+        selectedType?: "textAndLink" | "getDirections" | "presetImage";
+      };
+      openInNewTab: boolean;
+      buttonText?: TranslatableString;
+      customId?: string;
+      customClass?: string;
+      dataAttributes?: Array<{ key: string; value: string }>;
+      ariaLabel?: TranslatableString;
+    };
+    styles: {
+      variant: string;
+    };
+  };
+};
+
+const ctaSource = createItemSource<CTAItemProps>({
+  label: "CTA Items",
+  mappingFields: {
+    title: {
+      type: "entityField",
+      label: "Title",
+      filter: { types: ["type.string"] },
+    },
+    cta: {
+      type: "comprehensiveCTA",
+      label: "CTA",
     },
   },
 });
@@ -398,6 +442,103 @@ describe("createItemSource", () => {
         description: { defaultValue: { html: "<p>Manual summary</p>" } },
         eyebrow: "Manual",
         secondaryTitle: "Root fallback",
+      },
+    ]);
+  });
+
+  it("resolves comprehensive CTA mappings against the current linked item", () => {
+    const resolved = ctaSource.resolveItems(
+      {
+        field: "c_items",
+        constantValueEnabled: false,
+        constantValue: [],
+        mappings: {
+          title: {
+            field: "name",
+            constantValueEnabled: false,
+            constantValue: { defaultValue: "" },
+          },
+          cta: {
+            data: {
+              actionType: "link",
+              cta: {
+                field: "cta",
+                constantValue: {
+                  ctaType: "textAndLink",
+                  label: "Call to Action",
+                  link: "#",
+                  linkType: "URL",
+                },
+                selectedType: "textAndLink",
+              },
+              openInNewTab: false,
+              buttonText: {
+                defaultValue: "Button",
+              },
+              customId: "",
+              customClass: "",
+              dataAttributes: [],
+              ariaLabel: {
+                defaultValue: "Button",
+              },
+            },
+            styles: {
+              variant: "primary",
+            },
+          },
+        },
+      },
+      {
+        locale: "en",
+        cta: {
+          label: { defaultValue: "Root CTA" },
+          link: { defaultValue: "/root" },
+          linkType: "URL",
+        },
+        c_items: [
+          {
+            name: "Item one",
+            cta: {
+              label: { defaultValue: "Item CTA" },
+              link: { defaultValue: "/order" },
+              linkType: "OTHER",
+            },
+          },
+        ],
+      }
+    );
+
+    expect(resolved).toEqual([
+      {
+        title: "Item one",
+        cta: {
+          data: {
+            actionType: "link",
+            cta: {
+              field: "",
+              constantValueEnabled: true,
+              constantValue: {
+                label: { defaultValue: "Item CTA" },
+                link: { defaultValue: "/order" },
+                linkType: "OTHER",
+              },
+              selectedType: "textAndLink",
+            },
+            openInNewTab: false,
+            buttonText: {
+              defaultValue: "Button",
+            },
+            customId: "",
+            customClass: "",
+            dataAttributes: [],
+            ariaLabel: {
+              defaultValue: "Button",
+            },
+          },
+          styles: {
+            variant: "primary",
+          },
+        },
       },
     ]);
   });

--- a/packages/visual-editor/src/utils/itemSource/itemSourceResolution.ts
+++ b/packages/visual-editor/src/utils/itemSource/itemSourceResolution.ts
@@ -1,9 +1,52 @@
 import { type YextEntityField } from "../../editor/YextEntityFieldSelector.tsx";
+import { type YextCTAField } from "../../fields/CTASelectorField.tsx";
+import { type ComprehensiveCTAValue } from "../../fields/styledFields/ComprehensiveCTAField.tsx";
 import { type YextFieldDefinition } from "../../fields/fields.ts";
 import { resolveYextEntityField } from "../resolveYextEntityField.ts";
 import { type StreamDocument } from "../types/StreamDocument.ts";
 import { isEntityFieldDefinition } from "./itemSourceFieldTransforms.ts";
 import { type ResolvedItemField } from "./itemSourceTypes.ts";
+
+const comprehensiveCTADataField = {
+  type: "object",
+  objectFields: {
+    actionType: {
+      type: "text",
+    },
+    cta: {
+      type: "ctaSelector",
+    },
+    openInNewTab: {
+      type: "radio",
+      options: [],
+    },
+    buttonText: {
+      type: "translatableString",
+      filter: { types: ["type.string"] },
+    },
+    customId: {
+      type: "text",
+    },
+    customClass: {
+      type: "text",
+    },
+    dataAttributes: {
+      type: "array",
+      arrayFields: {
+        key: {
+          type: "text",
+        },
+        value: {
+          type: "text",
+        },
+      },
+    },
+    ariaLabel: {
+      type: "translatableString",
+      filter: { types: ["type.string"] },
+    },
+  },
+} satisfies YextFieldDefinition<ComprehensiveCTAValue["data"]>;
 
 /**
  * Runtime item resolution.
@@ -22,6 +65,49 @@ export const resolveItemValue = <TValue>(
   streamDocument: StreamDocument,
   itemDocument?: StreamDocument
 ): ResolvedItemField<TValue> => {
+  if (field.type === "ctaSelector") {
+    const ctaField = value as Partial<YextCTAField> | undefined;
+
+    if (!ctaField?.constantValueEnabled && !ctaField?.field) {
+      return undefined as ResolvedItemField<TValue>;
+    }
+
+    const resolvedCTA: Partial<NonNullable<YextCTAField["constantValue"]>> =
+      (resolveYextEntityField<YextCTAField["constantValue"] | undefined>(
+        itemDocument ?? streamDocument,
+        {
+          field: ctaField?.field ?? "",
+          constantValue: ctaField?.constantValue,
+          constantValueEnabled: ctaField?.constantValueEnabled,
+        },
+        streamDocument.locale
+      ) ?? {}) as Partial<NonNullable<YextCTAField["constantValue"]>>;
+
+    return {
+      field: "",
+      constantValueEnabled: true,
+      constantValue: resolvedCTA,
+      selectedType: ctaField?.selectedType,
+    } as ResolvedItemField<TValue>;
+  }
+
+  if (field.type === "comprehensiveCTA") {
+    const ctaValue =
+      value && typeof value === "object" && !Array.isArray(value)
+        ? (value as Partial<ComprehensiveCTAValue>)
+        : {};
+
+    return {
+      ...ctaValue,
+      data: resolveItemValue(
+        comprehensiveCTADataField,
+        ctaValue.data,
+        streamDocument,
+        itemDocument
+      ),
+    } as ResolvedItemField<TValue>;
+  }
+
   if (isEntityFieldDefinition(field)) {
     const entityField = value as Partial<YextEntityField<unknown>> | undefined;
     if (!entityField?.constantValueEnabled && !entityField?.field) {


### PR DESCRIPTION
comprehensiveCta wasn't resolving to entity values properly in resolveItemValue (used for list/card sections) because the cta wasn't being recursively resolved. This checks for the comprehensiveCta and resolves all subfields that can be entity-powered