### PR TITLE
chore: enable EntityFieldsToggle

### DIFF
--- a/packages/visual-editor/src/editor/EntityField.tsx
+++ b/packages/visual-editor/src/editor/EntityField.tsx
@@ -84,7 +84,7 @@ export const EntityField = React.forwardRef<HTMLDivElement, EntityFieldProps>(
               zoomWithViewport
               className={!constantValueEnabled ? "ve-bg-primary" : ""}
             >
-              <p>{tooltipContent}</p>
+              <p className="entity-field-tooltip-label">{tooltipContent}</p>
               <TooltipArrow
                 fill="bg-popover"
                 className={!constantValueEnabled ? "ve-fill-primary" : ""}

--- a/packages/visual-editor/src/editor/index.css
+++ b/packages/visual-editor/src/editor/index.css
@@ -9,6 +9,17 @@
     Inter, "SF Pro", "Helvetica Neue", Helvetica, sans-serif !important;
 }
 
+.entity-field-tooltip-label {
+  font-family: var(--puck-font-family) !important;
+  font-size: 0.75rem !important;
+  font-style: normal !important;
+  font-weight: 400 !important;
+  letter-spacing: normal !important;
+  line-height: 1rem !important;
+  text-decoration: none !important;
+  text-transform: none !important;
+}
+
 /* Custom styling for entity field selection in the Puck sidebar. */
 .entityField {
   margin-top: 5px;

--- a/packages/visual-editor/src/internal/puck/components/LayoutHeader.tsx
+++ b/packages/visual-editor/src/internal/puck/components/LayoutHeader.tsx
@@ -41,6 +41,7 @@ import {
 } from "../../../contexts/ErrorContext.tsx";
 import { getPublishErrorMessage } from "../../../utils/publishErrors.ts";
 import { getPublishTooltipMessageFromHeadDeployStatus } from "../../utils/getPublishTooltipMessageFromHeadDeployStatus.ts";
+import { EntityFieldsToggle } from "../ui/EntityFieldsToggle.tsx";
 
 const usePuck = createUsePuck();
 const devLogger = new DevLogger();
@@ -227,16 +228,12 @@ export const LayoutHeader = (props: LayoutHeaderProps) => {
           >
             {pt("pasteLayout", "Paste Layout")}
           </Button>
-
-          {/* TODO: re-enable EntityFieldsToggle */}
-          {/*
           <Separator
             orientation="vertical"
             decorative
             className="ve-mx-4 ve-h-7 ve-w-px ve-bg-gray-300 ve-my-auto"
           />
-          <EntityFieldsToggle /> 
-          */}
+          <EntityFieldsToggle />
           {localDev && showLocalDevOverrideButtons && (
             <LocalDevOverrideButtons />
           )}


### PR DESCRIPTION
Also ensure the Global Styles fonts don't affect the tooltips. 

They were originally disabled and EntityFields weren't setup properly in all templates