### PR TITLE
feat: support analytics for custom code section

### DIFF
--- a/packages/visual-editor/src/components/customCode/CustomCodeSection.tsx
+++ b/packages/visual-editor/src/components/customCode/CustomCodeSection.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { CodeXml } from "lucide-react";
-import { AnalyticsScopeProvider, useAnalytics } from "@yext/pages-components";
+import { AnalyticsScopeProvider } from "@yext/pages-components";
 import { VisibilityWrapper } from "../atoms/visibilityWrapper.tsx";
 import { msg, pt } from "../../utils/i18n/platform.ts";
 import { useDocument } from "../../hooks/useDocument.tsx";
@@ -8,77 +8,6 @@ import { WithId, WithPuckProps } from "@puckeditor/core";
 import { resolveEmbeddedFieldsInString } from "../../utils/resolveYextEntityField.ts";
 import { processHandlebarsTemplate } from "./customCodeHandlebars.ts";
 import { YextComponentConfig, YextFields } from "../../fields/fields.ts";
-
-type AnalyticsTrackProps = Parameters<
-  NonNullable<ReturnType<typeof useAnalytics>>["track"]
->[0];
-
-type CustomCodeAnalyticsData = Record<string, unknown> & {
-  action?: AnalyticsTrackProps["action"];
-};
-
-/** The default analytics action used when Custom Code scripts do not provide one. */
-const DEFAULT_CUSTOM_CODE_ANALYTICS_ACTION: AnalyticsTrackProps["action"] =
-  "C_CUSTOM";
-
-type CustomCodeAnalyticsBridge = {
-  track: (eventName: string, data?: CustomCodeAnalyticsData) => void;
-};
-
-type YextCustomCodeAnalytics = {
-  register: (
-    componentId: string,
-    analyticsBridge: CustomCodeAnalyticsBridge
-  ) => void;
-  unregister: (componentId: string) => void;
-  track: (
-    componentId: string,
-    eventName: string,
-    data?: CustomCodeAnalyticsData
-  ) => void;
-};
-
-declare global {
-  interface Window {
-    YextCustomCodeAnalytics?: YextCustomCodeAnalytics;
-  }
-}
-
-/**
- * Creates or returns the shared browser analytics bridge used by CustomCodeSection scripts.
- * Each CustomCodeSection registers its scoped analytics instance by componentId so multiple
- * custom code components can coexist without overwriting each other's analytics handlers.
- */
-const getYextCustomCodeAnalytics = (): YextCustomCodeAnalytics => {
-  if (window.YextCustomCodeAnalytics) {
-    return window.YextCustomCodeAnalytics;
-  }
-
-  const scopes: Record<string, CustomCodeAnalyticsBridge> = {};
-
-  window.YextCustomCodeAnalytics = {
-    register(componentId, analyticsBridge) {
-      scopes[componentId] = analyticsBridge;
-    },
-    unregister(componentId) {
-      delete scopes[componentId];
-    },
-    track(componentId, eventName, data) {
-      const scope = scopes[componentId];
-
-      if (!scope) {
-        console.warn(
-          `No Custom Code analytics scope found for componentId: ${componentId}`
-        );
-        return;
-      }
-
-      scope.track(eventName, data);
-    },
-  };
-
-  return window.YextCustomCodeAnalytics;
-};
 
 export interface CustomCodeSectionProps {
   /**
@@ -160,72 +89,7 @@ const EmptyCustomCodeSection = () => {
   );
 };
 
-/**
- * Registers the current component's scoped analytics bridge before executing user JavaScript.
- * This ensures injected scripts can call `yextAnalytics.track(...)` immediately while still
- * using the AnalyticsScopeProvider context for this CustomCodeSection instance.
- */
-const CustomCodeAnalyticsBridgeAndScriptRunner = ({
-  componentId,
-  containerRef,
-  processedJavascript,
-  scriptTagId,
-}: {
-  componentId: string;
-  containerRef: React.RefObject<HTMLDivElement>;
-  processedJavascript: string;
-  scriptTagId: string;
-}) => {
-  const analytics = useAnalytics();
-
-  React.useEffect(() => {
-    if (!containerRef.current || !processedJavascript) {
-      return;
-    }
-
-    const customCodeAnalytics = getYextCustomCodeAnalytics();
-    customCodeAnalytics.register(componentId, {
-      track: (eventName, data) => {
-        analytics?.track({
-          ...data,
-          action: data?.action ?? DEFAULT_CUSTOM_CODE_ANALYTICS_ACTION,
-          eventName,
-        });
-      },
-    });
-
-    const prevScript = containerRef.current.querySelector(`#${scriptTagId}`);
-    if (prevScript) {
-      prevScript.remove();
-    }
-
-    const script = document.createElement("script");
-    script.id = scriptTagId;
-    script.type = "text/javascript";
-    // Wrap user code in a block so each component gets a local yextAnalytics helper without leaking a global.
-    script.text = `
-{
-  const yextAnalytics = {
-    track: (eventName, data) =>
-      window.YextCustomCodeAnalytics.track(${JSON.stringify(componentId)}, eventName, data),
-  };
-
-${processedJavascript}
-}
-`;
-    containerRef.current.appendChild(script);
-
-    return () => {
-      script.remove();
-      customCodeAnalytics.unregister(componentId);
-    };
-  }, [analytics, componentId, processedJavascript, scriptTagId]);
-
-  return null;
-};
-
 const CustomCodeSectionWrapper = ({
-  id,
   html,
   css,
   javascript,
@@ -245,6 +109,25 @@ const CustomCodeSectionWrapper = ({
     locale
   );
 
+  React.useEffect(() => {
+    if (!containerRef.current) {
+      return;
+    }
+
+    const prevScript = containerRef.current.querySelector(`#${scriptTagId}`);
+    if (prevScript) {
+      prevScript.remove();
+    }
+
+    if (processedJavascript) {
+      const script = document.createElement("script");
+      script.id = scriptTagId;
+      script.type = "text/javascript";
+      script.text = processedJavascript;
+      containerRef.current.appendChild(script);
+    }
+  }, [processedJavascript]);
+
   if (!processedHtml) {
     return puck.isEditing ? <EmptyCustomCodeSection /> : null;
   }
@@ -255,12 +138,6 @@ const CustomCodeSectionWrapper = ({
       <div
         ref={containerRef}
         dangerouslySetInnerHTML={{ __html: processedHtml }}
-      />
-      <CustomCodeAnalyticsBridgeAndScriptRunner
-        componentId={id}
-        containerRef={containerRef}
-        processedJavascript={processedJavascript}
-        scriptTagId={scriptTagId}
       />
     </div>
   );

--- a/packages/visual-editor/src/components/customCode/CustomCodeSection.tsx
+++ b/packages/visual-editor/src/components/customCode/CustomCodeSection.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { CodeXml } from "lucide-react";
-import { AnalyticsScopeProvider } from "@yext/pages-components";
+import { AnalyticsScopeProvider, useAnalytics } from "@yext/pages-components";
 import { VisibilityWrapper } from "../atoms/visibilityWrapper.tsx";
 import { msg, pt } from "../../utils/i18n/platform.ts";
 import { useDocument } from "../../hooks/useDocument.tsx";
@@ -8,6 +8,77 @@ import { WithId, WithPuckProps } from "@puckeditor/core";
 import { resolveEmbeddedFieldsInString } from "../../utils/resolveYextEntityField.ts";
 import { processHandlebarsTemplate } from "./customCodeHandlebars.ts";
 import { YextComponentConfig, YextFields } from "../../fields/fields.ts";
+
+type AnalyticsTrackProps = Parameters<
+  NonNullable<ReturnType<typeof useAnalytics>>["track"]
+>[0];
+
+type CustomCodeAnalyticsData = Record<string, unknown> & {
+  action?: AnalyticsTrackProps["action"];
+};
+
+/** The default analytics action used when Custom Code scripts do not provide one. */
+const DEFAULT_CUSTOM_CODE_ANALYTICS_ACTION: AnalyticsTrackProps["action"] =
+  "C_CUSTOM";
+
+type CustomCodeAnalyticsBridge = {
+  track: (eventName: string, data?: CustomCodeAnalyticsData) => void;
+};
+
+type YextCustomCodeAnalytics = {
+  register: (
+    componentId: string,
+    analyticsBridge: CustomCodeAnalyticsBridge
+  ) => void;
+  unregister: (componentId: string) => void;
+  track: (
+    componentId: string,
+    eventName: string,
+    data?: CustomCodeAnalyticsData
+  ) => void;
+};
+
+declare global {
+  interface Window {
+    YextCustomCodeAnalytics?: YextCustomCodeAnalytics;
+  }
+}
+
+/**
+ * Creates or returns the shared browser analytics bridge used by CustomCodeSection scripts.
+ * Each CustomCodeSection registers its scoped analytics instance by componentId so multiple
+ * custom code components can coexist without overwriting each other's analytics handlers.
+ */
+const getYextCustomCodeAnalytics = (): YextCustomCodeAnalytics => {
+  if (window.YextCustomCodeAnalytics) {
+    return window.YextCustomCodeAnalytics;
+  }
+
+  const scopes: Record<string, CustomCodeAnalyticsBridge> = {};
+
+  window.YextCustomCodeAnalytics = {
+    register(componentId, analyticsBridge) {
+      scopes[componentId] = analyticsBridge;
+    },
+    unregister(componentId) {
+      delete scopes[componentId];
+    },
+    track(componentId, eventName, data) {
+      const scope = scopes[componentId];
+
+      if (!scope) {
+        console.warn(
+          `No Custom Code analytics scope found for componentId: ${componentId}`
+        );
+        return;
+      }
+
+      scope.track(eventName, data);
+    },
+  };
+
+  return window.YextCustomCodeAnalytics;
+};
 
 export interface CustomCodeSectionProps {
   /**
@@ -89,7 +160,72 @@ const EmptyCustomCodeSection = () => {
   );
 };
 
+/**
+ * Registers the current component's scoped analytics bridge before executing user JavaScript.
+ * This ensures injected scripts can call `yextAnalytics.track(...)` immediately while still
+ * using the AnalyticsScopeProvider context for this CustomCodeSection instance.
+ */
+const CustomCodeAnalyticsBridgeAndScriptRunner = ({
+  componentId,
+  containerRef,
+  processedJavascript,
+  scriptTagId,
+}: {
+  componentId: string;
+  containerRef: React.RefObject<HTMLDivElement>;
+  processedJavascript: string;
+  scriptTagId: string;
+}) => {
+  const analytics = useAnalytics();
+
+  React.useEffect(() => {
+    if (!containerRef.current || !processedJavascript) {
+      return;
+    }
+
+    const customCodeAnalytics = getYextCustomCodeAnalytics();
+    customCodeAnalytics.register(componentId, {
+      track: (eventName, data) => {
+        analytics?.track({
+          ...data,
+          action: data?.action ?? DEFAULT_CUSTOM_CODE_ANALYTICS_ACTION,
+          eventName,
+        });
+      },
+    });
+
+    const prevScript = containerRef.current.querySelector(`#${scriptTagId}`);
+    if (prevScript) {
+      prevScript.remove();
+    }
+
+    const script = document.createElement("script");
+    script.id = scriptTagId;
+    script.type = "text/javascript";
+    // Wrap user code in a block so each component gets a local yextAnalytics helper without leaking a global.
+    script.text = `
+{
+  const yextAnalytics = {
+    track: (eventName, data) =>
+      window.YextCustomCodeAnalytics.track(${JSON.stringify(componentId)}, eventName, data),
+  };
+
+${processedJavascript}
+}
+`;
+    containerRef.current.appendChild(script);
+
+    return () => {
+      script.remove();
+      customCodeAnalytics.unregister(componentId);
+    };
+  }, [analytics, componentId, processedJavascript, scriptTagId]);
+
+  return null;
+};
+
 const CustomCodeSectionWrapper = ({
+  id,
   html,
   css,
   javascript,
@@ -109,25 +245,6 @@ const CustomCodeSectionWrapper = ({
     locale
   );
 
-  React.useEffect(() => {
-    if (!containerRef.current) {
-      return;
-    }
-
-    const prevScript = containerRef.current.querySelector(`#${scriptTagId}`);
-    if (prevScript) {
-      prevScript.remove();
-    }
-
-    if (processedJavascript) {
-      const script = document.createElement("script");
-      script.id = scriptTagId;
-      script.type = "text/javascript";
-      script.text = processedJavascript;
-      containerRef.current.appendChild(script);
-    }
-  }, [processedJavascript]);
-
   if (!processedHtml) {
     return puck.isEditing ? <EmptyCustomCodeSection /> : null;
   }
@@ -138,6 +255,12 @@ const CustomCodeSectionWrapper = ({
       <div
         ref={containerRef}
         dangerouslySetInnerHTML={{ __html: processedHtml }}
+      />
+      <CustomCodeAnalyticsBridgeAndScriptRunner
+        componentId={id}
+        containerRef={containerRef}
+        processedJavascript={processedJavascript}
+        scriptTagId={scriptTagId}
       />
     </div>
   );

--- a/packages/visual-editor/src/utils/VisualEditorProvider.tsx
+++ b/packages/visual-editor/src/utils/VisualEditorProvider.tsx
@@ -57,6 +57,7 @@ const VisualEditorProvider = <T extends Record<string, any>>({
   children,
 }: VisualEditorProviderProps<T>) => {
   const pagesAnalytics = useAnalytics();
+
   // Use useMemo to prevent creating a new QueryClient on every render
   // QueryClient maintains internal caches, so creating new instances unnecessarily
   // could lead to memory accumulation

--- a/packages/visual-editor/src/utils/VisualEditorProvider.tsx
+++ b/packages/visual-editor/src/utils/VisualEditorProvider.tsx
@@ -31,12 +31,12 @@ type EditorProps = {
 type VisualEditorProviderProps<T> = UniversalProps<T> &
   AllOrNothing<EditorProps>;
 
-type CustomCodeAnalyticsRequest = Parameters<
+type AnalyticsTrackProps = Parameters<
   NonNullable<ReturnType<typeof useAnalytics>>["track"]
 >[0];
 
 type YextCustomCodeAnalytics = {
-  track: (request: CustomCodeAnalyticsRequest) => void;
+  track: (request: AnalyticsTrackProps) => void;
 };
 
 declare global {

--- a/packages/visual-editor/src/utils/VisualEditorProvider.tsx
+++ b/packages/visual-editor/src/utils/VisualEditorProvider.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useAnalytics } from "@yext/pages-components";
 import { TemplatePropsContext } from "../hooks/useDocument.tsx";
 import { EntityFieldsContext } from "../hooks/useEntityFields.tsx";
 import { TailwindConfig } from "./themeResolver.ts";
@@ -30,12 +31,32 @@ type EditorProps = {
 type VisualEditorProviderProps<T> = UniversalProps<T> &
   AllOrNothing<EditorProps>;
 
+type CustomCodeAnalyticsRequest = Parameters<
+  NonNullable<ReturnType<typeof useAnalytics>>["track"]
+>[0];
+
+type YextCustomCodeAnalytics = {
+  track: (request: CustomCodeAnalyticsRequest) => void;
+};
+
+declare global {
+  interface Window {
+    YextCustomCodeAnalytics?: YextCustomCodeAnalytics;
+  }
+}
+
+// Use layout effect in the browser so the analytics global exists before CustomCodeSection runs injected scripts
+// Fall back during SSR to avoid useLayoutEffect warnings.
+const useBrowserLayoutEffect =
+  typeof window === "undefined" ? React.useEffect : React.useLayoutEffect;
+
 const VisualEditorProvider = <T extends Record<string, any>>({
   templateProps,
   entityFields,
   tailwindConfig,
   children,
 }: VisualEditorProviderProps<T>) => {
+  const pagesAnalytics = useAnalytics();
   // Use useMemo to prevent creating a new QueryClient on every render
   // QueryClient maintains internal caches, so creating new instances unnecessarily
   // could lead to memory accumulation
@@ -54,6 +75,18 @@ const VisualEditorProvider = <T extends Record<string, any>>({
       normalizedTemplateProps.document.locale
     );
   }
+
+  useBrowserLayoutEffect(() => {
+    window.YextCustomCodeAnalytics = {
+      track: (request) => {
+        pagesAnalytics?.track(request);
+      },
+    };
+
+    return () => {
+      delete window.YextCustomCodeAnalytics;
+    };
+  }, [pagesAnalytics]);
 
   return (
     <ErrorProvider>


### PR DESCRIPTION
This PR supports analytics for custom code section. It adds the Analytics track method to the window so that inner-components are able to reference it. Each analytics is registered by componentId so multiple custom code components can coexist without overwriting each other's handlers. 

TEST=manual
Created a dev-release with this change and set it up with a site. For that site's layout, create 3 separate custom code components, each with different analytic calls. Deployed changes and saw analytic events come in both on the network tab and in Snowflake.

Snowflake query:
`select * from prod_analytics2.public.analytics_events where original_business_id = 4146665 order by event_timestamp desc;`

Example Javascript used in custom code component:
```
function trackCustomClick(button) {
  button.textContent = "Clickedddddd";

  window.YextCustomCodeAnalytics.track({
    scope: "customCodeComponent",
    eventName: "Custom Button Clicked",
    action: "LINK",
    buttonText: "Track Click",
  });
}
```

Video: 
https://drive.google.com/file/d/1SVUUV4njl_fKxF-ZfO3aDrCqPrm3PgAx/view?usp=drive_link
