### PR TITLE
fix: loosen item source mapping requirements for CTAs

### DIFF
--- a/packages/visual-editor/src/editor/yextEntityFieldUtils.test.ts
+++ b/packages/visual-editor/src/editor/yextEntityFieldUtils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { productCardsSource } from "../components/pageSections/ProductSection/ProductCardsWrapper.tsx";
+import { type EntityFieldSelectorField } from "../fields/EntityFieldSelectorField.tsx";
 import {
   getEntityFieldDisplayName,
   getFieldsForSelector,
@@ -202,7 +203,7 @@ describe("getFieldsForSelector", () => {
             "Product Reference > Primary Photo",
         },
       },
-      productCardsSource.field.filter
+      (productCardsSource.field as EntityFieldSelectorField).filter
     );
 
     expect(fields).toEqual(

--- a/packages/visual-editor/src/editor/yextEntityFieldUtils.test.ts
+++ b/packages/visual-editor/src/editor/yextEntityFieldUtils.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { productCardsSource } from "../components/pageSections/ProductSection/ProductCardsWrapper.tsx";
 import {
   getEntityFieldDisplayName,
   getFieldsForSelector,
@@ -135,6 +136,79 @@ describe("getFieldsForSelector", () => {
       expect.arrayContaining([
         expect.objectContaining({
           name: "c_articles",
+        }),
+      ])
+    );
+  });
+
+  it("treats c_productReference as a valid source for product cards requirements, despite missing CTA", () => {
+    const fields = getFieldsForSelector(
+      {
+        fields: [
+          {
+            name: "c_productReference",
+            definition: {
+              name: "c_productReference",
+              typeRegistryId: "type.entity_reference",
+              isList: true,
+              type: {
+                documentType: "DOCUMENT_TYPE_ENTITY",
+              },
+            },
+            children: {
+              fields: [
+                {
+                  name: "brand",
+                  definition: {
+                    name: "brand",
+                    typeName: "type.string",
+                    type: {},
+                  },
+                },
+                {
+                  name: "name",
+                  definition: {
+                    name: "name",
+                    typeName: "type.string",
+                    type: {},
+                  },
+                },
+                {
+                  name: "price",
+                  definition: {
+                    name: "price",
+                    typeName: "type.price",
+                    type: {},
+                  },
+                },
+                {
+                  name: "primaryPhoto",
+                  definition: {
+                    name: "primaryPhoto",
+                    typeName: "type.image",
+                    type: {},
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        displayNames: {
+          c_productReference: "Product Reference",
+          "c_productReference.brand": "Product Reference > Brand",
+          "c_productReference.name": "Product Reference > Name",
+          "c_productReference.price": "Product Reference > Price",
+          "c_productReference.primaryPhoto":
+            "Product Reference > Primary Photo",
+        },
+      },
+      productCardsSource.field.filter
+    );
+
+    expect(fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "c_productReference",
         }),
       ])
     );

--- a/packages/visual-editor/src/utils/itemSource/createItemSource.test.ts
+++ b/packages/visual-editor/src/utils/itemSource/createItemSource.test.ts
@@ -75,6 +75,25 @@ describe("createItemSource", () => {
     });
   });
 
+  it("treats text and rich text as compatible CTA source requirements", () => {
+    const ctaSource = createItemSource({
+      label: "Articles",
+      mappingFields: {
+        cta: {
+          type: "entityField",
+          label: "CTA",
+          filter: { types: ["type.cta"] },
+        },
+      },
+    });
+
+    expect(ctaSource.field).toMatchObject({
+      filter: {
+        itemSourceTypes: [["type.cta", "type.string", "type.rich_text_v2"]],
+      },
+    });
+  });
+
   it("uses the first default value as the add-item template and seeds manual items", () => {
     const customizedSource = createItemSource<ArticleItemProps>({
       label: "Articles",

--- a/packages/visual-editor/src/utils/itemSource/createItemSource.test.ts
+++ b/packages/visual-editor/src/utils/itemSource/createItemSource.test.ts
@@ -89,7 +89,7 @@ describe("createItemSource", () => {
 
     expect(ctaSource.field).toMatchObject({
       filter: {
-        itemSourceTypes: [["type.cta", "type.string", "type.rich_text_v2"]],
+        itemSourceTypes: [["type.cta", "type.string"]],
       },
     });
   });

--- a/packages/visual-editor/src/utils/itemSource/createSlottedItemSource.test.ts
+++ b/packages/visual-editor/src/utils/itemSource/createSlottedItemSource.test.ts
@@ -72,6 +72,26 @@ describe("createSlottedItemSource", () => {
     });
   });
 
+  it("treats text and rich text as compatible CTA source requirements", () => {
+    const ctaSource = createSlottedItemSource({
+      label: "Featured Items",
+      itemLabel: "Featured Item",
+      mappingFields: {
+        cta: {
+          type: "entityField",
+          label: "CTA",
+          filter: { types: ["type.cta"] },
+        },
+      },
+    });
+
+    expect(ctaSource.field).toMatchObject({
+      filter: {
+        itemSourceTypes: [["type.cta", "type.string", "type.rich_text_v2"]],
+      },
+    });
+  });
+
   it("resolves linked slot mappings against the current mapped item", () => {
     const resolved = featuredItemsSource.resolveItems(
       {

--- a/packages/visual-editor/src/utils/itemSource/createSlottedItemSource.test.ts
+++ b/packages/visual-editor/src/utils/itemSource/createSlottedItemSource.test.ts
@@ -87,7 +87,7 @@ describe("createSlottedItemSource", () => {
 
     expect(ctaSource.field).toMatchObject({
       filter: {
-        itemSourceTypes: [["type.cta", "type.string", "type.rich_text_v2"]],
+        itemSourceTypes: [["type.cta", "type.string"]],
       },
     });
   });

--- a/packages/visual-editor/src/utils/itemSource/itemSourceFieldTransforms.ts
+++ b/packages/visual-editor/src/utils/itemSource/itemSourceFieldTransforms.ts
@@ -131,7 +131,7 @@ const MAPPING_CONSTANT_VALUE_LIST_TYPES: EntityFieldTypes[] = ["type.string"];
 const ITEM_SOURCE_TYPE_COMPATIBILITY: Partial<
   Record<EntityFieldTypes, EntityFieldTypes[]>
 > = {
-  "type.cta": ["type.string", "type.rich_text_v2"],
+  "type.cta": ["type.string"],
 };
 
 function shouldEnableMappingConstantValue(

--- a/packages/visual-editor/src/utils/itemSource/itemSourceFieldTransforms.ts
+++ b/packages/visual-editor/src/utils/itemSource/itemSourceFieldTransforms.ts
@@ -128,6 +128,11 @@ const MAPPING_CONSTANT_VALUE_TYPES: EntityFieldTypes[] = [
 ];
 
 const MAPPING_CONSTANT_VALUE_LIST_TYPES: EntityFieldTypes[] = ["type.string"];
+const ITEM_SOURCE_TYPE_COMPATIBILITY: Partial<
+  Record<EntityFieldTypes, EntityFieldTypes[]>
+> = {
+  "type.cta": ["type.string", "type.rich_text_v2"],
+};
 
 function shouldEnableMappingConstantValue(
   field: EntityFieldSelectorField<any>
@@ -197,7 +202,14 @@ function getNestedItemSourceTypes(
   field: YextFieldDefinition<any>
 ): EntityFieldTypes[][] {
   if (isEntityFieldDefinition(field)) {
-    return field.filter.types?.length ? [field.filter.types] : [];
+    return field.filter.types?.length
+      ? [
+          field.filter.types.flatMap((entityFieldType) => [
+            entityFieldType,
+            ...(ITEM_SOURCE_TYPE_COMPATIBILITY[entityFieldType] ?? []),
+          ]),
+        ]
+      : [];
   }
 
   if (field.type === "object" && "objectFields" in field) {


### PR DESCRIPTION
Allows itemSource to select a parent field without CTAs, even if the cards require a CTA, provided that there is a text field available.

This allows a user to user a constant value to map to the CTA instead of requiring a CTA field.

Impetus: https://yext.slack.com/archives/C02UVSE7P6W/p1783433102868479

This change would allow them to use their c_productReference linked field without having to add CTAs to the Products and link them in the pageset.

They can then set the CTAs to constant value and use text to populate the fields.