### PR TITLE
fix: use Radix popover for ColorSelector

### DIFF
--- a/packages/visual-editor/locales/platform/cs/visual-editor.json
+++ b/packages/visual-editor/locales/platform/cs/visual-editor.json
@@ -48,7 +48,6 @@
   "closesAtTime": "Zavírá v {{time}}",
   "closesAtTimeWeek": "Zavírá v {{time}} {{dayOfWeek}}",
   "colorPicker": {
-    "close": "Zavřete výběr barvy",
     "open": "Otevřete výběr barvy"
   },
   "comingSoon": "Již brzy",

--- a/packages/visual-editor/locales/platform/da/visual-editor.json
+++ b/packages/visual-editor/locales/platform/da/visual-editor.json
@@ -48,7 +48,6 @@
   "closesAtTime": "Lukker kl. {{time}}",
   "closesAtTimeWeek": "Lukker kl. {{time}} {{dayOfWeek}}",
   "colorPicker": {
-    "close": "Luk farvevælgeren",
     "open": "Åbn farvevælgeren"
   },
   "comingSoon": "Kommer snart",

--- a/packages/visual-editor/locales/platform/de/visual-editor.json
+++ b/packages/visual-editor/locales/platform/de/visual-editor.json
@@ -48,7 +48,6 @@
   "closesAtTime": "Schließt um {{time}} Uhr",
   "closesAtTimeWeek": "Schließt am {{dayOfWeek}} um {{time}} Uhr",
   "colorPicker": {
-    "close": "Farbauswahl schließen",
     "open": "Farbauswahl öffnen"
   },
   "comingSoon": "Demnächst erhältlich",

--- a/packages/visual-editor/locales/platform/en-GB/visual-editor.json
+++ b/packages/visual-editor/locales/platform/en-GB/visual-editor.json
@@ -48,7 +48,6 @@
   "closesAtTime": "Closes at {{time}}",
   "closesAtTimeWeek": "Closes at {{time}} {{dayOfWeek}}",
   "colorPicker": {
-    "close": "Close color picker",
     "open": "Open color picker"
   },
   "comingSoon": "Coming Soon",

--- a/packages/visual-editor/locales/platform/en/visual-editor.json
+++ b/packages/visual-editor/locales/platform/en/visual-editor.json
@@ -48,7 +48,6 @@
   "closesAtTime": "Closes at {{time}}",
   "closesAtTimeWeek": "Closes at {{time}} {{dayOfWeek}}",
   "colorPicker": {
-    "close": "Close color picker",
     "open": "Open color picker"
   },
   "comingSoon": "Coming Soon",

--- a/packages/visual-editor/locales/platform/es/visual-editor.json
+++ b/packages/visual-editor/locales/platform/es/visual-editor.json
@@ -48,7 +48,6 @@
   "closesAtTime": "Cierra a las {{time}}",
   "closesAtTimeWeek": "Cierra a las {{time}} {{dayOfWeek}}",
   "colorPicker": {
-    "close": "Cerrar selector de color",
     "open": "Abrir selector de color"
   },
   "comingSoon": "Muy pronto",

--- a/packages/visual-editor/locales/platform/et/visual-editor.json
+++ b/packages/visual-editor/locales/platform/et/visual-editor.json
@@ -48,7 +48,6 @@
   "closesAtTime": "Suletakse {{time}}",
   "closesAtTimeWeek": "Suletakse kell {{time}} {{dayOfWeek}}",
   "colorPicker": {
-    "close": "Sulgege värvivalija",
     "open": "Ava värvivalija"
   },
   "comingSoon": "Varsti",

--- a/packages/visual-editor/locales/platform/fi/visual-editor.json
+++ b/packages/visual-editor/locales/platform/fi/visual-editor.json
@@ -48,7 +48,6 @@
   "closesAtTime": "Suljetaan {{time}}",
   "closesAtTimeWeek": "Suljetaan klo {{time}} {{dayOfWeek}}",
   "colorPicker": {
-    "close": "Sulje värivalitsin",
     "open": "Avaa värivalitsin"
   },
   "comingSoon": "Tulossa pian",

