### PR TITLE
feat: numeric embedded fields

### DIFF
--- a/packages/visual-editor/src/editor/EmbeddedFieldStringInput.test.tsx
+++ b/packages/visual-editor/src/editor/EmbeddedFieldStringInput.test.tsx
@@ -361,3 +361,125 @@ describe("EmbeddedFieldStringInput", () => {
     expect(toast.warning).not.toHaveBeenCalled();
   });
 });
+
+describe("numeric embedded entity fields", () => {
+  it("offers root and linked numeric fields and inserts a linked decimal path", () => {
+    render(
+      <TemplatePropsContext.Provider
+        value={{
+          document: {
+            yearEstablished: 2006,
+            rating: 4.5,
+            c_linkedProducts: [
+              {
+                price: {
+                  value: 19.95,
+                },
+              },
+            ],
+          },
+        }}
+      >
+        <TemplateMetadataContext.Provider value={generateTemplateMetadata()}>
+          <EntityFieldsContext.Provider
+            value={{
+              fields: [
+                {
+                  name: "yearEstablished",
+                  displayName: "Year Established",
+                  definition: {
+                    name: "yearEstablished",
+                    typeRegistryId: "type.integer",
+                    type: {
+                      numberType: "NUMBER_TYPE_INT",
+                    },
+                  },
+                },
+                {
+                  name: "rating",
+                  displayName: "Rating",
+                  definition: {
+                    name: "rating",
+                    typeRegistryId: "type.float",
+                    type: {
+                      numberType: "NUMBER_TYPE_FLOAT",
+                    },
+                  },
+                },
+                {
+                  name: "c_linkedProducts",
+                  displayName: "Linked Products",
+                  definition: {
+                    name: "c_linkedProducts",
+                    typeRegistryId: "type.entity_reference",
+                    type: {
+                      documentType: "DOCUMENT_TYPE_ENTITY",
+                    },
+                    isList: true,
+                  },
+                  children: {
+                    fields: [
+                      {
+                        name: "price",
+                        displayName: "Price",
+                        definition: {
+                          name: "price",
+                          typeRegistryId: "type.price",
+                          type: {
+                            objectType: "OBJECT_TYPE_DEFAULT",
+                          },
+                        },
+                        children: {
+                          fields: [
+                            {
+                              name: "value",
+                              displayName: "Value",
+                              definition: {
+                                name: "value",
+                                typeRegistryId: "type.decimal",
+                                type: {
+                                  stringType: "STRING_TYPE_DECIMAL",
+                                },
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+              displayNames: {
+                yearEstablished: "Year Established",
+                rating: "Rating",
+                c_linkedProducts: "Linked Products",
+                "c_linkedProducts.price": "Linked Products > Price",
+                "c_linkedProducts.price.value":
+                  "Linked Products > Price > Value",
+              },
+            }}
+          >
+            <EmbeddedFieldStringInputFromEntity
+              filter={{ types: ["type.string"] }}
+              onChange={() => undefined}
+              showFieldSelector={true}
+              value=""
+            />
+          </EntityFieldsContext.Provider>
+        </TemplateMetadataContext.Provider>
+      </TemplatePropsContext.Provider>
+    );
+
+    fireEvent.click(screen.getByLabelText("Add entity field"));
+
+    expect(screen.getByText("Year Established")).toBeDefined();
+    expect(screen.getByText("Rating")).toBeDefined();
+    expect(screen.getByText("Linked Products > Price > Value")).toBeDefined();
+
+    fireEvent.click(screen.getByText("Linked Products > Price > Value"));
+
+    expect(
+      screen.getByDisplayValue("[[c_linkedProducts.price.value]]")
+    ).toBeDefined();
+  });
+});

--- a/packages/visual-editor/src/editor/EmbeddedFieldStringInput.tsx
+++ b/packages/visual-editor/src/editor/EmbeddedFieldStringInput.tsx
@@ -1,5 +1,8 @@
 import React from "react";
-import { RenderEntityFieldFilter } from "../internal/utils/getFilteredEntityFields.ts";
+import {
+  type EntityFieldTypes,
+  type RenderEntityFieldFilter,
+} from "../internal/utils/getFilteredEntityFields.ts";
 import {
   getEntityFieldScopeDisplayName,
   getScopedEntityFieldDisplayName,
@@ -38,6 +41,31 @@ import { warnOnMultiValueLinkedEntityTraversal } from "../utils/linkedEntityWarn
 export type EmbeddedStringOption = {
   label: string;
   value: string;
+};
+
+const NUMERIC_EMBEDDED_FIELD_TYPES: EntityFieldTypes[] = [
+  "type.decimal",
+  "type.float",
+  "type.integer",
+];
+
+/**
+ * Numeric fields are valid in embedded text because their values are converted
+ * to strings. Avoid passings numbers directly to components expecting strings.
+ */
+const getEmbeddedStringFilter = <T extends Record<string, any>>(
+  filter: RenderEntityFieldFilter<T>
+): RenderEntityFieldFilter<T> => {
+  if (!filter.types?.includes("type.string")) {
+    return filter;
+  }
+
+  return {
+    ...filter,
+    types: Array.from(
+      new Set([...filter.types, ...NUMERIC_EMBEDDED_FIELD_TYPES])
+    ),
+  };
 };
 
 /**
@@ -115,7 +143,7 @@ export const EmbeddedFieldStringInputFromEntity = <
   const entityFieldOptions = React.useMemo(() => {
     const filteredEntityFields = getFieldsForSelector(
       entityFields,
-      filter,
+      getEmbeddedStringFilter(filter),
       streamDocument,
       sourceField || undefined
     );

--- a/packages/visual-editor/src/internal/utils/getFilteredEntityFields.test.ts
+++ b/packages/visual-editor/src/internal/utils/getFilteredEntityFields.test.ts
@@ -1679,3 +1679,70 @@ const mockEntityFields: YextSchemaField[] = [
 const mockStreamFields: StreamFields = {
   fields: mockEntityFields,
 };
+
+const numericStreamFields: StreamFields = {
+  fields: [
+    {
+      name: "name",
+      definition: {
+        name: "name",
+        typeRegistryId: "type.string",
+        type: {
+          stringType: "STRING_TYPE_DEFAULT",
+        },
+      },
+    },
+    {
+      name: "price",
+      definition: {
+        name: "price",
+        typeRegistryId: "type.decimal",
+        type: {
+          stringType: "STRING_TYPE_DECIMAL",
+        },
+      },
+    },
+    {
+      name: "rating",
+      definition: {
+        name: "rating",
+        typeRegistryId: "type.float",
+        type: {
+          numberType: "NUMBER_TYPE_FLOAT",
+        },
+      },
+    },
+    {
+      name: "yearEstablished",
+      definition: {
+        name: "yearEstablished",
+        typeRegistryId: "type.integer",
+        type: {
+          numberType: "NUMBER_TYPE_INT",
+        },
+      },
+    },
+  ],
+};
+
+describe("numeric entity field filtering", () => {
+  test("recognizes decimal, float, and integer schema types", () => {
+    const fields = getFilteredEntityFields(numericStreamFields, {
+      types: ["type.decimal", "type.float", "type.integer"],
+    });
+
+    expect(fields.map((field) => field.name)).toEqual([
+      "price",
+      "rating",
+      "yearEstablished",
+    ]);
+  });
+
+  test("keeps generic string filters string-only", () => {
+    const fields = getFilteredEntityFields(numericStreamFields, {
+      types: ["type.string"],
+    });
+
+    expect(fields.map((field) => field.name)).toEqual(["name"]);
+  });
+});

--- a/packages/visual-editor/src/internal/utils/getFilteredEntityFields.ts
+++ b/packages/visual-editor/src/internal/utils/getFilteredEntityFields.ts
@@ -38,6 +38,9 @@ export type RenderEntityFieldFilter<T extends Record<string, any>> =
 
 export type EntityFieldTypes =
   | "type.string"
+  | "type.decimal"
+  | "type.float"
+  | "type.integer"
   | "type.image"
   | "type.hours"
   | "type.address"

--- a/packages/visual-editor/src/utils/resolveYextEntityField.test.ts
+++ b/packages/visual-editor/src/utils/resolveYextEntityField.test.ts
@@ -1,5 +1,6 @@
 import { assert, describe, it } from "vitest";
 import {
+  resolveEmbeddedFieldsInString,
   resolveField,
   resolveYextEntityField,
 } from "./resolveYextEntityField.ts";
@@ -347,5 +348,43 @@ describe("resolveYextEntityField with embedded fields", () => {
         },
       }
     );
+  });
+});
+
+describe("numeric embedded field resolution", () => {
+  it("resolves root numeric primitives as unformatted text", () => {
+    const resolved = resolveEmbeddedFieldsInString(
+      "[[zero]] [[negative]] [[integer]] [[decimal]]",
+      {
+        zero: 0,
+        negative: -12,
+        integer: 42,
+        decimal: 19.95,
+      }
+    );
+
+    assert.equal(resolved, "0 -12 42 19.95");
+  });
+
+  it("resolves a decimal through the first linked entity", () => {
+    const resolved = resolveEmbeddedFieldsInString(
+      "[[c_linkedProducts.price.value]]",
+      {
+        c_linkedProducts: [
+          {
+            price: {
+              value: 19.95,
+            },
+          },
+          {
+            price: {
+              value: 29.95,
+            },
+          },
+        ],
+      }
+    );
+
+    assert.equal(resolved, "19.95");
   });
 });

--- a/packages/visual-editor/src/utils/resolveYextEntityField.ts
+++ b/packages/visual-editor/src/utils/resolveYextEntityField.ts
@@ -86,6 +86,10 @@ export const resolveEmbeddedFieldsInString = (
       return "";
     }
 
+    if (typeof resolvedValue === "number") {
+      return resolvedValue.toString();
+    }
+
     // If the resolved value is an object, stringify it.
     if (typeof resolvedValue === "object") {
       return JSON.stringify(resolvedValue);

--- a/starter/localData/dev-location-stream__en__cbafb9cd1c3e63d9814e236ba9181377.json
+++ b/starter/localData/dev-location-stream__en__cbafb9cd1c3e63d9814e236ba9181377.json
@@ -47,6 +47,7 @@
     "region": "VA"
   },
   "businessId": 1000146856,
+  "c_locationNumber": "1234",
   "c_linkedLocation": [
     {
       "address": {
@@ -55,6 +56,10 @@
         "line1": "1600 East Nasa Parkway",
         "postalCode": "77058",
         "region": "TX"
+      },
+      "c_deliveryFee": {
+        "currencyCode": "USD",
+        "value": "9.99"
       }
     },
     {
@@ -64,6 +69,50 @@
         "line1": "400 Broad Street",
         "postalCode": "98109",
         "region": "WA"
+      }
+    }
+  ],
+  "c_linkedProduct": [
+    {
+      "title": "Out of this Galaxy Burger",
+      "description": {
+        "html": "<p>A double smash burger with melted cheese and fresh toppings.</p>"
+      },
+      "image": {
+        "url": "https://placehold.co/600x400?text=Burger",
+        "alternateText": "Out of this Galaxy Burger",
+        "width": 600,
+        "height": 400
+      },
+      "price": {
+        "value": "12.99",
+        "currencyCode": "USD"
+      },
+      "cta": {
+        "label": "Order Now",
+        "linkType": "URL",
+        "link": "https://example.com/order/out-of-this-galaxy-burger"
+      }
+    },
+    {
+      "title": "Cosmic Fries",
+      "description": {
+        "html": "<p>The perfect addition to your meal.</p>"
+      },
+      "image": {
+        "url": "https://placehold.co/600x400?text=Fries",
+        "alternateText": "Cosmic Fries",
+        "width": 600,
+        "height": 400
+      },
+      "price": {
+        "value": "3.39",
+        "currencyCode": "USD"
+      },
+      "cta": {
+        "label": "View Menu",
+        "linkType": "URL",
+        "link": "https://example.com/menu/cosmic-fries"
       }
     }
   ],

--- a/starter/src/dev.config.ts
+++ b/starter/src/dev.config.ts
@@ -581,13 +581,18 @@ export const devTemplateStream = {
                   fields: [
                     {
                       name: "currencyCode",
-                      displayName: "Currency Code",
                       definition: {
                         name: "currencyCode",
-                        typeName: "type.option",
+                        typeRegistryId: "type.option",
                         type: {
                           stringType: "STRING_TYPE_OPTION",
                         },
+                        options: [
+                          {
+                            textValue: "USD",
+                            displayName: "USD-United States Dollar",
+                          },
+                        ],
                       },
                     },
                     {
@@ -12984,13 +12989,18 @@ export const devLinkedEntitySchemas = {
           fields: [
             {
               name: "currencyCode",
-              displayName: "Currency Code",
               definition: {
                 name: "currencyCode",
-                typeName: "type.option",
+                typeRegistryId: "type.option",
                 type: {
                   stringType: "STRING_TYPE_OPTION",
                 },
+                options: [
+                  {
+                    textValue: "USD",
+                    displayName: "USD-United States Dollar",
+                  },
+                ],
               },
             },
             {

--- a/starter/src/dev.config.ts
+++ b/starter/src/dev.config.ts
@@ -468,6 +468,18 @@ export const devTemplateStream = {
           fullObject: true,
         },
         {
+          name: "c_linkedLocation",
+          fullObject: true,
+        },
+        {
+          name: "c_linkedProduct",
+          fullObject: true,
+        },
+        {
+          name: "c_locationNumber",
+          fullObject: true,
+        },
+        {
           name: "meta",
           children: {
             fields: [
@@ -494,6 +506,285 @@ export const devTemplateStream = {
     },
     schema: {
       fields: [
+        {
+          name: "c_linkedLocation",
+          displayName: "Linked Location",
+          definition: {
+            name: "c_linkedLocation",
+            typeRegistryId: "type.entity_reference",
+            type: {
+              documentType: "DOCUMENT_TYPE_ENTITY",
+            },
+            isList: true,
+          },
+          children: {
+            fields: [
+              {
+                name: "address",
+                displayName: "Address",
+                definition: {
+                  name: "address",
+                  typeName: "type.address",
+                  type: {
+                    typeName: "type.address",
+                  },
+                },
+                children: {
+                  fields: [
+                    {
+                      name: "city",
+                      displayName: "City",
+                      definition: {
+                        name: "city",
+                        typeName: "type.string",
+                        type: {
+                          typeName: "type.string",
+                        },
+                      },
+                    },
+                    {
+                      name: "region",
+                      displayName: "Region",
+                      definition: {
+                        name: "region",
+                        typeName: "type.string",
+                        type: {
+                          typeName: "type.string",
+                        },
+                      },
+                    },
+                    {
+                      name: "postalCode",
+                      displayName: "Postal Code",
+                      definition: {
+                        name: "postalCode",
+                        typeName: "type.string",
+                        type: {
+                          typeName: "type.string",
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+              {
+                name: "c_deliveryFee",
+                displayName: "Delivery Fee",
+                definition: {
+                  name: "c_deliveryFee",
+                  typeRegistryId: "type.price",
+                  type: {
+                    objectType: "OBJECT_TYPE_DEFAULT",
+                  },
+                },
+                children: {
+                  fields: [
+                    {
+                      name: "currencyCode",
+                      displayName: "Currency Code",
+                      definition: {
+                        name: "currencyCode",
+                        typeName: "type.option",
+                        type: {
+                          stringType: "STRING_TYPE_OPTION",
+                        },
+                      },
+                    },
+                    {
+                      name: "value",
+                      displayName: "Value",
+                      definition: {
+                        name: "value",
+                        typeName: "type.decimal",
+                        type: {
+                          stringType: "STRING_TYPE_DECIMAL",
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+        {
+          name: "c_linkedProduct",
+          displayName: "Linked Product",
+          definition: {
+            name: "c_linkedProduct",
+            typeRegistryId: "type.entity_reference",
+            type: { documentType: "DOCUMENT_TYPE_ENTITY" },
+            isList: true,
+          },
+          children: {
+            fields: [
+              {
+                name: "title",
+                displayName: "Title",
+                definition: {
+                  name: "title",
+                  typeRegistryId: "type.string",
+                  type: { stringType: "STRING_TYPE_DEFAULT" },
+                },
+              },
+              {
+                name: "description",
+                displayName: "Description",
+                definition: {
+                  name: "description",
+                  typeRegistryId: "type.rich_text_v2",
+                  type: { objectType: "OBJECT_TYPE_RICH_TEXT" },
+                },
+                children: {
+                  fields: [
+                    {
+                      name: "html",
+                      definition: {
+                        name: "html",
+                        type: { stringType: "STRING_TYPE_HTML" },
+                      },
+                    },
+                  ],
+                },
+              },
+              {
+                name: "image",
+                displayName: "Image",
+                definition: {
+                  name: "image",
+                  typeRegistryId: "type.image",
+                  type: { objectType: "OBJECT_TYPE_IMAGE" },
+                },
+                children: {
+                  fields: [
+                    {
+                      name: "url",
+                      definition: {
+                        name: "url",
+                        type: { stringType: "STRING_TYPE_URL" },
+                      },
+                    },
+                    {
+                      name: "alternateText",
+                      definition: {
+                        name: "alternateText",
+                        type: { stringType: "STRING_TYPE_MULTILINE" },
+                      },
+                    },
+                    {
+                      name: "width",
+                      definition: {
+                        name: "width",
+                        type: { numberType: "NUMBER_TYPE_INT" },
+                      },
+                    },
+                    {
+                      name: "height",
+                      definition: {
+                        name: "height",
+                        type: { numberType: "NUMBER_TYPE_INT" },
+                      },
+                    },
+                  ],
+                },
+              },
+              {
+                name: "price",
+                displayName: "Price",
+                definition: {
+                  name: "price",
+                  typeRegistryId: "type.price",
+                  type: { objectType: "OBJECT_TYPE_DEFAULT" },
+                },
+                children: {
+                  fields: [
+                    {
+                      name: "currencyCode",
+                      definition: {
+                        name: "currencyCode",
+                        typeRegistryId: "type.option",
+                        type: {
+                          stringType: "STRING_TYPE_OPTION",
+                        },
+                        options: [
+                          {
+                            textValue: "USD",
+                            displayName: "USD-United States Dollar",
+                          },
+                        ],
+                      },
+                    },
+                    {
+                      name: "value",
+                      definition: {
+                        name: "value",
+                        typeRegistryId: "type.decimal",
+                        type: {
+                          stringType: "STRING_TYPE_DECIMAL",
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+              {
+                name: "cta",
+                displayName: "CTA",
+                definition: {
+                  name: "cta",
+                  typeRegistryId: "type.cta",
+                  type: { objectType: "OBJECT_TYPE_DEFAULT" },
+                },
+                children: {
+                  fields: [
+                    {
+                      name: "label",
+                      definition: {
+                        name: "label",
+                        typeRegistryId: "type.string",
+                        type: { stringType: "STRING_TYPE_DEFAULT" },
+                      },
+                    },
+                    {
+                      name: "linkType",
+                      definition: {
+                        name: "linkType",
+                        typeRegistryId: "type.option",
+                        type: { stringType: "STRING_TYPE_OPTION" },
+                        options: [
+                          { textValue: "OTHER", displayName: "Other" },
+                          { textValue: "URL", displayName: "URL" },
+                          { textValue: "PHONE", displayName: "Phone" },
+                          { textValue: "EMAIL", displayName: "Email" },
+                        ],
+                      },
+                    },
+                    {
+                      name: "link",
+                      definition: {
+                        name: "link",
+                        typeRegistryId: "type.string",
+                        type: { stringType: "STRING_TYPE_DEFAULT" },
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+        {
+          name: "c_locationNumber",
+          definition: {
+            name: "c_locationNumber",
+            registryId: "location.custom.4259018.locationnumber.0",
+            typeRegistryId: "type.decimal",
+            type: {
+              stringType: "STRING_TYPE_DECIMAL",
+            },
+          },
+          displayName: "locationNumber",
+        },
         {
           name: "c_exampleEvents",
           definition: {
@@ -11557,6 +11848,39 @@ export const devTemplateStream = {
     "c_deliveryPromo.image": "Delivery Promo \u003e Image",
     "c_deliveryPromo.title": "Delivery Promo \u003e Title",
     c_faqSection: "FAQ Section",
+    c_linkedLocation: "Linked Location",
+    "c_linkedLocation.address": "Linked Location \u003e Address",
+    "c_linkedLocation.address.city":
+      "Linked Location \u003e Address \u003e City",
+    "c_linkedLocation.address.region":
+      "Linked Location \u003e Address \u003e Region",
+    "c_linkedLocation.address.postalCode":
+      "Linked Location \u003e Address \u003e Postal Code",
+    "c_linkedLocation.c_deliveryFee": "Linked Location \u003e Delivery Fee",
+    "c_linkedLocation.c_deliveryFee.currencyCode":
+      "Linked Location \u003e Delivery Fee \u003e Currency Code",
+    "c_linkedLocation.c_deliveryFee.value":
+      "Linked Location \u003e Delivery Fee \u003e Value",
+    c_linkedProduct: "Linked Product",
+    "c_linkedProduct.title": "Linked Product \u003e Title",
+    "c_linkedProduct.description": "Linked Product \u003e Description",
+    "c_linkedProduct.description.html":
+      "Linked Product \u003e Description \u003e HTML",
+    "c_linkedProduct.image": "Linked Product \u003e Image",
+    "c_linkedProduct.image.url": "Linked Product \u003e Image \u003e URL",
+    "c_linkedProduct.image.alternateText":
+      "Linked Product \u003e Image \u003e Alternate Text",
+    "c_linkedProduct.image.width": "Linked Product \u003e Image \u003e Width",
+    "c_linkedProduct.image.height": "Linked Product \u003e Image \u003e Height",
+    "c_linkedProduct.price": "Linked Product \u003e Price",
+    "c_linkedProduct.price.value": "Linked Product \u003e Price \u003e Value",
+    "c_linkedProduct.price.currencyCode":
+      "Linked Product \u003e Price \u003e Currency Code",
+    "c_linkedProduct.cta": "Linked Product \u003e CTA",
+    "c_linkedProduct.cta.label": "Linked Product \u003e CTA \u003e Label",
+    "c_linkedProduct.cta.linkType":
+      "Linked Product \u003e CTA \u003e Link Type",
+    "c_linkedProduct.cta.link": "Linked Product \u003e CTA \u003e Link",
     "c_faqSection.linkedFAQs": "FAQ Section \u003e Linked FAQs",
     "c_faqSection.sectionTitle": "FAQ Section \u003e Section Title",
     c_hero: "Hero",
@@ -11570,6 +11894,7 @@ export const devTemplateStream = {
     c_productSection: "Product Section",
     "c_productSection.linkedProducts": "Product Section \u003e linkedProducts",
     "c_productSection.sectionTitle": "Product Section \u003e Section Title",
+    c_locationNumber: "Location Number",
     cityCoordinate: "City Lat/Long",
     "cityCoordinate.latitude": "City Lat/Long \u003e Latitude",
     "cityCoordinate.longitude": "City Lat/Long \u003e Longitude",
@@ -12526,6 +12851,200 @@ export const devLinkedEntitySchemas = {
                 type: {
                   typeName: "type.string",
                 },
+              },
+            },
+          ],
+        },
+      },
+      {
+        name: "c_deliveryFee",
+        definition: {
+          name: "c_deliveryFee",
+          registryId: "location.custom.4259018.deliveryfee.0",
+          typeRegistryId: "type.price",
+          type: {
+            objectType: "OBJECT_TYPE_DEFAULT",
+          },
+        },
+        children: {
+          fields: [
+            {
+              name: "currencyCode",
+              definition: {
+                name: "currencyCode",
+                typeRegistryId: "type.option",
+                type: {
+                  stringType: "STRING_TYPE_OPTION",
+                },
+                options: [
+                  {
+                    textValue: "USD",
+                    displayName: "USD-United States Dollar",
+                  },
+                ],
+              },
+            },
+            {
+              name: "value",
+              definition: {
+                name: "value",
+                typeRegistryId: "type.decimal",
+                type: {
+                  stringType: "STRING_TYPE_DECIMAL",
+                },
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
+  c_linkedProduct: {
+    displayName: "Linked Product",
+    fields: [
+      {
+        name: "title",
+        displayName: "Title",
+        definition: {
+          name: "title",
+          typeName: "type.string",
+          type: { typeName: "type.string" },
+        },
+      },
+      {
+        name: "description",
+        displayName: "Description",
+        definition: {
+          name: "description",
+          typeName: "type.rich_text_v2",
+          type: { typeName: "type.rich_text_v2" },
+        },
+        children: {
+          fields: [
+            {
+              name: "html",
+              definition: {
+                name: "html",
+                type: { stringType: "STRING_TYPE_HTML" },
+              },
+            },
+          ],
+        },
+      },
+      {
+        name: "image",
+        displayName: "Image",
+        definition: {
+          name: "image",
+          typeName: "type.image",
+          type: { typeName: "type.image" },
+        },
+        children: {
+          fields: [
+            {
+              name: "url",
+              definition: {
+                name: "url",
+                type: { stringType: "STRING_TYPE_URL" },
+              },
+            },
+            {
+              name: "alternateText",
+              definition: {
+                name: "alternateText",
+                type: { stringType: "STRING_TYPE_MULTILINE" },
+              },
+            },
+            {
+              name: "width",
+              definition: {
+                name: "width",
+                type: { numberType: "NUMBER_TYPE_INT" },
+              },
+            },
+            {
+              name: "height",
+              definition: {
+                name: "height",
+                type: { numberType: "NUMBER_TYPE_INT" },
+              },
+            },
+          ],
+        },
+      },
+      {
+        name: "price",
+        displayName: "Price",
+        definition: {
+          name: "price",
+          typeName: "type.price",
+          type: { typeName: "type.price" },
+        },
+        children: {
+          fields: [
+            {
+              name: "currencyCode",
+              displayName: "Currency Code",
+              definition: {
+                name: "currencyCode",
+                typeName: "type.option",
+                type: {
+                  stringType: "STRING_TYPE_OPTION",
+                },
+              },
+            },
+            {
+              name: "value",
+              displayName: "Value",
+              definition: {
+                name: "value",
+                typeName: "type.decimal",
+                type: {
+                  stringType: "STRING_TYPE_DECIMAL",
+                },
+              },
+            },
+          ],
+        },
+      },
+      {
+        name: "cta",
+        displayName: "CTA",
+        definition: {
+          name: "cta",
+          typeName: "type.cta",
+          type: { typeName: "type.cta" },
+        },
+        children: {
+          fields: [
+            {
+              name: "label",
+              definition: {
+                name: "label",
+                typeRegistryId: "type.string",
+                type: { stringType: "STRING_TYPE_DEFAULT" },
+              },
+            },
+            {
+              name: "linkType",
+              definition: {
+                name: "linkType",
+                typeRegistryId: "type.option",
+                type: { stringType: "STRING_TYPE_OPTION" },
+                options: [
+                  { textValue: "OTHER", displayName: "Other" },
+                  { textValue: "URL", displayName: "URL" },
+                  { textValue: "PHONE", displayName: "Phone" },
+                  { textValue: "EMAIL", displayName: "Email" },
+                ],
+              },
+            },
+            {
+              name: "link",
+              definition: {
+                name: "link",
+                typeRegistryId: "type.string",
+                type: { stringType: "STRING_TYPE_DEFAULT" },
               },
             },
           ],


### PR DESCRIPTION
1. Show base entity numeric fields in the embedded field picker (these already resolved properly but did not appear in the dropdown)
2. Resolve linked entity numeric fields and show them in the embedded field picker
3. Add some test linked entity data


https://github.com/user-attachments/assets/332d7389-5ab2-4fab-91d2-6255bcedec7b

Will put up a corresponding YSS PR for the RTF drawer