### PR TITLE
fix: increase color picker z index

### DIFF
--- a/packages/visual-editor/src/fields/ColorSelector.tsx
+++ b/packages/visual-editor/src/fields/ColorSelector.tsx
@@ -112,7 +112,7 @@ const colorPickerStyles = (color: Color) => {
     } as React.CSSProperties,
     popover: {
       position: "absolute",
-      zIndex: "2",
+      zIndex: "5",
     } as React.CSSProperties,
     cover: {
       position: "fixed",


### PR DESCRIPTION
The color picker can appear below an expanded array field, which is at z-index 3.

Example of the issue:
<img width="311" height="316" alt="image" src="https://github.com/user-attachments/assets/b8f06bd4-d1a9-4114-a4e9-e07809ff64ec" />