--- a/packages/visual-editor/locales/platform/fr/visual-editor.json
+++ b/packages/visual-editor/locales/platform/fr/visual-editor.json
@@ -48,7 +48,6 @@
   "closesAtTime": "Ferme à {{time}}",
   "closesAtTimeWeek": "Ferme à {{time}} {{dayOfWeek}}",
   "colorPicker": {
-    "close": "Fermer le sélecteur de couleurs",
     "open": "Ouvrir le sélecteur de couleurs"
   },
   "comingSoon": "À venir",

--- a/packages/visual-editor/locales/platform/hr/visual-editor.json
+++ b/packages/visual-editor/locales/platform/hr/visual-editor.json
@@ -48,7 +48,6 @@
   "closesAtTime": "Zatvara se u {{time}}",
   "closesAtTimeWeek": "Zatvara se u {{time}} {{dayOfWeek}}",
   "colorPicker": {
-    "close": "Zatvori birač boja",
     "open": "Otvori birač boja"
   },
   "comingSoon": "Dolazi uskoro",

--- a/packages/visual-editor/locales/platform/hu/visual-editor.json
+++ b/packages/visual-editor/locales/platform/hu/visual-editor.json
@@ -48,7 +48,6 @@
   "closesAtTime": "Zárás: {{time}}",
   "closesAtTimeWeek": "Zárás: {{time}} {{dayOfWeek}}",
   "colorPicker": {
-    "close": "Zárja be a színválasztót",
     "open": "Nyissa meg a színválasztót"
   },
   "comingSoon": "Hamarosan",

--- a/packages/visual-editor/locales/platform/it/visual-editor.json
+++ b/packages/visual-editor/locales/platform/it/visual-editor.json
@@ -48,7 +48,6 @@
   "closesAtTime": "Chiude alle {{time}}",
   "closesAtTimeWeek": "Chiude alle {{time}} {{dayOfWeek}}",
   "colorPicker": {
-    "close": "Chiudi il selettore colori",
     "open": "Apri il selettore colori"
   },
   "comingSoon": "Prossimamente",

--- a/packages/visual-editor/locales/platform/ja/visual-editor.json
+++ b/packages/visual-editor/locales/platform/ja/visual-editor.json
@@ -48,7 +48,6 @@
   "closesAtTime": "{{time}}に閉まります",
   "closesAtTimeWeek": "{{time}} {{dayOfWeek}} に閉店",
   "colorPicker": {
-    "close": "カラーピッカーを閉じる",
     "open": "カラーピッカーを開く"
   },
   "comingSoon": "近日公開",

--- a/packages/visual-editor/locales/platform/lt/visual-editor.json
+++ b/packages/visual-editor/locales/platform/lt/visual-editor.json
@@ -48,7 +48,6 @@
   "closesAtTime": "Uždaroma {{time}}",
   "closesAtTimeWeek": "Uždaroma {{time}} {{dayOfWeek}}",
   "colorPicker": {
-    "close": "Uždarykite spalvų parinkiklį",
     "open": "Atidarykite spalvų rinkiklį"
   },
   "comingSoon": "Netrukus",

--- a/packages/visual-editor/locales/platform/lv/visual-editor.json
+++ b/packages/visual-editor/locales/platform/lv/visual-editor.json
@@ -48,7 +48,6 @@
   "closesAtTime": "Tiek slēgts plkst. {{time}}",
   "closesAtTimeWeek": "Tiek slēgts plkst. {{time}} {{dayOfWeek}}",
   "colorPicker": {
-    "close": "Aizvērt krāsu atlasītāju",
     "open": "Atveriet krāsu atlasītāju"
   },
   "comingSoon": "Drīzumā",

--- a/packages/visual-editor/locales/platform/nb/visual-editor.json
+++ b/packages/visual-editor/locales/platform/nb/visual-editor.json
@@ -48,7 +48,6 @@
   "closesAtTime": "Stenger kl. {{time}}",
   "closesAtTimeWeek": "Stenger kl. {{time}} {{dayOfWeek}}",
   "colorPicker": {
-    "close": "Lukk fargevelgeren",
     "open": "Åpne fargevelgeren"
   },
   "comingSoon": "Kommer snart",

--- a/packages/visual-editor/locales/platform/nl/visual-editor.json
+++ b/packages/visual-editor/locales/platform/nl/visual-editor.json
@@ -48,7 +48,6 @@
   "closesAtTime": "Sluit om {{time}}",
   "closesAtTimeWeek": "Sluit om {{time}} {{dayOfWeek}}",
   "colorPicker": {
-    "close": "Sluit de kleurkiezer",
     "open": "Kleurkiezer openen"
   },
   "comingSoon": "Binnenkort beschikbaar",

--- a/packages/visual-editor/locales/platform/pl/visual-editor.json
+++ b/packages/visual-editor/locales/platform/pl/visual-editor.json
@@ -48,7 +48,6 @@
   "closesAtTime": "Zamyka się o {{time}}",
   "closesAtTimeWeek": "Zamyka się o {{time}} {{dayOfWeek}}",
   "colorPicker": {
-    "close": "Zamknij selektor kolorów",
     "open": "Otwórz selektor kolorów"
   },
   "comingSoon": "Już wkrótce",

--- a/packages/visual-editor/locales/platform/pt/visual-editor.json
+++ b/packages/visual-editor/locales/platform/pt/visual-editor.json
@@ -48,7 +48,6 @@
   "closesAtTime": "Fecha às {{time}}",
   "closesAtTimeWeek": "Fecha às {{time}} {{dayOfWeek}}",
   "colorPicker": {
-    "close": "Fechar seletor de cores",
     "open": "Abrir seletor de cores"
   },
   "comingSoon": "Em breve",

--- a/packages/visual-editor/locales/platform/ro/visual-editor.json
+++ b/packages/visual-editor/locales/platform/ro/visual-editor.json
@@ -48,7 +48,6 @@
   "closesAtTime": "Se închide la {{time}}",
   "closesAtTimeWeek": "Se închide la {{time}} {{dayOfWeek}}",
   "colorPicker": {
-    "close": "Închideți selectorul de culori",
     "open": "Deschideți selectorul de culori"
   },
   "comingSoon": "În curând",

--- a/packages/visual-editor/locales/platform/sk/visual-editor.json
+++ b/packages/visual-editor/locales/platform/sk/visual-editor.json
@@ -48,7 +48,6 @@
   "closesAtTime": "Zatvára sa o {{time}}",
   "closesAtTimeWeek": "Zatvára sa o {{time}} {{dayOfWeek}}",
   "colorPicker": {
-    "close": "Zavrieť výber farieb",
     "open": "Otvorte výber farieb"
   },
   "comingSoon": "Už čoskoro",

--- a/packages/visual-editor/locales/platform/sv/visual-editor.json
+++ b/packages/visual-editor/locales/platform/sv/visual-editor.json
@@ -48,7 +48,6 @@
   "closesAtTime": "Stänger kl. {{time}}",
   "closesAtTimeWeek": "Stänger kl. {{time}} {{dayOfWeek}}",
   "colorPicker": {
-    "close": "Stäng färgväljaren",
     "open": "Öppna färgväljaren"
   },
   "comingSoon": "Kommer snart",

--- a/packages/visual-editor/locales/platform/tr/visual-editor.json
+++ b/packages/visual-editor/locales/platform/tr/visual-editor.json
@@ -48,7 +48,6 @@
   "closesAtTime": "{{time}} itibarıyla kapanıyor",
   "closesAtTimeWeek": "{{time}} {{dayOfWeek}} itibarıyla kapanıyor",
   "colorPicker": {
-    "close": "Renk seçiciyi kapat",
     "open": "Renk seçiciyi aç"
   },
   "comingSoon": "Yakında gelecek",

--- a/packages/visual-editor/locales/platform/zh-TW/visual-editor.json
+++ b/packages/visual-editor/locales/platform/zh-TW/visual-editor.json
@@ -48,7 +48,6 @@
   "closesAtTime": "於 {{time}} 關閉",
   "closesAtTimeWeek": "於 {{time}} {{dayOfWeek}} 關閉",
   "colorPicker": {
-    "close": "關閉顏色選擇器",
     "open": "打開顏色選擇器"
   },
   "comingSoon": "即將推出",

--- a/packages/visual-editor/locales/platform/zh/visual-editor.json
+++ b/packages/visual-editor/locales/platform/zh/visual-editor.json
@@ -48,7 +48,6 @@
   "closesAtTime": "于 {{time}} 关闭",
   "closesAtTimeWeek": "于 {{time}} {{dayOfWeek}} 关闭",
   "colorPicker": {
-    "close": "关闭颜色选择器",
     "open": "打开颜色选择器"
   },
   "comingSoon": "即将推出",

--- a/packages/visual-editor/src/fields/ColorSelector.tsx
+++ b/packages/visual-editor/src/fields/ColorSelector.tsx
@@ -1,6 +1,11 @@
 import React, { useEffect, useState } from "react";
 import { CustomField, FieldLabel } from "@puckeditor/core";
 import { Color, ColorResult, SketchPicker } from "react-color";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "../internal/puck/ui/Popover.tsx";
 import { pt } from "../utils/i18n/platform.ts";
 
 type RenderProps = Parameters<CustomField<any>["render"]>[0];
@@ -51,44 +56,26 @@ export const ColorPickerInput = ({
 
   const fieldStyles = colorPickerStyles(draftColor);
   return (
-    <div className="ve-relative">
-      <button
-        type="button"
-        aria-label={ariaLabel}
-        style={fieldStyles.swatch}
-        onClick={() => {
-          if (isOpen) {
-            setIsOpen(false);
-            return;
-          }
-
-          setIsOpen(true);
-        }}
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverTrigger asChild>
+        <button type="button" aria-label={ariaLabel} style={fieldStyles.swatch}>
+          <div style={fieldStyles.color} />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        side="bottom"
+        sideOffset={8}
+        className="ve-w-auto ve-border-0 ve-bg-transparent ve-p-0 ve-shadow-none"
       >
-        <div style={fieldStyles.color} />
-      </button>
-      {isOpen && (
-        <div
-          style={fieldStyles.popover}
-          onClick={(event) => event.stopPropagation()}
-          onPointerDown={(event) => event.stopPropagation()}
-          onPointerUp={(event) => event.stopPropagation()}
-        >
-          <button
-            type="button"
-            aria-label={pt("colorPicker.close", "Close color picker")}
-            style={fieldStyles.cover}
-            onClick={() => setIsOpen(false)}
-          />
-          <SketchPicker
-            disableAlpha={true}
-            color={draftColor}
-            onChange={handlePickerChange}
-            onChangeComplete={handlePickerChangeComplete}
-          />
-        </div>
-      )}
-    </div>
+        <SketchPicker
+          disableAlpha={true}
+          color={draftColor}
+          onChange={handlePickerChange}
+          onChangeComplete={handlePickerChangeComplete}
+        />
+      </PopoverContent>
+    </Popover>
   );
 };
 
@@ -109,21 +96,6 @@ const colorPickerStyles = (color: Color) => {
       display: "inline-block",
       cursor: "pointer",
       lineHeight: 0,
-    } as React.CSSProperties,
-    popover: {
-      position: "absolute",
-      zIndex: "2",
-    } as React.CSSProperties,
-    cover: {
-      position: "fixed",
-      top: "0px",
-      right: "0px",
-      bottom: "0px",
-      left: "0px",
-      border: "none",
-      background: "transparent",
-      padding: "0px",
-      cursor: "default",
     } as React.CSSProperties,
   };
 };

--- a/packages/visual-editor/src/internal/utils/constructThemePuckFields.test.ts
+++ b/packages/visual-editor/src/internal/utils/constructThemePuckFields.test.ts
@@ -7,8 +7,11 @@ import {
   convertStyleToPuckField,
 } from "./constructThemePuckFields.ts";
 
-vi.mock("react", async () => {
+vi.mock("react", async (importOriginal) => {
+  const react = await importOriginal<typeof import("react")>();
+
   return {
+    ...react,
     useCallback: (fn: any) => fn,
   };
 });


### PR DESCRIPTION
This updates the ColorSelector to use the shared Radix popover instead of a custom solution. It fixes an issue where, if the color field was the last field in the props menu, the color picker would open below the visible area of the screen. Now it opens below the color preview if there is room, or above it if necessary.

This screenshot shows the color picker opening above the color preview because the field is at the bottom of the page:
<img width="432" height="405" alt="Screenshot 2026-07-09 at 6 20 15 PM" src="https://github.com/user-attachments/assets/fd964289-a380-43c4-949b-0fc17cd18b33" />
